### PR TITLE
Don’t submit empty values from non-searchable dropdowns

### DIFF
--- a/.changeset/dropdown-no-empty-submit.md
+++ b/.changeset/dropdown-no-empty-submit.md
@@ -1,0 +1,19 @@
+---
+'@acusti/dropdown': minor
+---
+
+Stop firing onSubmitItem with an empty value when a non-searchable dropdown
+is submitted with no item active
+
+A menu-style (non-searchable) Dropdown defaults to `allowEmpty`, so
+pressing Enter/Space with nothing highlighted — or releasing the pointer on
+non-item menu chrome (a title, padding, the list gap) — fired
+`onSubmitItem({ value: '' })`. Consumers that pass the submitted value
+straight through (for example casting it to an enum) could persist that
+empty value and trip downstream validation. An empty value is now only
+emitted when the dropdown has a text input to source it from — a searchable
+dropdown's input, or a text input inside a custom trigger; a dropdown with
+no input and nothing selected is a no-op. Submitting an item whose
+`data-ukt-value` is explicitly empty still works. `allowEmpty` is now also
+enforced when `allowCreate` is set: submitting a cleared input with no
+active item no longer emits an empty value when `allowEmpty={false}`.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -143,8 +143,13 @@ type Props = {
      */
     allowCreate?: boolean;
     /**
-     * Boolean indicating if the user can submit an empty value (i.e. clear
-     * the value). Defaults to true.
+     * Boolean indicating if submitting with no item active emits an empty
+     * value (i.e. clears the value). Only has an effect when the dropdown has a
+     * text input to source that value from — a searchable dropdown’s search
+     * input, or a text input inside a custom trigger. With no such input there
+     * is no value to submit, so submitting with nothing selected is a no-op
+     * regardless; clear such a dropdown with an explicit empty-valued item
+     * instead. Defaults to true.
      */
     allowEmpty?: boolean;
     /**

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -729,4 +729,212 @@ describe('@acusti/dropdown', () => {
             );
         });
     });
+
+    describe('submitting with no active item', () => {
+        it('does not call onSubmitItem when a non-searchable dropdown is submitted with nothing selected', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                        <li data-ukt-item data-ukt-value="two">
+                            Two
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            // Dropdown is open with nothing highlighted; submitting must be a
+            // no-op, not an empty-valued onSubmitItem.
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+        });
+
+        it('does not call onSubmitItem when the pointer is released on non-item menu chrome', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <div>
+                        <h5 data-testid="menu-title">Pick one</h5>
+                        <ul>
+                            <li data-ukt-item data-ukt-value="one">
+                                One
+                            </li>
+                        </ul>
+                    </div>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.click(screen.getByTestId('menu-title'));
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+        });
+
+        it('does not call onSubmitItem when allowCreate is set but there is no input to source a value', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            // allowCreate has nothing to create from without a text input, so
+            // submitting with nothing selected must still be a no-op rather
+            // than bypassing the empty-submit guard.
+            render(
+                <Dropdown allowCreate onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+        });
+
+        it('still submits an item whose value is explicitly empty', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <ul>
+                        <li data-ukt-item data-ukt-value="">
+                            Clear
+                        </li>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.click(screen.getByText('Clear'));
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ label: 'Clear', value: '' }),
+            );
+        });
+
+        it('still lets a searchable dropdown submit an empty (cleared) value', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown isSearchable onSubmitItem={handleSubmitItem}>
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            await user.click(input);
+            // Empty input + allowEmpty (default) → an explicit clear submit.
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ value: '' }),
+            );
+        });
+
+        it('still lets a custom text-input trigger submit an empty (cleared) value when not searchable', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            // No isSearchable, but the custom trigger contains a text input,
+            // which Dropdown adopts as its value source. Clearing it and
+            // submitting is a real empty value, not the value-less menu case.
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    <input aria-label="amount" />
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox', { name: 'amount' });
+            await user.click(input);
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ value: '' }),
+            );
+        });
+
+        it('enforces allowEmpty={false} on the allowCreate path (cleared input does not submit)', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown
+                    allowCreate
+                    allowEmpty={false}
+                    isSearchable
+                    onSubmitItem={handleSubmitItem}
+                >
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            await user.click(input);
+            // Cleared input + no active item: an empty “creation” is a clear,
+            // so allowEmpty must gate it even though allowCreate is set.
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+        });
+
+        it('still lets allowCreate with default allowEmpty submit a cleared value', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown allowCreate isSearchable onSubmitItem={handleSubmitItem}>
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            await user.click(input);
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ value: '' }),
+            );
+        });
+    });
 });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -41,8 +41,13 @@ export type Props = {
      */
     allowCreate?: boolean;
     /**
-     * Boolean indicating if the user can submit an empty value (i.e. clear
-     * the value). Defaults to true.
+     * Boolean indicating if submitting with no item active emits an empty
+     * value (i.e. clears the value). Only has an effect when the dropdown has a
+     * text input to source that value from — a searchable dropdown’s search
+     * input, or a text input inside a custom trigger. With no such input there
+     * is no value to submit, so submitting with nothing selected is a no-op
+     * regardless; clear such a dropdown with an explicit empty-valued item
+     * instead. Defaults to true.
      */
     allowEmpty?: boolean;
     /**
@@ -233,11 +238,24 @@ export default function Dropdown({
         if (!hasItemsRef.current) return;
 
         const element = getActiveItemElement(dropdownElement);
-        if (!element && !allowCreateRef.current) {
-            // If not allowEmpty, don’t allow submitting an empty item
-            if (!allowEmptyRef.current) return;
-            // If we have an input element as trigger & the user didn’t clear the text, do nothing
-            if (inputElementRef.current?.value) return;
+        if (!element) {
+            // With nothing selected, the only possible value comes from a text
+            // input (a searchable dropdown’s input, or one inside a custom
+            // trigger). No input means there’s no value to submit at all, so
+            // bail regardless of allowCreate/allowEmpty instead of firing an
+            // empty-valued onSubmitItem consumers have to defend against. (To
+            // let such a dropdown clear its value, give it an explicit
+            // empty-valued item, which submits as a normal active selection.)
+            if (!inputElementRef.current) return;
+            if (inputElementRef.current.value) {
+                // Non-empty text matching no item is a created value
+                if (!allowCreateRef.current) return;
+            } else if (!allowEmptyRef.current) {
+                // A cleared input is an empty (clearing) submit, which
+                // allowEmpty gates even when allowCreate is set — “creating”
+                // an empty value is clearing, not creating
+                return;
+            }
         }
 
         let itemLabel = element?.innerText ?? '';


### PR DESCRIPTION
`handleSubmitItem` fires `onSubmitItem({ value: '' })` when a non-searchable (menu) Dropdown is submitted with no item active (Enter/Space with nothing highlighted, or a pointer release on non-item menu chrome). `allowEmpty` defaults to `true` and there is no input to hold a value, so the empty submit reached consumers, who could pass it straight through (e.g. cast to an enum) and persist an invalid value.

Emit an empty value only when the dropdown has a text input to source it from: a searchable dropdown’s search input, or a text input inside a custom trigger. With no input and nothing selected, submitting is now a no-op regardless of `allowCreate` or `allowEmpty`. The guard is restructured so the two flags gate independently: a non-empty input value is a creation (`allowCreate`), a cleared one is a clear (`allowEmpty`). Previously `allowCreate` bypassed both checks, so it could emit `''` even with `allowEmpty={false}`. An item whose `data-ukt-value` is explicitly empty still submits.