### PR TITLE
Implement nested submenus and the Menubar component

### DIFF
--- a/.changeset/nested-dropdown-submenus.md
+++ b/.changeset/nested-dropdown-submenus.md
@@ -1,0 +1,53 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add nested submenus and the Menubar component
+
+Dropdowns now compose: nesting a `Dropdown` inside another dropdown’s body
+renders it as a parent item that discloses a submenu, and the new `Menubar`
+named export combines sibling dropdowns into a macOS-style menu bar.
+
+- Submenus nest to arbitrary depth and are declared either by nesting
+  `Dropdown` components or by authoring the `data-ukt-submenu` markup
+  protocol directly — the component form compiles to the attribute form
+- Parent items disclose and never submit; `onSubmitItem` fires only for
+  leaf items, and the `Item` payload gains a `path` array reporting the
+  leaf’s ancestor parent items (empty for top-level items)
+- macOS-style disclosure: a parent item highlights immediately when it
+  becomes active (pointer or arrow keys) and discloses its submenu after a
+  short intent delay with the highlight staying on the parent; → dives into
+  the submenu, ← surfaces back out, and Escape closes the whole menu and
+  returns focus to the trigger
+- The active path is one `data-ukt-active` item per open level, with the
+  deepest item getting the primary highlight and ancestors a muted one (new
+  `--uktdd-body-bg-color-path`/`--uktdd-body-color-path` custom
+  properties); parent-item open state is carried by `aria-expanded`
+- Submenus reuse the anchor-positioning layout model (the expanded parent
+  item is the anchor) with new `--uktdd-submenu-position-area`,
+  `--uktdd-submenu-position-try-fallbacks`, and `--uktdd-submenu-translate`
+  custom properties; parent items render a macOS-style disclosure chevron
+  (drawn in CSS, restylable via `[aria-haspopup='menu']::after`), and
+  submenu bodies get an explicit text color via the new
+  `--uktdd-body-color` custom property (default `canvastext`) so an active
+  parent’s highlight color can’t inherit into its submenu’s items
+- The `--uktdd-body-translate` default changed from `0 0` to the
+  rendering-identical `none`: any other value makes the body a containing
+  block for its fixed-position submenus, which constrains and clips them,
+  so translate nudges are now opt-in per dropdown and documented as
+  incompatible with submenus
+- Parent items and submenus get ARIA filled in automatically
+  (`aria-haspopup`/`aria-expanded`/`aria-controls` and `role="menu"`/`id`),
+  only where the consumer hasn’t set it
+- `Menubar` renders `role="menubar"`, keeps at most one menu open, switches
+  menus on hover once any menu is open, roves focus between triggers with
+  ←/→ (sliding the open menu when one is open, wrapping at the ends), gives
+  the open menu’s trigger an active-state background (new
+  `--uktdd-menubar-trigger-bg-color-active` custom property, tinting over
+  the trigger’s own background), and supersedes the `group` prop, which was
+  declared in the `Props` type but never implemented and has been removed
+- A `Dropdown` nested with `hasItems={false}` isn’t a submenu — it renders
+  as an independent anchored dropdown inside the outer body (e.g. an ℹ️
+  info popover next to an input in a form dropdown); interacting with it
+  doesn’t close or submit the outer dropdown, and Escape closes the
+  innermost open dropdown first

--- a/.changeset/submenu-mouse-intent.md
+++ b/.changeset/submenu-mouse-intent.md
@@ -1,0 +1,18 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add mouse-intent (safe-area) tracking so submenus don't close when the
+pointer cuts diagonally toward them
+
+When a submenu is open and the pointer moves diagonally from the parent
+item toward the submenu, its path often crosses sibling items in the parent
+menu. Previously that collapsed the submenu the instant the pointer touched
+a sibling. Now the dropdown tracks the triangle from where the pointer left
+the parent item to the open submenu's two near corners (the macOS
+"diagonal" behavior): while the pointer stays inside that triangle it's
+heading toward the submenu, so the submenu stays open even over sibling
+items. A pause inside the triangle (rather than continued motion) gives up
+and switches to the item under the pointer, and a direct move onto a
+sibling (outside the triangle) switches immediately as before.
+Pointer-only; keyboard navigation is unaffected.

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -144,6 +144,30 @@
     inline-size: 300px;
 }
 
+.uktmenubar {
+    .uktdropdown-trigger {
+        border: 1px solid #666;
+        border-left: 0;
+        border-right: 0;
+        border-radius: 0;
+        padding: 5px 7px;
+    }
+}
+
+.uktmenubar .uktdropdown {
+    font-size: 13px;
+
+    &:first-child .uktdropdown-trigger {
+        border-left: 1px solid #666;
+        padding-left: 11px;
+    }
+
+    &:last-child .uktdropdown-trigger {
+        border-right: 1px solid #666;
+        padding-right: 11px;
+    }
+}
+
 .textarea-trigger .uktdropdown-body {
     inline-size: 400px;
     font-size: 13px;

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { fn } from 'storybook/test';
 import * as React from 'react';
 
 import CSSValueInput from '../../css-value-input/src/CSSValueInput.js';
-import Dropdown from '../../dropdown/src/Dropdown.js';
+import Dropdown, { Menubar } from '../../dropdown/src/Dropdown.js';
 
 import './CSSValueInput.css';
 import './Dropdown.css';
@@ -535,5 +535,156 @@ export const OutOfBoundsAtRight: Story = {
         isSearchable: true,
         name: 'outofboundsatright',
         placeholder: 'Fill available space',
+    },
+};
+
+export const SubmenuDropdown: Story = {
+    args: {
+        children: [
+            'Format',
+            <ul>
+                <li data-ukt-item>Bold</li>
+                <li data-ukt-item>Italic</li>
+                <li data-ukt-item>Underline</li>
+                <Dropdown label="Align">
+                    <ul>
+                        <li data-ukt-value="left">Left</li>
+                        <li data-ukt-value="center">Center</li>
+                        <li data-ukt-value="right">Right</li>
+                        <li data-ukt-value="justify">Justify</li>
+                    </ul>
+                </Dropdown>
+                <Dropdown label="Spacing">
+                    <ul>
+                        <li data-ukt-value="1">Single</li>
+                        <li data-ukt-value="1.5">1.5 Lines</li>
+                        <li data-ukt-value="2">Double</li>
+                        <Dropdown label="Custom">
+                            <ul>
+                                <li data-ukt-value="0.5">0.5 Lines</li>
+                                <li data-ukt-value="3">Triple</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>
+            </ul>,
+        ] as const,
+        className: 'submenu-example',
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'A `Dropdown` nested inside another dropdown’s body renders as a parent item that discloses a submenu. Pause on a parent item to disclose its submenu (pointer or arrow keys), press → to dive in, ← to surface back out. Parent items never submit; `onSubmitItem` fires only for leaf items, with the leaf’s ancestor `path` in the payload.',
+            },
+        },
+    },
+};
+
+export const MenubarAppMenu: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: '`Menubar` combines sibling dropdowns into a single menu like the system menu in the top toolbar of macOS: one menu open at a time, ←/→ move between menus, and once any menu is open, hovering another trigger switches to it.',
+            },
+        },
+    },
+    render() {
+        return (
+            <Menubar>
+                <Dropdown onSubmitItem={fn()}>
+                    File
+                    <ul>
+                        <li data-ukt-item>New Window</li>
+                        <li data-ukt-item>New Tab</li>
+                        <Dropdown label="Open Recent">
+                            <ul>
+                                <li data-ukt-item>project-a</li>
+                                <li data-ukt-item>project-b</li>
+                                <li data-ukt-item>project-c</li>
+                            </ul>
+                        </Dropdown>
+                        <li data-ukt-item>Close Window</li>
+                    </ul>
+                </Dropdown>
+                <Dropdown onSubmitItem={fn()}>
+                    Edit
+                    <ul>
+                        <li data-ukt-item>Undo</li>
+                        <li data-ukt-item>Redo</li>
+                        <Dropdown label="Find">
+                            <ul>
+                                <li data-ukt-item>Find…</li>
+                                <li data-ukt-item>Find Next</li>
+                                <li data-ukt-item>Find Previous</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>
+                <Dropdown onSubmitItem={fn()}>
+                    View
+                    <ul>
+                        <li data-ukt-item>Zoom In</li>
+                        <li data-ukt-item>Zoom Out</li>
+                        <li data-ukt-item>Actual Size</li>
+                    </ul>
+                </Dropdown>
+            </Menubar>
+        );
+    },
+};
+
+export const NestedInfoPopover: Story = {
+    args: {
+        children: [
+            'Layout',
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                <div style={{ alignItems: 'center', display: 'flex', gap: '0.25rem' }}>
+                    <CSSValueInput
+                        cssValueType="length"
+                        label="Width"
+                        onSubmitValue={() => {}}
+                        placeholder="100vw"
+                        unit="vw"
+                    />
+                    <Dropdown hasItems={false}>
+                        <button aria-label="About width" type="button">
+                            ℹ️
+                        </button>
+                        <p style={{ margin: 0, maxWidth: '16rem' }}>
+                            Width accepts any CSS length. Use the ↑/↓ arrow keys in the
+                            input to step the current value.
+                        </p>
+                    </Dropdown>
+                </div>
+                <div style={{ alignItems: 'center', display: 'flex', gap: '0.25rem' }}>
+                    <CSSValueInput
+                        cssValueType="length"
+                        label="Rotation"
+                        onSubmitValue={() => {}}
+                        placeholder="0deg"
+                        step={5}
+                        unit="deg"
+                    />
+                    <Dropdown hasItems={false}>
+                        <button aria-label="About rotation" type="button">
+                            ℹ️
+                        </button>
+                        <p style={{ margin: 0, maxWidth: '16rem' }}>
+                            Rotation accepts any CSS angle (deg, rad, turn) and steps by
+                            5deg with the ↑/↓ arrow keys.
+                        </p>
+                    </Dropdown>
+                </div>
+            </div>,
+        ] as const,
+        className: 'nested-info-popover',
+        hasItems: false,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'A `Dropdown` nested with `hasItems={false}` isn’t a submenu — it renders as an independent anchored dropdown inside the outer body, like these ℹ️ info popovers describing each input. Interacting with the popover doesn’t close or submit the outer dropdown, and Escape closes the innermost open dropdown first.',
+            },
+        },
     },
 };

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -548,6 +548,11 @@ Submenu semantics:
   [Keyboard Navigation](#keyboard-navigation--accessibility).
 - A parent item’s open state is carried by its `aria-expanded` attribute,
   which is also the styling hook for submenu visibility.
+- With the pointer, an open submenu tracks mouse intent: moving diagonally
+  from the parent item toward the submenu keeps it open even as the pointer
+  crosses sibling items along the way (the macOS “safe triangle” between
+  the pointer and the submenu’s near edge). Moving straight onto a sibling
+  — or pausing mid-diagonal — switches to that item as usual.
 
 ### The `data-ukt-submenu` protocol
 

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -17,8 +17,18 @@
     --uktdd-body-position-area: bottom span-right;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-left, --uktdd-bottom-right, --uktdd-top-right;
-    --uktdd-body-translate: 0 0;
+    /* any translate value except none makes the box a containing block for
+       its fixed-position submenus, constraining and clipping them, so only
+       set a translate on dropdowns without submenus */
+    --uktdd-body-translate: none;
+    --uktdd-body-color: canvastext;
+    --uktdd-body-bg-color-path: #dcdcdc;
+    --uktdd-body-color-path: currentColor;
     --uktdd-label-pad-right: 0.625em;
+    --uktdd-submenu-position-area: inline-end span-block-end;
+    --uktdd-submenu-position-try-fallbacks: --uktdd-submenu-inline-start;
+    --uktdd-submenu-translate: none;
+    --uktdd-menubar-trigger-bg-color-active: rgba(0, 0, 0, 0.12);
 }
 
 .uktdropdown,
@@ -80,6 +90,96 @@
         background-color: var(--uktdd-body-bg-color-hover);
         color: var(--uktdd-body-color-hover);
     }
+
+    /* an active item is on the path — not deepest — while a deeper highlight
+       exists or the pointer is inside its submenu; macOS mutes the parent
+       even when the pointer is over a separator or disabled submenu item */
+    [data-ukt-active]:has([data-ukt-submenu] [data-ukt-active]),
+    [data-ukt-active]:has([data-ukt-submenu]:hover) {
+        background-color: var(--uktdd-body-bg-color-path);
+        color: var(--uktdd-body-color-path);
+    }
+
+    [data-ukt-item][aria-disabled="true"] {
+        opacity: 0.5;
+        pointer-events: none;
+    }
+
+    /* the expanded parent item anchors its submenu; anchor-scope keeps each
+       level’s submenu bound to its own parent item */
+    [data-ukt-item] {
+        anchor-scope: --uktdd-submenu-anchor;
+    }
+
+    /* parent items get a macOS-style disclosure chevron, right-aligned */
+    :is([data-ukt-item], [data-ukt-value])[aria-haspopup="menu"] {
+        position: relative;
+        padding-inline-end: 2em;
+
+        &::after {
+            content: "";
+            position: absolute;
+            inset-inline-end: 0.9em;
+            inset-block-start: 50%;
+            inline-size: 0.3em;
+            block-size: 0.3em;
+            border-block-start: 0.14em solid currentColor;
+            border-inline-end: 0.14em solid currentColor;
+            translate: 0 -50%;
+            rotate: 45deg;
+        }
+
+        &:dir(rtl)::after {
+            rotate: -45deg;
+        }
+    }
+
+    [data-ukt-item][aria-expanded="true"] {
+        anchor-name: --uktdd-submenu-anchor;
+
+        > [data-ukt-submenu] {
+            display: block;
+        }
+    }
+
+    [data-ukt-submenu] {
+        box-sizing: border-box;
+        display: none;
+        /* an explicit color so items don’t inherit the white highlight color
+           from their active parent item (the submenu is its DOM child) */
+        color: var(--uktdd-body-color);
+        position: fixed;
+        position-anchor: --uktdd-submenu-anchor;
+        position-area: var(--uktdd-submenu-position-area);
+        position-try-fallbacks: var(--uktdd-submenu-position-try-fallbacks);
+        translate: var(--uktdd-submenu-translate);
+        z-index: 2;
+        margin: 0;
+        padding: var(--uktdd-body-pad-top) var(--uktdd-body-pad-right)
+            var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
+        inline-size: max-content;
+        max-inline-size: var(--uktdd-body-max-width);
+        max-block-size: var(--uktdd-body-max-height);
+        overflow: auto;
+        overscroll-behavior: contain;
+        list-style: none;
+        background-color: var(--uktdd-body-bg-color);
+        box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+    }
+}
+
+.uktmenubar {
+    display: flex;
+    align-items: stretch;
+    width: max-content;
+    font-family: var(--uktdd-font-family);
+
+    /* the open menu’s trigger reads as active, like the highlighted item in
+       the macOS menu bar; the default tints over whatever background the
+       trigger already has, so it works regardless of how it’s styled */
+    .uktdropdown.is-open .uktdropdown-trigger {
+        box-shadow: inset 0 0 0 100vmax var(--uktdd-menubar-trigger-bg-color-active);
+    }
 }
 
 .uktdropdown-content {
@@ -105,4 +205,8 @@
 
 @position-try --uktdd-top-right {
     position-area: top span-left;
+}
+
+@position-try --uktdd-submenu-inline-start {
+    position-area: inline-start span-block-end;
 }

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { type MouseEvent } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import Dropdown from './Dropdown.js';
+import Dropdown, { type Props } from './Dropdown.js';
 
 afterEach(cleanup);
 
@@ -935,6 +935,639 @@ describe('@acusti/dropdown', () => {
             expect(handleSubmitItem).toHaveBeenCalledWith(
                 expect.objectContaining({ value: '' }),
             );
+        });
+    });
+
+    describe('mouseup submission targets the clicked item', () => {
+        const renderMenu = (handleSubmitItem: (payload: unknown) => void) =>
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                        <li aria-hidden className="separator" data-testid="separator" />
+                        <li data-ukt-item data-ukt-value="two">
+                            Two
+                        </li>
+                        <li aria-disabled="true" data-ukt-item data-ukt-value="three">
+                            Three
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+        it('submits the clicked item, not a divergent keyboard-active item', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderMenu(handleSubmitItem);
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{ArrowDown}'); // “One” becomes active
+            fireEvent.mouseUp(screen.getByText('Two'));
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ value: 'two' }),
+            );
+        });
+
+        it('does not submit the active item when the click lands on a separator', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderMenu(handleSubmitItem);
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{ArrowDown}'); // “One” becomes active
+            fireEvent.mouseUp(screen.getByTestId('separator'));
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            // Like macOS, the click is a no-op: the menu stays open with
+            // the active item unchanged
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+        });
+
+        it('does not submit the active item when the click lands on a disabled item', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderMenu(handleSubmitItem);
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{ArrowDown}'); // “One” becomes active
+            fireEvent.mouseUp(screen.getByText('Three'));
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+        });
+    });
+
+    describe('submenus (nested Dropdowns)', () => {
+        const renderFormatMenu = (
+            props: Partial<Props> = {},
+            submenuProps: Partial<Props> = {},
+        ) => {
+            const result = render(
+                <Dropdown {...props}>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <li data-ukt-item>Italic</li>
+                        <Dropdown label={<span>Align</span>} {...submenuProps}>
+                            <ul data-testid="align-submenu">
+                                <li data-ukt-value="left">Left</li>
+                                <li data-ukt-value="center">Center</li>
+                                <li data-ukt-value="right">Right</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+            return result;
+        };
+
+        const getParentItem = () => {
+            const item = screen.getByText('Align').closest('li');
+            expect(item).toBeTruthy();
+            return item as HTMLElement;
+        };
+
+        it('renders a nested Dropdown as a parent item using the data-ukt-submenu protocol with ARIA filled in', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+
+            const parentItem = getParentItem();
+            expect(parentItem.hasAttribute('data-ukt-item')).toBe(true);
+            expect(parentItem.getAttribute('aria-haspopup')).toBe('menu');
+            expect(parentItem.getAttribute('aria-expanded')).toBe('false');
+
+            const submenu = screen.getByTestId('align-submenu');
+            expect(submenu.hasAttribute('data-ukt-submenu')).toBe(true);
+            expect(submenu.getAttribute('role')).toBe('menu');
+            expect(submenu.id).toBeTruthy();
+            expect(parentItem.getAttribute('aria-controls')).toBe(submenu.id);
+        });
+
+        it('dives into and surfaces out of a submenu with →/← while the parent item stays active', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+
+            const parentItem = getParentItem();
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{ArrowRight}');
+            expect(parentItem.getAttribute('aria-expanded')).toBe('true');
+            const leftItem = screen.getByText('Left');
+            expect(leftItem.hasAttribute('data-ukt-active')).toBe(true);
+            // the parent item stays on the active path
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+
+            // ↑/↓ navigate the submenu level, not the top level
+            await user.keyboard('{ArrowDown}');
+            expect(screen.getByText('Center').hasAttribute('data-ukt-active')).toBe(true);
+            expect(leftItem.hasAttribute('data-ukt-active')).toBe(false);
+
+            await user.keyboard('{ArrowLeft}');
+            expect(parentItem.getAttribute('aria-expanded')).toBe('false');
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+            expect(screen.getByText('Center').hasAttribute('data-ukt-active')).toBe(
+                false,
+            );
+        });
+
+        it('applies the flat item-detection heuristic within submenu bodies with no marked items', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown label={<span>Align</span>}>
+                            <ul>
+                                <li>Left</li>
+                                <li>Center</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}');
+
+            // Unmarked submenu items are detected heuristically per level
+            const leftItem = screen.getByText('Left');
+            expect(leftItem.hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{ArrowDown}');
+            expect(screen.getByText('Center').hasAttribute('data-ukt-active')).toBe(true);
+
+            // Hover resolves within the item’s own level, not the parent item
+            // (mousemove first: pointer movement switches the input method
+            // back to mouse after keyboard navigation)
+            fireEvent.mouseMove(leftItem);
+            fireEvent.mouseOver(leftItem);
+            expect(leftItem.hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{Enter}');
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    label: 'Left',
+                    path: [{ label: 'Align', value: 'Align' }],
+                    value: 'Left',
+                }),
+            );
+        });
+
+        it('collapses expanded descendant submenus when surfacing with ←', async () => {
+            const handleMoreClose = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                                <Dropdown
+                                    label={<span>More</span>}
+                                    onClose={handleMoreClose}
+                                >
+                                    <ul>
+                                        <li data-ukt-value="x">X</li>
+                                    </ul>
+                                </Dropdown>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            // Dive into the Align submenu and land on its More parent item
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}{ArrowDown}');
+
+            const alignItem = screen.getByText('Align').closest('li') as HTMLElement;
+            const moreItem = screen.getByText('More').closest('li') as HTMLElement;
+            // Pausing on More discloses its submenu (highlight stays on More)
+            await waitFor(() =>
+                expect(moreItem.getAttribute('aria-expanded')).toBe('true'),
+            );
+
+            await user.keyboard('{ArrowLeft}');
+            expect(alignItem.getAttribute('aria-expanded')).toBe('false');
+            expect(moreItem.getAttribute('aria-expanded')).toBe('false');
+            expect(handleMoreClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('opens the submenu on Enter instead of submitting (parent items never submit)', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            const parentItem = getParentItem();
+            expect(parentItem.getAttribute('aria-expanded')).toBe('true');
+            expect(screen.getByText('Left').hasAttribute('data-ukt-active')).toBe(true);
+            // the dropdown stays open
+            expect(screen.getByTestId('align-submenu')).toBeTruthy();
+        });
+
+        it('submits leaf items with their ancestor path', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+            await user.keyboard('{ArrowRight}');
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    label: 'Left',
+                    path: [{ label: 'Align', value: 'Align' }],
+                    value: 'left',
+                }),
+            );
+        });
+
+        it('submits top-level leaf items with an empty path', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}');
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ label: 'Bold', path: [], value: 'Bold' }),
+            );
+        });
+
+        it('discloses the submenu after a short intent delay when pausing on a parent item', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+
+            const parentItem = getParentItem();
+            // not disclosed synchronously…
+            expect(parentItem.getAttribute('aria-expanded')).toBe('false');
+            // …but disclosed after the intent delay, highlight staying on the parent
+            await waitFor(() =>
+                expect(parentItem.getAttribute('aria-expanded')).toBe('true'),
+            );
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+            expect(screen.getByText('Left').hasAttribute('data-ukt-active')).toBe(false);
+        });
+
+        it('does not flash the submenu open when arrowing quickly past a parent item', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            // Arrow onto the parent item and away again immediately
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowUp}');
+
+            const parentItem = getParentItem();
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            expect(parentItem.getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('scopes typeahead to the current level', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowRight}');
+            await user.keyboard('ri');
+
+            expect(screen.getByText('Right').hasAttribute('data-ukt-active')).toBe(true);
+        });
+
+        it('closes the whole menu on Escape and returns focus to the trigger', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            const trigger = screen.getByRole('button', { name: 'Format' });
+            await user.click(trigger);
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowRight}');
+            await user.keyboard('{Escape}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('align-submenu')).toBe(null);
+            expect(document.activeElement).toBe(trigger);
+        });
+
+        it('dispatches scoped onOpen/onClose/onSubmitItem to the nested Dropdown', async () => {
+            const handleRootSubmitItem = vi.fn();
+            const handleAlignClose = vi.fn();
+            const handleAlignOpen = vi.fn();
+            const handleAlignSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu(
+                { onSubmitItem: handleRootSubmitItem },
+                {
+                    onClose: handleAlignClose,
+                    onOpen: handleAlignOpen,
+                    onSubmitItem: handleAlignSubmitItem,
+                },
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+            await user.keyboard('{ArrowRight}');
+            expect(handleAlignOpen).toHaveBeenCalledTimes(1);
+
+            await user.keyboard('{ArrowLeft}');
+            expect(handleAlignClose).toHaveBeenCalledTimes(1);
+
+            // a top-level submit doesn’t reach the nested dropdown
+            await user.keyboard('{ArrowUp}{ArrowUp}');
+            await user.keyboard('{Enter}');
+            expect(handleRootSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleAlignSubmitItem).not.toHaveBeenCalled();
+        });
+
+        it('dispatches a submenu leaf submission to both the root and the nested Dropdown', async () => {
+            const handleRootSubmitItem = vi.fn();
+            const handleAlignSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu(
+                { onSubmitItem: handleRootSubmitItem },
+                { onSubmitItem: handleAlignSubmitItem },
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowRight}');
+            await user.keyboard('{Enter}');
+
+            const expectedPayload = expect.objectContaining({
+                path: [{ label: 'Align', value: 'Align' }],
+                value: 'left',
+            });
+            expect(handleRootSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleRootSubmitItem).toHaveBeenCalledWith(expectedPayload);
+            expect(handleAlignSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleAlignSubmitItem).toHaveBeenCalledWith(expectedPayload);
+        });
+
+        it('toggles the submenu open on click without submitting or closing the menu', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+
+            const parentItem = getParentItem();
+            fireEvent.mouseOver(parentItem);
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+            fireEvent.mouseUp(parentItem);
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            expect(parentItem.getAttribute('aria-expanded')).toBe('true');
+            expect(screen.getByTestId('align-submenu')).toBeTruthy();
+        });
+
+        it('submits a hovered submenu leaf on mouseup with its path', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            renderFormatMenu({ onSubmitItem: handleSubmitItem });
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+
+            const parentItem = getParentItem();
+            fireEvent.mouseOver(parentItem);
+            fireEvent.mouseUp(parentItem);
+
+            const centerItem = screen.getByText('Center');
+            fireEvent.mouseOver(centerItem);
+            expect(centerItem.hasAttribute('data-ukt-active')).toBe(true);
+            // the parent stays on the active path
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(true);
+            fireEvent.mouseUp(centerItem);
+
+            expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    path: [{ label: 'Align', value: 'Align' }],
+                    value: 'center',
+                }),
+            );
+        });
+
+        it('skips disabled nested Dropdowns during keyboard navigation', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown disabled label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                            </ul>
+                        </Dropdown>
+                        <li data-ukt-item>Italic</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('{ArrowDown}{ArrowDown}');
+
+            const parentItem = screen.getByText('Align').closest('li') as HTMLElement;
+            expect(parentItem.getAttribute('aria-disabled')).toBe('true');
+            expect(parentItem.hasAttribute('data-ukt-active')).toBe(false);
+            expect(screen.getByText('Italic').hasAttribute('data-ukt-active')).toBe(true);
+        });
+
+        it('warns about props that are ignored on a nested Dropdown', async () => {
+            const consoleErrorSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+            const user = userEvent.setup();
+
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown isSearchable label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('ignored on a nested (submenu) Dropdown'),
+            );
+            consoleErrorSpy.mockRestore();
+        });
+    });
+
+    it('skips aria-disabled items during keyboard navigation in flat (heuristic) bodies', async () => {
+        const user = userEvent.setup();
+        render(
+            <Dropdown>
+                Menu
+                <ul>
+                    <li>One</li>
+                    <li aria-disabled="true">Two</li>
+                    <li>Three</li>
+                </ul>
+            </Dropdown>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Menu' }));
+        await user.keyboard('{ArrowDown}{ArrowDown}');
+
+        expect(screen.getByText('Two').hasAttribute('data-ukt-active')).toBe(false);
+        expect(screen.getByText('Three').hasAttribute('data-ukt-active')).toBe(true);
+    });
+
+    it('stays closed when Escape restores focus to a searchable trigger input', async () => {
+        const user = userEvent.setup();
+        render(
+            <Dropdown isSearchable>
+                <ul>
+                    <li data-ukt-item>
+                        <button type="button">Action</button>
+                    </li>
+                </ul>
+            </Dropdown>,
+        );
+
+        const input = screen.getByRole('textbox');
+        await user.click(input);
+        expect(screen.getByRole('listbox')).toBeTruthy();
+
+        // Move focus into the body so Escape’s focus restore fires the
+        // trigger input’s onFocus (which opens the dropdown on focus)
+        const bodyButton = screen.getByRole('button', { name: 'Action' });
+        act(() => bodyButton.focus());
+        expect(screen.getByRole('listbox')).toBeTruthy();
+
+        await user.keyboard('{Escape}');
+        expect(screen.queryByRole('listbox')).toBe(null);
+        expect(document.activeElement).toBe(input);
+    });
+
+    describe('nested non-menu dropdowns (hasItems={false})', () => {
+        it('renders a nested hasItems={false} Dropdown as an independent anchored dropdown', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown hasItems={false}>
+                    <button>Settings</button>
+                    <div>
+                        <label>
+                            Full name <input />
+                        </label>
+                        <Dropdown hasItems={false}>
+                            <button aria-label="About full name">ℹ️</button>
+                            <p data-testid="info-popover">Used for your profile.</p>
+                        </Dropdown>
+                    </div>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Settings' }));
+            expect(screen.getByRole('textbox')).toBeTruthy();
+            expect(screen.queryByTestId('info-popover')).toBe(null);
+
+            await user.click(screen.getByRole('button', { name: 'About full name' }));
+            // the info popover opens and the outer dropdown stays open
+            expect(screen.getByTestId('info-popover')).toBeTruthy();
+            expect(screen.getByRole('textbox')).toBeTruthy();
+
+            // Escape closes only the innermost open dropdown…
+            await user.keyboard('{Escape}');
+            expect(screen.queryByTestId('info-popover')).toBe(null);
+            expect(screen.getByRole('textbox')).toBeTruthy();
+
+            // …and a second Escape closes the outer one
+            await user.keyboard('{Escape}');
+            expect(screen.queryByRole('textbox')).toBe(null);
+        });
+
+        it('closes the nested popover when its trigger is clicked again, keeping the outer dropdown open', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown hasItems={false}>
+                    <button>Settings</button>
+                    <div>
+                        <label>
+                            Full name <input />
+                        </label>
+                        <Dropdown hasItems={false}>
+                            <button aria-label="About full name">ℹ️</button>
+                            <p data-testid="info-popover">Used for your profile.</p>
+                        </Dropdown>
+                    </div>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Settings' }));
+            const infoTrigger = screen.getByRole('button', {
+                name: 'About full name',
+            });
+            await user.click(infoTrigger);
+            expect(screen.getByTestId('info-popover')).toBeTruthy();
+
+            await user.click(infoTrigger);
+            expect(screen.queryByTestId('info-popover')).toBe(null);
+            expect(screen.getByRole('textbox')).toBeTruthy();
+        });
+
+        it('does not submit the outer menu when opening a nested popover from an item', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <Dropdown onSubmitItem={handleSubmitItem}>
+                    Menu
+                    <ul>
+                        <li data-ukt-item>
+                            Alpha
+                            <Dropdown hasItems={false}>
+                                <button aria-label="About alpha">ℹ️</button>
+                                <p data-testid="alpha-info">Alpha info.</p>
+                            </Dropdown>
+                        </li>
+                        <li data-ukt-item>Beta</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.click(screen.getByRole('button', { name: 'About alpha' }));
+
+            expect(screen.getByTestId('alpha-info')).toBeTruthy();
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+            // the outer menu stays open
+            expect(screen.getByText('Beta')).toBeTruthy();
         });
     });
 });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -34,6 +34,7 @@ import {
     collapseItemsOutsidePath,
     expandItem,
     getActiveItemElement,
+    getDeepestExpandedItem,
     getItemElements,
     getItemForTarget,
     getItemPath,
@@ -41,6 +42,8 @@ import {
     getParentItem,
     getSubmenuOfItem,
     isItemExpanded,
+    isPointInTriangle,
+    type Point,
     setActiveItem,
 } from './helpers.js';
 
@@ -141,6 +144,11 @@ const TEXT_INPUT_SELECTOR =
 // puts its delay around 200–250ms; anything much shorter flashes
 const SUBMENU_DISCLOSURE_DELAY = 200;
 
+// How long the pointer can dwell inside the safe area (heading toward an open
+// submenu) before we give up and switch to whatever it’s actually over. Reset
+// on every move, so it only fires on a pause — motion keeps the submenu open
+const SAFE_AREA_TIMEOUT = 300;
+
 export default function Dropdown(props: Props) {
     const parentDropdown = useContext(DropdownContext);
     // A Dropdown nested inside another dropdown’s body is a submenu: it
@@ -209,6 +217,11 @@ function RootDropdown({
     const disclosureTimerRef = useRef<null | TimeoutID>(null);
     const pendingDisclosureItemRef = useRef<MaybeHTMLElement>(null);
     const submenuRegistrationsRef = useRef<Set<SubmenuRegistration>>(new Set());
+    const pointerRef = useRef<Point | null>(null);
+    const lastMouseEventRef = useRef<MouseEvent | null>(null);
+    const safeAreaRef = useRef<{ apex: Point; parent: HTMLElement } | null>(null);
+    const safeAreaTimerRef = useRef<null | TimeoutID>(null);
+    const wasInSafeAreaRef = useRef<boolean>(false);
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
@@ -336,11 +349,126 @@ function RootDropdown({
         clearDisclosureTimer();
     };
 
+    const clearSafeAreaTimer = () => {
+        if (safeAreaTimerRef.current != null) {
+            clearTimeout(safeAreaTimerRef.current);
+            safeAreaTimerRef.current = null;
+        }
+    };
+
+    // Clear the safe-area give-up timer on unmount so it can’t fire against
+    // unmounted DOM
+    useEffect(() => clearSafeAreaTimer, []);
+
+    // The safe area is the triangle from where the pointer last sat on the
+    // open submenu’s parent (the apex) to that submenu’s two near corners.
+    // While the pointer is inside it, it’s traveling toward the submenu, so the
+    // submenu stays open even as the pointer crosses sibling items — the macOS
+    // diagonal behavior
+    const isPointerInSafeArea = (x: number, y: number): boolean => {
+        const safeArea = safeAreaRef.current;
+        if (!safeArea || !isItemExpanded(safeArea.parent)) return false;
+        const submenu = getSubmenuOfItem(safeArea.parent);
+        if (!submenu) return false;
+        const submenuRect = submenu.getBoundingClientRect();
+        const parentRect = safeArea.parent.getBoundingClientRect();
+        // Submenus can open to either side; the near edge is the one facing
+        // the parent item
+        const nearX =
+            submenuRect.left >= parentRect.right - 1
+                ? submenuRect.left
+                : submenuRect.right;
+        return isPointInTriangle(
+            { x, y },
+            safeArea.apex,
+            { x: nearX, y: submenuRect.top },
+            { x: nearX, y: submenuRect.bottom },
+        );
+    };
+
+    // The pointer left the safe area (or paused in it without reaching the
+    // submenu): stop protecting the submenu and switch to whatever the pointer
+    // is over now. Passing the target avoids an elementFromPoint read; the
+    // give-up timer has no event, so it falls back to hit-testing the pointer
+    const commitPointerTarget = (targetElement?: MaybeHTMLElement) => {
+        clearSafeAreaTimer();
+        safeAreaRef.current = null;
+        wasInSafeAreaRef.current = false;
+        const pointer = pointerRef.current;
+        const target =
+            targetElement ??
+            (pointer
+                ? (dropdownElement?.ownerDocument.elementFromPoint(
+                      pointer.x,
+                      pointer.y,
+                  ) as MaybeHTMLElement)
+                : null);
+        if (!dropdownElement || !target || !dropdownElement.contains(target)) return;
+        const item = getItemForTarget(dropdownElement, target);
+        const event = lastMouseEventRef.current;
+        // Only reachable via mouse events, so a real mouse event is on hand
+        if (item && event) {
+            setActiveItem({
+                dropdownElement,
+                element: item,
+                event,
+                onActiveItem: handleActiveItem,
+            });
+        }
+        syncSubmenuDisclosure();
+    };
+
+    // Track the pointer against the open submenu’s safe area: anchor the apex
+    // while over the parent item, and (re)arm the give-up timer while traveling
+    // toward the submenu so only a pause — not motion — ends the protection
+    const trackSafeArea = (event: ReactMouseEvent<HTMLElement>) => {
+        // Safe-area intent only applies to an open menu with items; skip the
+        // per-move DOM query otherwise (mousemove is a hot path)
+        if (!dropdownElement || !isOpenRef.current || !hasItemsRef.current) return;
+        const pointer = { x: event.clientX, y: event.clientY };
+        pointerRef.current = pointer;
+        lastMouseEventRef.current = event.nativeEvent;
+        const parent = getDeepestExpandedItem(dropdownElement);
+        if (!parent) {
+            safeAreaRef.current = null;
+            wasInSafeAreaRef.current = false;
+            clearSafeAreaTimer();
+            return;
+        }
+        const target = event.target as HTMLElement;
+        const submenu = getSubmenuOfItem(parent);
+        const isOverParent =
+            parent.contains(target) && !(submenu?.contains(target) ?? false);
+        if (isOverParent) {
+            safeAreaRef.current = { apex: pointer, parent };
+            wasInSafeAreaRef.current = false;
+            clearSafeAreaTimer();
+            return;
+        }
+        // A newly-open submenu we haven’t anchored an apex for yet
+        if (safeAreaRef.current?.parent !== parent) {
+            safeAreaRef.current = null;
+        }
+        clearSafeAreaTimer();
+        if (isPointerInSafeArea(pointer.x, pointer.y)) {
+            wasInSafeAreaRef.current = true;
+            safeAreaTimerRef.current = setTimeout(commitPointerTarget, SAFE_AREA_TIMEOUT);
+        } else if (wasInSafeAreaRef.current) {
+            // Just crossed out of the triangle. The pointer may still be over
+            // the same sibling it entered while protected, so no mouseover will
+            // fire — re-evaluate and activate whatever it’s on now
+            commitPointerTarget(target);
+        }
+    };
+
     const closeDropdown = () => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
         clearDisclosureTimer();
+        clearSafeAreaTimer();
+        safeAreaRef.current = null;
+        wasInSafeAreaRef.current = false;
         if (closingTimerRef.current != null) {
             clearTimeout(closingTimerRef.current);
             closingTimerRef.current = null;
@@ -485,8 +613,10 @@ function RootDropdown({
         dispatchToSubmenus('onSubmitItem', payload);
     };
 
-    const handleMouseMove = ({ clientX, clientY }: ReactMouseEvent<HTMLElement>) => {
+    const handleMouseMove = (event: ReactMouseEvent<HTMLElement>) => {
+        const { clientX, clientY } = event;
         currentInputMethodRef.current = 'mouse';
+        trackSafeArea(event);
         const initialPosition = mouseDownPositionRef.current;
         if (!initialPosition) return;
         if (
@@ -519,6 +649,9 @@ function RootDropdown({
             return;
         }
 
+        // Heading toward an open submenu: keep it open even over sibling items
+        if (isPointerInSafeArea(event.clientX, event.clientY)) return;
+
         const item = getItemForTarget(dropdownElement, eventTarget);
         if (!item) return;
 
@@ -533,6 +666,18 @@ function RootDropdown({
 
     const handleMouseOut = (event: ReactMouseEvent<HTMLElement>) => {
         if (!hasItemsRef.current) return;
+        // The pointer left the dropdown entirely: drop the safe area so its
+        // give-up timer can’t later fire on a stale position, and fall through
+        // to the normal collapse (mousemove has stopped, so nothing else will)
+        const relatedTarget = event.relatedTarget as Node | null;
+        const isLeavingDropdown = !dropdownElement?.contains(relatedTarget);
+        if (isLeavingDropdown) {
+            clearSafeAreaTimer();
+            safeAreaRef.current = null;
+            wasInSafeAreaRef.current = false;
+        }
+        // Heading toward an open submenu: don’t clear the active item / collapse
+        if (isPointerInSafeArea(event.clientX, event.clientY)) return;
         const activeItem = getActiveItemElement(dropdownElement);
         if (!activeItem) return;
         const eventRelatedTarget = event.relatedTarget as HTMLElement;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -13,17 +13,34 @@ import {
     type ReactElement,
     type ReactNode,
     type SyntheticEvent,
+    useContext,
     useEffect,
     useId,
+    useMemo,
     useRef,
     useState,
 } from 'react';
 
+import {
+    DropdownContext,
+    type DropdownContextValue,
+    MenubarContext,
+    type SubmenuRegistration,
+} from './context.js';
 import styles from './Dropdown.css?inline';
 import {
+    annotateParentItems,
+    collapseItem,
+    collapseItemsOutsidePath,
+    expandItem,
     getActiveItemElement,
     getItemElements,
-    ITEM_SELECTOR,
+    getItemForTarget,
+    getItemPath,
+    getLevelRoot,
+    getParentItem,
+    getSubmenuOfItem,
+    isItemExpanded,
     setActiveItem,
 } from './helpers.js';
 
@@ -31,8 +48,15 @@ export type Item = {
     element: MaybeHTMLElement;
     event: Event | SyntheticEvent<HTMLElement>;
     label: string;
+    /**
+     * Ancestor parent items from the root level down to the item’s
+     * immediate parent. Empty for top-level items.
+     */
+    path: Array<ItemPathEntry>;
     value: string;
 };
+
+export type ItemPathEntry = { label: string; value: string };
 
 export type Props = {
     /**
@@ -60,6 +84,10 @@ export type Props = {
     isOpenOnMount?: boolean;
     isSearchable?: boolean;
     keepOpenOnSubmit?: boolean;
+    /**
+     * Label content for the trigger button (when using single child syntax).
+     * For a nested (submenu) Dropdown, this is the parent item’s content.
+     */
     label?: ReactNode;
     minHeightBody?: number;
     minWidthBody?: number;
@@ -104,10 +132,29 @@ type TimeoutID = ReturnType<typeof setTimeout>;
 const CHILDREN_ERROR =
     '@acusti/dropdown requires either 1 child (the dropdown body) or 2 children: the dropdown trigger and the dropdown body.';
 const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="submit"]';
+const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 const TEXT_INPUT_SELECTOR =
     'input:not([type=radio]):not([type=checkbox]):not([type=range]),textarea';
 
-export default function Dropdown({
+// Matches macOS: quick, natural arrowing past parent items never flashes
+// their submenus, but a brief pause discloses. Frame-stepping macOS menus
+// puts its delay around 200–250ms; anything much shorter flashes
+const SUBMENU_DISCLOSURE_DELAY = 200;
+
+export default function Dropdown(props: Props) {
+    const parentDropdown = useContext(DropdownContext);
+    // A Dropdown nested inside another dropdown’s body is a submenu: it
+    // renders as a parent item and delegates to the root dropdown’s engine.
+    // A nested Dropdown with hasItems={false} isn’t a menu, so it renders as
+    // an independent anchored dropdown instead (e.g. an info popover inside
+    // a form dropdown)
+    if (parentDropdown && props.hasItems !== false) {
+        return <SubmenuDropdown {...props} parentDropdown={parentDropdown} />;
+    }
+    return <RootDropdown {...props} />;
+}
+
+function RootDropdown({
     allowCreate,
     allowEmpty = true,
     children,
@@ -151,6 +198,7 @@ export default function Dropdown({
     const [dropdownElement, setDropdownElement] = useState<MaybeHTMLElement>(null);
     const bodyId = useId();
     const popupRole = isSearchable ? 'listbox' : hasItems ? 'menu' : 'dialog';
+    const menubar = useContext(MenubarContext);
     const inputElementRef = useRef<HTMLInputElement | null>(null);
     const closingTimerRef = useRef<null | TimeoutID>(null);
     const isOpeningTimerRef = useRef<null | TimeoutID>(null);
@@ -158,6 +206,9 @@ export default function Dropdown({
     const clearEnteredCharactersTimerRef = useRef<null | TimeoutID>(null);
     const enteredCharactersRef = useRef<string>('');
     const mouseDownPositionRef = useRef<MousePosition | null>(null);
+    const disclosureTimerRef = useRef<null | TimeoutID>(null);
+    const pendingDisclosureItemRef = useRef<MaybeHTMLElement>(null);
+    const submenuRegistrationsRef = useRef<Set<SubmenuRegistration>>(new Set());
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
@@ -213,17 +264,143 @@ export default function Dropdown({
         }
     }, [isOpen]);
 
+    // Nested (submenu) Dropdowns register here so their scoped callbacks
+    // (onActiveItem/onOpen/onClose/onSubmitItem) can be dispatched to them
+    const dropdownContextValue: DropdownContextValue = useMemo(
+        () => ({
+            registerSubmenu(registration: SubmenuRegistration) {
+                submenuRegistrationsRef.current.add(registration);
+                return () => {
+                    submenuRegistrationsRef.current.delete(registration);
+                };
+            },
+        }),
+        [],
+    );
+
+    const dispatchToSubmenus = (key: 'onActiveItem' | 'onSubmitItem', payload: Item) => {
+        if (!payload.element) return;
+        for (const registration of submenuRegistrationsRef.current) {
+            if (registration.element.contains(payload.element)) {
+                registration[key]?.(payload);
+            }
+        }
+    };
+
+    const handleActiveItem = (payload: Item) => {
+        onActiveItem?.(payload);
+        dispatchToSubmenus('onActiveItem', payload);
+    };
+
+    const handleToggleSubmenu = (item: HTMLElement, isExpanded: boolean) => {
+        for (const registration of submenuRegistrationsRef.current) {
+            if (registration.element === item) {
+                (isExpanded ? registration.onOpen : registration.onClose)?.();
+            }
+        }
+    };
+
+    const clearDisclosureTimer = () => {
+        if (disclosureTimerRef.current != null) {
+            clearTimeout(disclosureTimerRef.current);
+            disclosureTimerRef.current = null;
+        }
+        pendingDisclosureItemRef.current = null;
+    };
+
+    // Clear the disclosure intent timer on unmount so it can’t fire against
+    // unmounted DOM or dispatch submenu callbacks after teardown
+    useEffect(() => clearDisclosureTimer, []);
+
+    // A parent item discloses its submenu after a short intent delay whenever
+    // it becomes (and stays) the deepest active item, for pointer and keyboard
+    // alike; submenus off the active path collapse immediately
+    const syncSubmenuDisclosure = () => {
+        if (!dropdownElement) return;
+        const activeElement = getActiveItemElement(dropdownElement);
+        collapseItemsOutsidePath(dropdownElement, activeElement, handleToggleSubmenu);
+        const submenu = activeElement ? getSubmenuOfItem(activeElement) : null;
+        if (activeElement && submenu && !isItemExpanded(activeElement)) {
+            // A timer already pending for this item keeps its original start time
+            if (pendingDisclosureItemRef.current === activeElement) return;
+            clearDisclosureTimer();
+            pendingDisclosureItemRef.current = activeElement;
+            disclosureTimerRef.current = setTimeout(() => {
+                disclosureTimerRef.current = null;
+                pendingDisclosureItemRef.current = null;
+                if (!activeElement.hasAttribute('data-ukt-active')) return;
+                expandItem(activeElement, handleToggleSubmenu);
+            }, SUBMENU_DISCLOSURE_DELAY);
+            return;
+        }
+        clearDisclosureTimer();
+    };
+
     const closeDropdown = () => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
+        clearDisclosureTimer();
         if (closingTimerRef.current != null) {
             clearTimeout(closingTimerRef.current);
             closingTimerRef.current = null;
         }
     };
 
+    const focusTrigger = () => {
+        const firstChild = dropdownElement?.firstElementChild as MaybeHTMLElement;
+        if (!firstChild) return;
+        const focusable = firstChild.matches(FOCUSABLE_SELECTOR)
+            ? firstChild
+            : (firstChild.querySelector(FOCUSABLE_SELECTOR) as MaybeHTMLElement);
+        focusable?.focus();
+    };
+
+    // Register with an enclosing Menubar (one open menu at a time, ←/→
+    // moves between menus, hover-to-switch once any menu is open). Closing
+    // goes through closeDropdown so pending timers (submenu disclosure,
+    // close delay) can’t fire against a menu the menubar already closed.
+    useEffect(() => {
+        if (!menubar || !dropdownElement) return;
+        return menubar.registerMember({
+            close: closeDropdown,
+            element: dropdownElement,
+            focusTrigger,
+            isOpen: () => isOpenRef.current,
+            open: () => setIsOpen(true),
+        });
+    });
+
+    useEffect(() => {
+        if (isOpen && menubar && dropdownElement) {
+            menubar.notifyOpened(dropdownElement);
+        }
+    }, [dropdownElement, isOpen, menubar]);
+
     const handleSubmitItem = (event: Event | React.SyntheticEvent<HTMLElement>) => {
+        const element = hasItemsRef.current
+            ? getActiveItemElement(dropdownElement)
+            : null;
+
+        const submenuOfActive = element ? getSubmenuOfItem(element) : null;
+        if (element && submenuOfActive) {
+            // Parent items disclose; they never submit
+            clearDisclosureTimer();
+            expandItem(element, handleToggleSubmenu);
+            if (currentInputMethodRef.current === 'keyboard' && dropdownElement) {
+                const firstItem = getItemElements(dropdownElement, submenuOfActive)?.[0];
+                if (firstItem) {
+                    setActiveItem({
+                        dropdownElement,
+                        element: firstItem,
+                        event,
+                        onActiveItem: handleActiveItem,
+                    });
+                }
+            }
+            return;
+        }
+
         if (isOpenRef.current && !keepOpenOnSubmitRef.current) {
             // A short timeout before closing is better UX when user selects an item so dropdown
             // doesn’t close before expected. It also enables using <Link />s in the dropdown body.
@@ -232,7 +409,6 @@ export default function Dropdown({
 
         if (!hasItemsRef.current) return;
 
-        const element = getActiveItemElement(dropdownElement);
         if (!element) {
             // With nothing selected, the only possible value comes from a text
             // input (a searchable dropdown’s input, or one inside a custom
@@ -298,12 +474,15 @@ export default function Dropdown({
             }
         }
 
-        onSubmitItemRef.current?.({
+        const payload: Item = {
             element,
             event,
             label: itemLabel,
+            path: getItemPath(element),
             value: nextValue,
-        });
+        };
+        onSubmitItemRef.current?.(payload);
+        dispatchToSubmenus('onSubmitItem', payload);
     };
 
     const handleMouseMove = ({ clientX, clientY }: ReactMouseEvent<HTMLElement>) => {
@@ -328,18 +507,28 @@ export default function Dropdown({
         // Ensure we have the dropdown root HTMLElement
         if (!dropdownElement) return;
 
-        const itemElements = getItemElements(dropdownElement);
-        if (!itemElements) return;
-
         const eventTarget = event.target as HTMLElement;
-        const item = eventTarget.closest(ITEM_SELECTOR) as MaybeHTMLElement;
-        const element = item ?? eventTarget;
-        for (const itemElement of itemElements) {
-            if (itemElement === element) {
-                setActiveItem({ dropdownElement, element, event, onActiveItem });
-                return;
-            }
+        if (!eventTarget.closest('.uktdropdown-body')) return;
+
+        // Hover inside an open nested dropdown belongs to that dropdown
+        const hoveredRoot = eventTarget.closest('.uktdropdown');
+        if (
+            hoveredRoot !== dropdownElement &&
+            hoveredRoot?.classList.contains('is-open')
+        ) {
+            return;
         }
+
+        const item = getItemForTarget(dropdownElement, eventTarget);
+        if (!item) return;
+
+        setActiveItem({
+            dropdownElement,
+            element: item,
+            event,
+            onActiveItem: handleActiveItem,
+        });
+        syncSubmenuDisclosure();
     };
 
     const handleMouseOut = (event: ReactMouseEvent<HTMLElement>) => {
@@ -352,6 +541,7 @@ export default function Dropdown({
         }
         // If user moused out of activeItem (not into a descendant), it’s no longer active
         delete activeItem.dataset.uktActive;
+        syncSubmenuDisclosure();
     };
 
     const handleMouseDown = (event: ReactMouseEvent<HTMLElement>) => {
@@ -382,8 +572,26 @@ export default function Dropdown({
         }
 
         const eventTarget = event.target as HTMLElement;
+
+        // Clicks inside an open nested dropdown belong to that dropdown
+        const clickedRoot = eventTarget.closest('.uktdropdown');
+        if (
+            clickedRoot !== dropdownElement &&
+            clickedRoot?.classList.contains('is-open') &&
+            dropdownElement?.contains(clickedRoot)
+        ) {
+            return;
+        }
+
+        // A click only counts as inside the body if the closest body element
+        // belongs to this dropdown (a nested dropdown’s trigger sits inside
+        // the outer body, but the outer body isn’t the nested one’s own)
+        const targetBody = eventTarget.closest('.uktdropdown-body');
+        const isInOwnBody = Boolean(
+            targetBody && targetBody.closest('.uktdropdown') === dropdownElement,
+        );
         // If click was outside dropdown body, don’t trigger submit
-        if (!eventTarget.closest('.uktdropdown-body')) {
+        if (!isInOwnBody) {
             // Don’t close dropdown if isOpening or search input is focused
             if (
                 !isOpeningRef.current &&
@@ -396,6 +604,29 @@ export default function Dropdown({
 
         // If dropdown has no items and click was within dropdown body, do nothing
         if (!hasItemsRef.current) return;
+
+        if (dropdownElement) {
+            const clickedItem = getItemForTarget(dropdownElement, eventTarget);
+            if (clickedItem) {
+                // Submit the item the click actually landed on: sync the
+                // active item to it in case they diverge (e.g. active was
+                // set via keyboard, then user clicked elsewhere)
+                setActiveItem({
+                    dropdownElement,
+                    element: clickedItem,
+                    event,
+                    onActiveItem: handleActiveItem,
+                });
+            } else if (getActiveItemElement(dropdownElement)) {
+                // A click that doesn’t land on an item — body padding, a
+                // separator, or a disabled item (pointer-events: none
+                // retargets its clicks to the container) — must not submit
+                // the previously active item: like macOS, it does nothing.
+                // With no active item it falls through, so a body click
+                // can still submit an input-sourced value
+                return;
+            }
+        }
 
         handleSubmitItem(event);
     };
@@ -412,6 +643,18 @@ export default function Dropdown({
         };
 
         const isEventTargetingDropdown = dropdownElement.contains(eventTarget);
+
+        // Key events originating inside an open nested dropdown are that
+        // dropdown’s business (e.g. an info popover nested in this body)
+        const nestedRoot = eventTarget.closest?.('.uktdropdown');
+        if (
+            nestedRoot &&
+            nestedRoot !== dropdownElement &&
+            dropdownElement.contains(nestedRoot) &&
+            nestedRoot.classList.contains('is-open')
+        ) {
+            return;
+        }
 
         if (!isOpenRef.current) {
             // If dropdown is closed, don’t handle key events if event target isn’t within dropdown
@@ -456,9 +699,10 @@ export default function Dropdown({
                     // If props.allowCreate, only override the input’s value with an
                     // exact text match so user can enter a value not in items
                     isExactMatch: allowCreateRef.current,
-                    onActiveItem,
+                    onActiveItem: handleActiveItem,
                     text: enteredCharactersRef.current,
                 });
+                syncSubmenuDisclosure();
 
                 if (clearEnteredCharactersTimerRef.current != null) {
                     clearTimeout(clearEnteredCharactersTimerRef.current);
@@ -487,41 +731,107 @@ export default function Dropdown({
         ) {
             // Close dropdown if hasItems or event target not using key events
             if (hasItemsRef.current || !isTargetUsingKeyEvents) {
+                // Escape closes the whole menu — submenus included — and
+                // returns focus to the element that opened it. Focus before
+                // closing: a searchable trigger input opens the dropdown on
+                // focus, so its synchronous onFocus must land before the
+                // close state update for the close to win the batch
+                focusTrigger();
                 closeDropdown();
             }
             return;
         }
 
-        // Handle ↑/↓ arrows
+        // Handle arrow keys
         if (hasItemsRef.current) {
             if (key === 'ArrowUp') {
                 onEventHandled();
                 if (altKey || metaKey) {
-                    setActiveItem({ dropdownElement, event, index: 0, onActiveItem });
+                    setActiveItem({
+                        dropdownElement,
+                        event,
+                        index: 0,
+                        onActiveItem: handleActiveItem,
+                    });
                 } else {
                     setActiveItem({
                         dropdownElement,
                         event,
                         indexAddend: -1,
-                        onActiveItem,
+                        onActiveItem: handleActiveItem,
                     });
                 }
+                syncSubmenuDisclosure();
                 return;
             }
             if (key === 'ArrowDown') {
                 onEventHandled();
                 if (altKey || metaKey) {
                     // Using a negative index counts back from the end
-                    setActiveItem({ dropdownElement, event, index: -1, onActiveItem });
+                    setActiveItem({
+                        dropdownElement,
+                        event,
+                        index: -1,
+                        onActiveItem: handleActiveItem,
+                    });
                 } else {
                     setActiveItem({
                         dropdownElement,
                         event,
                         indexAddend: 1,
-                        onActiveItem,
+                        onActiveItem: handleActiveItem,
                     });
                 }
+                syncSubmenuDisclosure();
                 return;
+            }
+            // ←/→ dive into and surface out of submenus (and move between
+            // menus in a menubar); leave them alone when a text input has focus
+            if (!isTargetUsingKeyEvents) {
+                if (key === 'ArrowRight') {
+                    const activeElement = getActiveItemElement(dropdownElement);
+                    const submenu = activeElement
+                        ? getSubmenuOfItem(activeElement)
+                        : null;
+                    if (activeElement && submenu) {
+                        onEventHandled();
+                        clearDisclosureTimer();
+                        expandItem(activeElement, handleToggleSubmenu);
+                        const firstItem = getItemElements(dropdownElement, submenu)?.[0];
+                        if (firstItem) {
+                            setActiveItem({
+                                dropdownElement,
+                                element: firstItem,
+                                event,
+                                onActiveItem: handleActiveItem,
+                            });
+                        }
+                        return;
+                    }
+                    if (menubar) {
+                        onEventHandled();
+                        menubar.moveOpen(dropdownElement, 1);
+                    }
+                    return;
+                }
+                if (key === 'ArrowLeft') {
+                    const activeElement = getActiveItemElement(dropdownElement);
+                    const levelRoot = activeElement ? getLevelRoot(activeElement) : null;
+                    if (levelRoot) {
+                        onEventHandled();
+                        clearDisclosureTimer();
+                        const parentItem = getParentItem(levelRoot);
+                        if (parentItem) {
+                            collapseItem(parentItem, handleToggleSubmenu);
+                        }
+                        return;
+                    }
+                    if (menubar) {
+                        onEventHandled();
+                        menubar.moveOpen(dropdownElement, -1);
+                    }
+                    return;
+                }
             }
         }
     };
@@ -618,7 +928,7 @@ export default function Dropdown({
                 // If props.allowCreate, only override the input’s value with an
                 // exact text match so user can enter a value not in items
                 isExactMatch: allowCreateRef.current,
-                onActiveItem,
+                onActiveItem: handleActiveItem,
                 text: enteredCharactersRef.current,
             });
         };
@@ -642,6 +952,11 @@ export default function Dropdown({
                 inputElement.removeEventListener('input', handleInput);
             }
         };
+    };
+
+    // Fill in parent-item/submenu ARIA when the body mounts (open)
+    const handleBodyRef = (ref: HTMLDivElement | null) => {
+        if (ref) annotateParentItems(ref);
     };
 
     if (!isValidElement(trigger)) {
@@ -735,12 +1050,15 @@ export default function Dropdown({
                             'has-items': hasItems,
                         })}
                         id={bodyId}
+                        ref={handleBodyRef}
                         role={popupRole}
                     >
                         <div className="uktdropdown-content">
-                            {childrenCount > 1
-                                ? (children as ChildrenTuple)[1]
-                                : children}
+                            <DropdownContext.Provider value={dropdownContextValue}>
+                                {childrenCount > 1
+                                    ? (children as ChildrenTuple)[1]
+                                    : children}
+                            </DropdownContext.Provider>
                         </div>
                     </div>
                 ) : null}
@@ -748,3 +1066,94 @@ export default function Dropdown({
         </Fragment>
     );
 }
+
+const INERT_SUBMENU_PROPS = [
+    'allowCreate',
+    'allowEmpty',
+    'isOpenOnMount',
+    'isSearchable',
+    'keepOpenOnSubmit',
+    'minHeightBody',
+    'minWidthBody',
+    'name',
+    'placeholder',
+    'tabIndex',
+    'value',
+] as const;
+
+// The nested (submenu) rendering of Dropdown: a parent item that discloses a
+// child menu. It renders the data-ukt-submenu protocol and registers with the
+// root dropdown, whose engine handles all interaction.
+function SubmenuDropdown(props: Props & { parentDropdown: DropdownContextValue }) {
+    const {
+        children,
+        className,
+        disabled,
+        label,
+        onActiveItem,
+        onClose,
+        onOpen,
+        onSubmitItem,
+        parentDropdown,
+        style,
+    } = props;
+
+    const itemRef = useRef<HTMLLIElement | null>(null);
+
+    useEffect(() => {
+        const element = itemRef.current;
+        if (!element) return;
+        return parentDropdown.registerSubmenu({
+            element,
+            onActiveItem,
+            onClose,
+            onOpen,
+            onSubmitItem,
+        });
+    }, [onActiveItem, onClose, onOpen, onSubmitItem, parentDropdown]);
+
+    // Misuse feedback is unconditional, like the children-count error above
+    const warnedRef = useRef(false);
+    useEffect(() => {
+        if (warnedRef.current) return;
+        const inertProps = INERT_SUBMENU_PROPS.filter(
+            (propName) => props[propName] !== undefined,
+        );
+        if (!inertProps.length) return;
+        warnedRef.current = true;
+        console.error(
+            `@acusti/dropdown: ${inertProps.join(', ')} only apply to a top-level Dropdown and are ignored on a nested (submenu) Dropdown.`,
+        );
+    });
+
+    const childrenCount = Children.count(children);
+    let labelContent: ReactNode = label;
+    let body: ReactNode = children;
+    if (childrenCount > 1) {
+        labelContent = (children as ChildrenTuple)[0];
+        body = (children as ChildrenTuple)[1];
+    }
+
+    const submenu = isValidElement(body) ? (
+        cloneElement(body as ReactElement<Record<string, unknown>>, {
+            'data-ukt-submenu': '',
+        })
+    ) : (
+        <div data-ukt-submenu="">{body}</div>
+    );
+
+    return (
+        <li
+            aria-disabled={disabled || undefined}
+            className={className}
+            data-ukt-item=""
+            ref={itemRef}
+            style={style}
+        >
+            {labelContent}
+            {submenu}
+        </li>
+    );
+}
+
+export { default as Menubar, type MenubarProps } from './Menubar.js';

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Dropdown, { Menubar } from './Dropdown.js';
+
+afterEach(cleanup);
+
+const renderMenubar = (props: { onSubmitItem?: (payload: unknown) => void } = {}) =>
+    render(
+        <Menubar>
+            <Dropdown onSubmitItem={props.onSubmitItem}>
+                File
+                <ul data-testid="file-menu">
+                    <li data-ukt-item>New</li>
+                    <li data-ukt-item>Open…</li>
+                </ul>
+            </Dropdown>
+            <Dropdown>
+                Edit
+                <ul data-testid="edit-menu">
+                    <li data-ukt-item>Undo</li>
+                    <li data-ukt-item>Redo</li>
+                </ul>
+            </Dropdown>
+            <Dropdown>
+                View
+                <ul data-testid="view-menu">
+                    <li data-ukt-item>Zoom In</li>
+                </ul>
+            </Dropdown>
+        </Menubar>,
+    );
+
+describe('@acusti/dropdown Menubar', () => {
+    it('renders its dropdowns inside a role="menubar" container', () => {
+        renderMenubar();
+        const menubar = screen.getByRole('menubar');
+        expect(menubar.classList.contains('uktmenubar')).toBe(true);
+        expect(screen.getByRole('button', { name: 'File' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy();
+    });
+
+    it('keeps at most one menu open at a time', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        // focusing + opening another member closes the open one
+        const viewTrigger = screen.getByRole('button', { name: 'View' });
+        act(() => viewTrigger.focus());
+        await user.keyboard('{Enter}');
+        expect(screen.getByTestId('view-menu')).toBeTruthy();
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+    });
+
+    it('closes an open menu when its trigger is clicked again (hover pre-switches, click toggles)', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        // Clicking another trigger hovers it first, which switches the open
+        // menu to it (macOS behavior); the click then toggles it closed like
+        // any click on an open menu’s trigger
+        await user.click(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+        expect(screen.queryByTestId('edit-menu')).toBe(null);
+    });
+
+    it('switches the open menu on hover without a click', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.getByTestId('edit-menu')).toBeTruthy();
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+    });
+
+    it('does not open a menu on hover when no menu is open', () => {
+        renderMenubar();
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.queryByTestId('edit-menu')).toBe(null);
+    });
+
+    it('switches the open menu when focus moves to another trigger', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        act(() => screen.getByRole('button', { name: 'Edit' }).focus());
+        expect(screen.getByTestId('edit-menu')).toBeTruthy();
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+    });
+
+    it('roves focus between triggers with ←/→ while no menu is open, wrapping at the ends', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        const fileTrigger = screen.getByRole('button', { name: 'File' });
+        const editTrigger = screen.getByRole('button', { name: 'Edit' });
+        const viewTrigger = screen.getByRole('button', { name: 'View' });
+
+        fileTrigger.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(document.activeElement).toBe(editTrigger);
+
+        await user.keyboard('{ArrowRight}');
+        expect(document.activeElement).toBe(viewTrigger);
+
+        // wraps from the last trigger back to the first
+        await user.keyboard('{ArrowRight}');
+        expect(document.activeElement).toBe(fileTrigger);
+
+        // and from the first back to the last
+        await user.keyboard('{ArrowLeft}');
+        expect(document.activeElement).toBe(viewTrigger);
+    });
+
+    it('slides the open menu to the adjacent trigger with ←/→', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        await user.keyboard('{ArrowRight}');
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+        expect(screen.getByTestId('edit-menu')).toBeTruthy();
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Edit' }));
+
+        await user.keyboard('{ArrowLeft}');
+        expect(screen.queryByTestId('edit-menu')).toBe(null);
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+    });
+
+    it('slides to the previous menu with ← wrapping to the last menu', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.keyboard('{ArrowLeft}');
+
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+        expect(screen.getByTestId('view-menu')).toBeTruthy();
+    });
+
+    it('still navigates items with ↑/↓ and submits with Enter inside the open menu', async () => {
+        const handleSubmitItem = vi.fn();
+        const user = userEvent.setup();
+        renderMenubar({ onSubmitItem: handleSubmitItem });
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.keyboard('{ArrowDown}{ArrowDown}');
+        await user.keyboard('{Enter}');
+
+        expect(handleSubmitItem).toHaveBeenCalledTimes(1);
+        expect(handleSubmitItem).toHaveBeenCalledWith(
+            expect.objectContaining({ label: 'Open…', path: [], value: 'Open…' }),
+        );
+    });
+
+    it('closes the open menu on Escape and returns focus to its trigger', async () => {
+        const user = userEvent.setup();
+        renderMenubar();
+
+        const fileTrigger = screen.getByRole('button', { name: 'File' });
+        await user.click(fileTrigger);
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        await user.keyboard('{Escape}');
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+        expect(document.activeElement).toBe(fileTrigger);
+    });
+});

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -1,0 +1,124 @@
+import clsx from 'clsx';
+import {
+    type CSSProperties,
+    type FocusEvent as ReactFocusEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type MouseEvent as ReactMouseEvent,
+    type ReactNode,
+    useMemo,
+    useRef,
+} from 'react';
+
+import {
+    MenubarContext,
+    type MenubarContextValue,
+    type MenubarMember,
+} from './context.js';
+
+export type MenubarProps = {
+    children: ReactNode;
+    className?: string;
+    style?: CSSProperties;
+};
+
+const compareDocumentOrder = (a: MenubarMember, b: MenubarMember) => {
+    if (a.element === b.element) return 0;
+    const position = a.element.compareDocumentPosition(b.element);
+    if ((position & Node.DOCUMENT_POSITION_FOLLOWING) !== 0) return -1;
+    if ((position & Node.DOCUMENT_POSITION_PRECEDING) !== 0) return 1;
+    return 0;
+};
+
+// Combines sibling Dropdowns into a single menu, like the system menu in the
+// top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
+// once any menu is open, hovering or focusing another trigger switches to it.
+export default function Menubar({ children, className, style }: MenubarProps) {
+    const membersRef = useRef<Set<MenubarMember>>(new Set());
+
+    const getOrderedMembersRef = useRef(() =>
+        Array.from(membersRef.current).sort(compareDocumentOrder),
+    );
+    const getOrderedMembers = getOrderedMembersRef.current;
+
+    const contextValue: MenubarContextValue = useMemo(
+        () => ({
+            moveOpen(fromElement: HTMLElement, direction: -1 | 1) {
+                const members = getOrderedMembersRef.current();
+                if (members.length < 2) return;
+                const index = members.findIndex(
+                    (member) => member.element === fromElement,
+                );
+                if (index === -1) return;
+                const nextIndex = (index + direction + members.length) % members.length;
+                members[index].close();
+                members[nextIndex].open();
+                members[nextIndex].focusTrigger();
+            },
+            notifyOpened(element: HTMLElement) {
+                for (const member of membersRef.current) {
+                    if (member.element !== element && member.isOpen()) {
+                        member.close();
+                    }
+                }
+            },
+            registerMember(member: MenubarMember) {
+                membersRef.current.add(member);
+                return () => {
+                    membersRef.current.delete(member);
+                };
+            },
+        }),
+        [],
+    );
+
+    // Rove focus between triggers with ←/→ while no menu is open (the open
+    // dropdown’s own key handling slides the open menu between triggers)
+    const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+        const { key } = event;
+        if (key !== 'ArrowLeft' && key !== 'ArrowRight') return;
+        const members = getOrderedMembers();
+        if (members.length < 2) return;
+        if (members.some((member) => member.isOpen())) return;
+        const eventTarget = event.target as HTMLElement;
+        const index = members.findIndex((member) => member.element.contains(eventTarget));
+        if (index === -1) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const direction = key === 'ArrowRight' ? 1 : -1;
+        members[(index + direction + members.length) % members.length].focusTrigger();
+    };
+
+    // Once any menu is open, moving hover or focus to another member’s
+    // trigger switches to it (opening notifies the menubar, which closes
+    // the other open member)
+    const switchToMemberAt = (eventTarget: HTMLElement) => {
+        const members = getOrderedMembers();
+        if (!members.some((member) => member.isOpen())) return;
+        const member = members.find((m) => m.element.contains(eventTarget));
+        if (!member || member.isOpen()) return;
+        member.open();
+    };
+
+    const handleFocus = (event: ReactFocusEvent<HTMLDivElement>) => {
+        switchToMemberAt(event.target as HTMLElement);
+    };
+
+    const handleMouseOver = (event: ReactMouseEvent<HTMLDivElement>) => {
+        switchToMemberAt(event.target as HTMLElement);
+    };
+
+    return (
+        <div
+            className={clsx('uktmenubar', className)}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyDown}
+            onMouseOver={handleMouseOver}
+            role="menubar"
+            style={style}
+        >
+            <MenubarContext.Provider value={contextValue}>
+                {children}
+            </MenubarContext.Provider>
+        </div>
+    );
+}

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -1,0 +1,35 @@
+import { createContext } from 'react';
+
+import { type Item } from './Dropdown.js';
+
+export type DropdownContextValue = {
+    registerSubmenu: (registration: SubmenuRegistration) => () => void;
+};
+
+export type SubmenuRegistration = {
+    element: HTMLElement;
+    onActiveItem?: (payload: Item) => void;
+    onClose?: () => unknown;
+    onOpen?: () => unknown;
+    onSubmitItem?: (payload: Item) => void;
+};
+
+// Provided by the root Dropdown; a Dropdown that finds this context renders
+// as a submenu (parent item + data-ukt-submenu) instead of a root dropdown.
+export const DropdownContext = createContext<DropdownContextValue | null>(null);
+
+export type MenubarContextValue = {
+    moveOpen: (fromElement: HTMLElement, direction: -1 | 1) => void;
+    notifyOpened: (element: HTMLElement) => void;
+    registerMember: (member: MenubarMember) => () => void;
+};
+
+export type MenubarMember = {
+    close: () => void;
+    element: HTMLElement;
+    focusTrigger: () => void;
+    isOpen: () => boolean;
+    open: () => void;
+};
+
+export const MenubarContext = createContext<MenubarContextValue | null>(null);

--- a/packages/dropdown/src/helpers.test.ts
+++ b/packages/dropdown/src/helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPointInTriangle, type Point } from './helpers.js';
+
+describe('isPointInTriangle', () => {
+    // A right triangle: apex on the left, near edge (base) vertical on the right,
+    // like a submenu opening to the inline-end of its parent item
+    const apex: Point = { x: 0, y: 5 };
+    const nearTop: Point = { x: 10, y: 0 };
+    const nearBottom: Point = { x: 10, y: 10 };
+
+    it('includes points inside the triangle', () => {
+        expect(isPointInTriangle({ x: 5, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+        expect(isPointInTriangle({ x: 8, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+    });
+
+    it('includes the vertices and edges', () => {
+        expect(isPointInTriangle(apex, apex, nearTop, nearBottom)).toBe(true);
+        expect(isPointInTriangle(nearTop, apex, nearTop, nearBottom)).toBe(true);
+        // Midpoint of the near (base) edge
+        expect(isPointInTriangle({ x: 10, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+    });
+
+    it('excludes points outside the triangle', () => {
+        // Beyond the near edge (past the submenu edge)
+        expect(isPointInTriangle({ x: 12, y: 5 }, apex, nearTop, nearBottom)).toBe(false);
+        // Straight up from the apex — a sibling above the parent, not toward the
+        // submenu
+        expect(isPointInTriangle({ x: 0, y: 0 }, apex, nearTop, nearBottom)).toBe(false);
+        // Straight down from the apex — a sibling below the parent
+        expect(isPointInTriangle({ x: 3, y: 9 }, apex, nearTop, nearBottom)).toBe(false);
+        // Behind the apex
+        expect(isPointInTriangle({ x: -5, y: 5 }, apex, nearTop, nearBottom)).toBe(false);
+    });
+
+    it('is orientation-independent (works for a mirror triangle opening left)', () => {
+        const rightApex: Point = { x: 10, y: 5 };
+        const leftTop: Point = { x: 0, y: 0 };
+        const leftBottom: Point = { x: 0, y: 10 };
+        expect(isPointInTriangle({ x: 5, y: 5 }, rightApex, leftTop, leftBottom)).toBe(
+            true,
+        );
+        expect(isPointInTriangle({ x: -2, y: 5 }, rightApex, leftTop, leftBottom)).toBe(
+            false,
+        );
+    });
+});

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -129,6 +129,20 @@ export const getActiveItemElement = (dropdownElement: MaybeHTMLElement) => {
     return actives ? actives[actives.length - 1] : null;
 };
 
+// The deepest expanded parent item — the one whose submenu is the innermost
+// open one — in document order
+export const getDeepestExpandedItem = (
+    dropdownElement: MaybeHTMLElement,
+): MaybeHTMLElement => {
+    if (!dropdownElement) return null;
+    const expanded = (
+        Array.from(
+            dropdownElement.querySelectorAll('[aria-expanded="true"]'),
+        ) as Array<HTMLElement>
+    ).filter((element) => element.matches(ITEM_SELECTOR));
+    return expanded.length ? expanded[expanded.length - 1] : null;
+};
+
 export const isItemExpanded = (item: HTMLElement) =>
     item.getAttribute('aria-expanded') === 'true';
 
@@ -376,4 +390,19 @@ export const setActiveItem = ({
     }
 
     return nextActiveItem;
+};
+
+export type Point = { x: number; y: number };
+
+// Whether a point is inside (or on an edge of) triangle a-b-c, from the sign
+// of the cross product for each edge: all the same sign ⇒ inside
+export const isPointInTriangle = (p: Point, a: Point, b: Point, c: Point): boolean => {
+    const cross = (u: Point, v: Point, w: Point) =>
+        (u.x - w.x) * (v.y - w.y) - (v.x - w.x) * (u.y - w.y);
+    const d1 = cross(p, a, b);
+    const d2 = cross(p, b, c);
+    const d3 = cross(p, c, a);
+    const hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+    const hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+    return !(hasNegative && hasPositive);
 };

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -3,35 +3,206 @@ import { type SyntheticEvent } from 'react';
 
 import { type Item } from './Dropdown.js';
 
-export const ITEM_SELECTOR = `[data-ukt-item], [data-ukt-value]`;
+export const ITEM_SELECTOR = '[data-ukt-item], [data-ukt-value]';
+export const SUBMENU_SELECTOR = '[data-ukt-submenu]';
 
-export const getItemElements = (dropdownElement: HTMLElement | null) => {
-    if (!dropdownElement) return null;
+const DISABLED_ITEM_SELECTOR = '[aria-disabled="true"]';
 
-    const bodyElement = dropdownElement.querySelector('.uktdropdown-body');
+export type OnToggleSubmenu = (item: HTMLElement, isExpanded: boolean) => void;
+
+type MaybeHTMLElement = HTMLElement | null;
+
+const getBodyElement = (dropdownElement: MaybeHTMLElement) =>
+    (dropdownElement?.querySelector('.uktdropdown-body') ?? null) as MaybeHTMLElement;
+
+// The level root that owns an item: the closest [data-ukt-submenu] ancestor,
+// or null for items at the top level of the dropdown body
+export const getLevelRoot = (element: HTMLElement) =>
+    element.closest(SUBMENU_SELECTOR) as MaybeHTMLElement;
+
+// An item’s own submenu (a parent item), excluding submenus of descendant items
+export const getSubmenuOfItem = (item: HTMLElement): MaybeHTMLElement => {
+    const submenu = item.querySelector(SUBMENU_SELECTOR) as MaybeHTMLElement;
+    if (!submenu) return null;
+    const owner = submenu.parentElement?.closest(ITEM_SELECTOR);
+    return owner === item ? submenu : null;
+};
+
+// The parent item that owns a submenu level
+export const getParentItem = (levelRoot: HTMLElement) =>
+    (levelRoot.parentElement?.closest(ITEM_SELECTOR) ?? null) as MaybeHTMLElement;
+
+// A parent item’s label is its text content excluding the submenu subtree
+export const getItemLabel = (item: HTMLElement): string => {
+    if (!getSubmenuOfItem(item)) return item.innerText ?? '';
+    const clone = item.cloneNode(true) as HTMLElement;
+    for (const submenu of Array.from(clone.querySelectorAll(SUBMENU_SELECTOR))) {
+        submenu.remove();
+    }
+    return (clone.textContent ?? '').trim();
+};
+
+// Ancestor parent items from the root level down to the element’s immediate parent
+export const getItemPath = (element: MaybeHTMLElement): Item['path'] => {
+    const path: Item['path'] = [];
+    if (!element) return path;
+    let levelRoot = getLevelRoot(element);
+    while (levelRoot) {
+        const parentItem = getParentItem(levelRoot);
+        if (!parentItem) break;
+        const label = getItemLabel(parentItem);
+        path.unshift({ label, value: parentItem.dataset.uktValue ?? label });
+        levelRoot = getLevelRoot(parentItem);
+    }
+    return path;
+};
+
+export const getItemElements = (
+    dropdownElement: MaybeHTMLElement,
+    levelRoot?: MaybeHTMLElement,
+): Array<HTMLElement> | null => {
+    const bodyElement = getBodyElement(dropdownElement);
     if (!bodyElement) return null;
 
-    let items: HTMLCollection | NodeListOf<Element> =
-        bodyElement.querySelectorAll(ITEM_SELECTOR);
+    const root = levelRoot ?? bodyElement;
+    const candidates = Array.from(
+        root.querySelectorAll(ITEM_SELECTOR),
+    ) as Array<HTMLElement>;
 
-    if (items.length) return items;
+    if (candidates.length) {
+        return candidates.filter((item) => {
+            if (item.matches(DISABLED_ITEM_SELECTOR)) return false;
+            return getLevelRoot(item) === (levelRoot ?? null);
+        });
+    }
+
     // If no items found via [data-ukt-item] or [data-ukt-value] selector,
-    // use first instance of multiple children found
-    items = bodyElement.children;
+    // use first instance of multiple children found — flat bodies and flat
+    // submenu levels alike
+    let items: HTMLCollection = root.children;
     while (items.length === 1) {
         if (items[0].children == null) break;
         items = items[0].children;
     }
     // If unable to find an element with more than one child, treat direct child as items
     if (items.length === 1) {
-        items = bodyElement.children;
+        items = root.children;
     }
-    return items;
+    return (Array.from(items) as Array<HTMLElement>).filter(
+        (item) => !item.matches(DISABLED_ITEM_SELECTOR),
+    );
 };
 
-export const getActiveItemElement = (dropdownElement: HTMLElement | null) => {
+// The item an event target belongs to within its own level: the closest
+// marked item, or — when the target sits in a level with no marked items
+// (a heuristically-detected level) — the target itself if it’s one of that
+// level’s detected items. Misses (body padding, separators) and disabled
+// items resolve to null.
+export const getItemForTarget = (
+    dropdownElement: HTMLElement,
+    target: HTMLElement,
+): MaybeHTMLElement => {
+    let item = target.closest(ITEM_SELECTOR) as MaybeHTMLElement;
+    // If nothing matched, or the target sits in a deeper level than the
+    // matched item (an unmarked, heuristically-detected submenu level),
+    // resolve the item within the target’s own level instead
+    const targetLevelRoot = getLevelRoot(target);
+    if (!item || (targetLevelRoot && item.contains(targetLevelRoot))) {
+        const itemElements = getItemElements(dropdownElement, targetLevelRoot);
+        item = itemElements?.find((itemElement) => itemElement === target) ?? item;
+    }
+    if (!item || !dropdownElement.contains(item)) return null;
+    if (item.matches(DISABLED_ITEM_SELECTOR)) return null;
+    return item;
+};
+
+// All active items, in document order (ancestors before descendants)
+export const getActiveItemElements = (dropdownElement: MaybeHTMLElement) => {
     if (!dropdownElement) return null;
-    return dropdownElement.querySelector('[data-ukt-active]') as HTMLElement | null;
+    const actives = dropdownElement.querySelectorAll('[data-ukt-active]');
+    return actives.length ? (Array.from(actives) as Array<HTMLElement>) : null;
+};
+
+// The deepest active item — the one keyboard input operates on
+export const getActiveItemElement = (dropdownElement: MaybeHTMLElement) => {
+    const actives = getActiveItemElements(dropdownElement);
+    return actives ? actives[actives.length - 1] : null;
+};
+
+export const isItemExpanded = (item: HTMLElement) =>
+    item.getAttribute('aria-expanded') === 'true';
+
+let submenuIdCounter = 0;
+
+const ensureSubmenuAria = (item: HTMLElement, submenu: HTMLElement) => {
+    if (!submenu.hasAttribute('role')) submenu.setAttribute('role', 'menu');
+    if (!submenu.id) submenu.id = `uktdd-submenu-${++submenuIdCounter}`;
+    if (!item.hasAttribute('aria-haspopup')) item.setAttribute('aria-haspopup', 'menu');
+    if (!item.hasAttribute('aria-expanded')) item.setAttribute('aria-expanded', 'false');
+    if (!item.hasAttribute('aria-controls')) {
+        item.setAttribute('aria-controls', submenu.id);
+    }
+};
+
+// Fill in submenu/parent-item ARIA (only what the consumer hasn’t set)
+export const annotateParentItems = (bodyElement: MaybeHTMLElement) => {
+    if (!bodyElement) return;
+    for (const submenu of Array.from(bodyElement.querySelectorAll(SUBMENU_SELECTOR))) {
+        const item = getParentItem(submenu as HTMLElement);
+        if (item) ensureSubmenuAria(item, submenu as HTMLElement);
+    }
+};
+
+export const expandItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmenu) => {
+    const submenu = getSubmenuOfItem(item);
+    if (!submenu) return;
+    ensureSubmenuAria(item, submenu);
+    if (isItemExpanded(item)) return;
+    item.setAttribute('aria-expanded', 'true');
+    onToggleSubmenu?.(item, true);
+};
+
+export const collapseItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmenu) => {
+    if (!isItemExpanded(item)) return;
+    const submenu = getSubmenuOfItem(item);
+    if (submenu) {
+        // Collapse any expanded descendants first so their state can’t leak
+        // into the next disclosure and their onClose callbacks fire
+        // (recursion makes the collapse order deepest-first)
+        const expandedDescendants = (
+            Array.from(
+                submenu.querySelectorAll('[aria-expanded="true"]'),
+            ) as Array<HTMLElement>
+        ).filter((descendant) => descendant.matches(ITEM_SELECTOR));
+        for (const descendant of expandedDescendants) {
+            collapseItem(descendant, onToggleSubmenu);
+        }
+        for (const active of Array.from(submenu.querySelectorAll('[data-ukt-active]'))) {
+            delete (active as HTMLElement).dataset.uktActive;
+        }
+    }
+    item.setAttribute('aria-expanded', 'false');
+    onToggleSubmenu?.(item, false);
+};
+
+// Collapse every expanded parent item that isn’t an ancestor of element
+// (element == null collapses all), deepest-first
+export const collapseItemsOutsidePath = (
+    dropdownElement: MaybeHTMLElement,
+    element: MaybeHTMLElement,
+    onToggleSubmenu?: OnToggleSubmenu,
+) => {
+    const bodyElement = getBodyElement(dropdownElement);
+    if (!bodyElement) return;
+    const expandedItems = (
+        Array.from(
+            bodyElement.querySelectorAll('[aria-expanded="true"]'),
+        ) as Array<HTMLElement>
+    ).filter((item) => item.matches(ITEM_SELECTOR));
+    for (const item of expandedItems.reverse()) {
+        if (element && item.contains(element)) continue;
+        collapseItem(item, onToggleSubmenu);
+    }
 };
 
 const clearItemElementsState = (itemElements: Array<HTMLElement>) => {
@@ -39,7 +210,31 @@ const clearItemElementsState = (itemElements: Array<HTMLElement>) => {
         if (itemElement.hasAttribute('data-ukt-active')) {
             delete itemElement.dataset.uktActive;
         }
+        // Also clear active state in any deeper levels within this item
+        for (const active of Array.from(
+            itemElement.querySelectorAll('[data-ukt-active]'),
+        )) {
+            delete (active as HTMLElement).dataset.uktActive;
+        }
     });
+};
+
+// Make the active set exactly the chain of element + its ancestor parent items
+const setActiveChain = (dropdownElement: HTMLElement, element: HTMLElement) => {
+    const chain = new Set<HTMLElement>([element]);
+    let levelRoot = getLevelRoot(element);
+    while (levelRoot) {
+        const parentItem = getParentItem(levelRoot);
+        if (!parentItem) break;
+        chain.add(parentItem);
+        levelRoot = getLevelRoot(parentItem);
+    }
+    for (const active of getActiveItemElements(dropdownElement) ?? []) {
+        if (!chain.has(active)) delete active.dataset.uktActive;
+    }
+    for (const item of chain) {
+        item.setAttribute('data-ukt-active', '');
+    }
 };
 
 type BaseSetActiveItemPayload = {
@@ -75,16 +270,22 @@ export const setActiveItem = ({
     | ({
           isExactMatch?: boolean;
           text: string;
-      } & Omit<BaseSetActiveItemPayload, 'isExactMatch' | 'text'>)) => {
-    const items = getItemElements(dropdownElement);
-    if (!items) return;
+      } & Omit<BaseSetActiveItemPayload, 'isExactMatch' | 'text'>)): MaybeHTMLElement => {
+    const currentDeepest = getActiveItemElement(dropdownElement);
+    // Keys and text operate on the current level (the level of the deepest
+    // active item); activating an element directly targets its own level
+    const levelRoot = element
+        ? getLevelRoot(element)
+        : currentDeepest
+          ? getLevelRoot(currentDeepest)
+          : null;
 
-    const itemElements = Array.from(items) as Array<HTMLElement>;
-    if (!itemElements.length) return;
+    const itemElements = getItemElements(dropdownElement, levelRoot);
+    if (!itemElements || itemElements.length === 0) return currentDeepest;
 
     const lastIndex = itemElements.length - 1;
-    const currentActiveIndex = itemElements.findIndex((itemElement) =>
-        itemElement.hasAttribute('data-ukt-active'),
+    const currentActiveIndex = itemElements.findIndex(
+        (itemElement) => itemElement === currentDeepest,
     );
 
     let nextActiveIndex = currentActiveIndex;
@@ -97,6 +298,7 @@ export const setActiveItem = ({
         nextActiveIndex = itemElements.findIndex(
             (itemElement) => itemElement === element,
         );
+        if (nextActiveIndex === -1) return currentDeepest;
     } else if (typeof indexAddend === 'number') {
         // If there’s no currentActiveIndex and we are handling -1, start at lastIndex
         if (currentActiveIndex === -1 && indexAddend === -1) {
@@ -110,10 +312,10 @@ export const setActiveItem = ({
         // If text is empty, clear existing active items and early return
         if (!text) {
             clearItemElementsState(itemElements);
-            return;
+            return null;
         }
 
-        const itemTexts = itemElements.map((itemElement) => itemElement.innerText);
+        const itemTexts = itemElements.map(getItemLabel);
         if (isExactMatch) {
             const textToCompare = text.toLowerCase();
             nextActiveIndex = itemTexts.findIndex((itemText) =>
@@ -129,15 +331,21 @@ export const setActiveItem = ({
         }
     }
 
-    const nextActiveItem = items[nextActiveIndex] as HTMLElement | null;
-    if (nextActiveItem == null || nextActiveIndex === currentActiveIndex) return;
+    const nextActiveItem = itemElements[nextActiveIndex] as MaybeHTMLElement;
+    if (nextActiveItem == null || nextActiveItem === currentDeepest) {
+        return currentDeepest;
+    }
 
-    // Clear any existing active dropdown body item state
-    clearItemElementsState(itemElements);
-    nextActiveItem.setAttribute('data-ukt-active', '');
-    const label = nextActiveItem.innerText;
+    setActiveChain(dropdownElement, nextActiveItem);
+    const label = getItemLabel(nextActiveItem);
     const value = nextActiveItem.dataset.uktValue ?? label;
-    onActiveItem?.({ element: nextActiveItem, event, label, value });
+    onActiveItem?.({
+        element: nextActiveItem,
+        event,
+        label,
+        path: getItemPath(nextActiveItem),
+        value,
+    });
     // Find closest scrollable parent and ensure that next active item is visible
     let { parentElement } = nextActiveItem;
     let scrollableParent = null;
@@ -166,4 +374,6 @@ export const setActiveItem = ({
             scrollableParent.scrollTop = scrollTop;
         }
     }
+
+    return nextActiveItem;
 };


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #377.** This PR targets the docs branch and implements the API specified there. Review #377 for the API design; review this PR for the implementation. They should merge together (this one into #377, or #377 first and then this one retargeted to `main`).

## Summary

Implements nested submenus and the `Menubar` component exactly as documented in the README on the base branch: dropdowns compose — nest a `Dropdown` inside another dropdown's body for a submenu, wrap sibling dropdowns in `Menubar` for a macOS-style menu bar. A nested `Dropdown` with `hasItems={false}` isn't a menu, so it composes the other way: an independent anchored dropdown inside the outer body (e.g. an ℹ️ info popover next to an input in a form dropdown).

## Implementation

- **`helpers.ts` — level-scoped item engine.** An item belongs to the level of its closest `data-ukt-submenu` ancestor; the flat-body item-detection heuristic applies per level, to any level root with no marked items. Active state is an *active path*: one `data-ukt-active` item per open level, ancestors staying active while the highlight is deeper. `setActiveItem` derives the current level internally, so ↑/↓, typeahead, and first/last-jump scope correctly without call-site changes. Also: parent-item label extraction (text excluding the submenu subtree), `Item.path` computation, `aria-expanded`-backed expand/collapse (collapsing a parent also collapses its expanded descendants, deepest-first), automatic parent-item/submenu ARIA that only fills in what the consumer hasn't set, and `aria-disabled` items excluded from navigation in both the marked-item and flat-body paths.
- **`Dropdown.tsx` — the interaction model.** Keys operate on the level of the deepest highlighted item. → dives (expand + highlight first item), ← surfaces, Enter/Space on a parent item discloses instead of submitting, Escape closes the whole menu and returns focus to the trigger (focusing before the close state update so a searchable trigger's open-on-focus can't win the batch and reopen). Pausing on a parent item — pointer *or* arrow keys — discloses its submenu after a 200ms intent delay (tuned to macOS: quick, natural arrowing never flashes submenus) with the highlight staying on the parent; arrowing or mousing quickly past never flashes submenus open; submenus off the active path collapse immediately; the pending disclosure timer is cleared on unmount. `onSubmitItem` fires only for leaf items, with the leaf's ancestor `path` in the payload. Mouseup submits the item the click actually landed on (hover and click share one level-aware `getItemForTarget` resolution, which also owns the disabled-item check), syncing the active item to it when they diverge; a click on padding, a separator, or a disabled item while something is active is a no-op like macOS, while a body click with nothing active still falls through to the input-sourced-value path for searchable dropdowns.
- **Nested `Dropdown` via context.** A `Dropdown` that finds a parent Dropdown context renders the `data-ukt-submenu` protocol (`<li>{label}…`) instead of a root dropdown, registering scoped `onActiveItem`/`onOpen`/`onClose`/`onSubmitItem` callbacks with the root engine. `disabled` disables the parent item (excluded from navigation); top-level-only props warn unconditionally, matching the package's existing children-count misuse error.
- **Nested non-menu dropdowns.** A nested `Dropdown` with `hasItems={false}` renders as an independent anchored dropdown instead of a parent item. The outer dropdown respects the nested one's territory: hover, click, and key events inside an *open* nested dropdown are deferred to it; click handling is scoped by body ownership, so interacting with the popover never closes or submits the outer dropdown (and clicking the nested trigger toggles the nested dropdown rather than counting as an outer body click); Escape closes the innermost open dropdown first, and a second Escape closes the outer one.
- **`Menubar`** — new named export: `role="menubar"`, at most one menu open, hover- and focus-to-switch once any menu is open, ←/→ roving focus between triggers while closed and sliding the open menu while open, wrapping at the ends. The open menu's trigger gets an active-state background (new `--uktdd-menubar-trigger-bg-color-active`, tinting over the trigger's own background) so it reads as selected like the highlighted item in the macOS menu bar.
- **`Dropdown.css`** — submenu visibility driven by `aria-expanded`; submenus anchor-positioned off the expanded parent item (`anchor-scope` binds each level's submenu to its own parent), opening at inline-end with an inline-start fallback via new `--uktdd-submenu-*` custom properties; two-tier active-path highlight via `:has()` (muted while a deeper highlight exists *or* the pointer is inside the open submenu, matching macOS) with `--uktdd-body-bg-color-path`/`--uktdd-body-color-path`; parent items render a macOS-style disclosure chevron (CSS-drawn on `::after`, `currentColor`, RTL-aware); submenu bodies get an explicit text color via the new `--uktdd-body-color` custom property (default `canvastext`) so an active parent's white highlight color can't inherit into its submenu's items; the `--uktdd-body-translate` default changed from `0 0` to the rendering-identical `none` because any other value makes the body a containing block for its fixed-position submenus, constraining and clipping them (`--uktdd-submenu-translate` defaults to `none` for the same reason, one level down); menubar active-trigger tint, disabled-item, and `.uktmenubar` styles. Verified in-browser via Storybook + Playwright: submenus open at the parent item's inline-end, top-aligned, unclipped by the body, with legible items in all hover/keyboard states across three nesting levels, the chevron rendering, and the menubar active tint following the open menu.

## Bundle size

Impact on the code that ships to the browser (the package's contribution to a consumer bundle — inlined CSS included, `react`/`clsx`/`@acusti/*` external as usual). Measured at the current head, including all review-round fixes, the nested non-menu dropdown support, and the submenu positioning/chevron/menubar-active CSS:

| Consumer | minified | min+gzip | Δ gzip vs main |
| --- | --- | --- | --- |
| `main` (before) | 13.5 kB | 5.3 kB | — |
| This PR, `Dropdown` only (Menubar tree-shaken) | 24.1 kB | 8.6 kB | **+3.3 kB** |
| This PR, `Dropdown` + `Menubar` | 26.2 kB | 9.2 kB | **+3.9 kB** |

- **`Menubar` tree-shakes**: a consumer importing only the default `Dropdown` export doesn't pay for it (verified with an esbuild `--bundle --minify` pass over an entry that imports only the default export — the only `menubar` occurrence left is the `.uktmenubar` rules in the inlined stylesheet).
- The +3.3 kB gzip for Dropdown-only consumers is the submenu engine itself (level-scoped item resolution, active-path state, intent-delay disclosure, ARIA generation, nested-dropdown territory scoping) plus the new submenu CSS in the inlined stylesheet — it's carried by all consumers since the engine is integral to `Dropdown`.
- Methodology: `vite build` per branch, then `esbuild --bundle --minify` + `gzip -9` on the output; tree-shake check via esbuild bundle of a default-export-only entry.

## Testing

- 36 new tests (66 total in the package): level-scoped navigation, dive/surface (including descendant submenu collapse when surfacing), intent-delay disclosure (including no-flash on quick pass-by), parent-items-never-submit, `Item.path`, scoped nested callbacks, disabled items in both marked and flat bodies, ARIA generation, Escape close-all + focus restore (including staying closed when focus restore targets a searchable trigger input), heuristic (unmarked) submenu bodies, clicked-item submission (clicked item wins over a divergent keyboard-active item; separator/disabled clicks never submit), Menubar one-at-a-time/roving/sliding/hover- and focus-switch behavior, and nested non-menu dropdowns (popover opens without closing or submitting the outer dropdown, nested trigger re-click toggles only the popover, Escape closes innermost-first then the outer on a second press).
- One test documented an emergent macOS-faithful behavior: clicking a second menubar trigger hovers it first, so hover-to-switch opens its menu before the click — which then toggles it closed, exactly like clicking an open menu's title on macOS.
- Browser verification via Storybook + Playwright (happy-dom can't exercise CSS anchor positioning): submenu geometry, clipping, active-path colors, the disclosure chevron, and the menubar active-trigger tint (following the open menu on hover-switch) across all three stories.
- Full monorepo validation passes: build, tests, lint, tsc, format.

## Notes for review

- The default CSS shows a submenu that is a **direct child** of its expanded parent item; the engine tolerates deeper descendants but the README's "descendant" wording could be tightened to recommend direct-child placement (one-line docs tweak on the base branch).
- Three new Storybook stories (`SubmenuDropdown`, `MenubarAppMenu`, `NestedInfoPopover`) and a minor changeset for `@acusti/dropdown` are included; the changeset also records the `group` prop removal from #377 and the `--uktdd-body-translate` default change. The menubar story's trigger buttons drop their border-radius in story-only CSS.
- Copilot review feedback was addressed and folded into the feature commit per the AGENTS.md commit guidance; see the review threads for dispositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usz1o3ztrzypEwResn7s6e