### PR TITLE
Keep submenus open when the pointer cuts diagonally toward them

### DIFF
--- a/.changeset/submenu-mouse-intent.md
+++ b/.changeset/submenu-mouse-intent.md
@@ -1,0 +1,18 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add mouse-intent (safe-area) tracking so submenus don't close when the
+pointer cuts diagonally toward them
+
+When a submenu is open and the pointer moves diagonally from the parent
+item toward the submenu, its path often crosses sibling items in the parent
+menu. Previously that collapsed the submenu the instant the pointer touched
+a sibling. Now the dropdown tracks the triangle from where the pointer left
+the parent item to the open submenu's two near corners (the macOS
+"diagonal" behavior): while the pointer stays inside that triangle it's
+heading toward the submenu, so the submenu stays open even over sibling
+items. A pause inside the triangle (rather than continued motion) gives up
+and switches to the item under the pointer, and a direct move onto a
+sibling (outside the triangle) switches immediately as before.
+Pointer-only; keyboard navigation is unaffected.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -548,6 +548,11 @@ Submenu semantics:
   [Keyboard Navigation](#keyboard-navigation--accessibility).
 - A parent item’s open state is carried by its `aria-expanded` attribute,
   which is also the styling hook for submenu visibility.
+- With the pointer, an open submenu tracks mouse intent: moving diagonally
+  from the parent item toward the submenu keeps it open even as the pointer
+  crosses sibling items along the way (the macOS “safe triangle” between
+  the pointer and the submenu’s near edge). Moving straight onto a sibling
+  — or pausing mid-diagonal — switches to that item as usual.
 
 ### The `data-ukt-submenu` protocol
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -34,6 +34,7 @@ import {
     collapseItemsOutsidePath,
     expandItem,
     getActiveItemElement,
+    getDeepestExpandedItem,
     getItemElements,
     getItemForTarget,
     getItemPath,
@@ -41,6 +42,8 @@ import {
     getParentItem,
     getSubmenuOfItem,
     isItemExpanded,
+    isPointInTriangle,
+    type Point,
     setActiveItem,
 } from './helpers.js';
 
@@ -141,6 +144,11 @@ const TEXT_INPUT_SELECTOR =
 // puts its delay around 200–250ms; anything much shorter flashes
 const SUBMENU_DISCLOSURE_DELAY = 200;
 
+// How long the pointer can dwell inside the safe area (heading toward an open
+// submenu) before we give up and switch to whatever it’s actually over. Reset
+// on every move, so it only fires on a pause — motion keeps the submenu open
+const SAFE_AREA_TIMEOUT = 300;
+
 export default function Dropdown(props: Props) {
     const parentDropdown = useContext(DropdownContext);
     // A Dropdown nested inside another dropdown’s body is a submenu: it
@@ -209,6 +217,11 @@ function RootDropdown({
     const disclosureTimerRef = useRef<null | TimeoutID>(null);
     const pendingDisclosureItemRef = useRef<MaybeHTMLElement>(null);
     const submenuRegistrationsRef = useRef<Set<SubmenuRegistration>>(new Set());
+    const pointerRef = useRef<Point | null>(null);
+    const lastMouseEventRef = useRef<MouseEvent | null>(null);
+    const safeAreaRef = useRef<{ apex: Point; parent: HTMLElement } | null>(null);
+    const safeAreaTimerRef = useRef<null | TimeoutID>(null);
+    const wasInSafeAreaRef = useRef<boolean>(false);
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
@@ -336,11 +349,126 @@ function RootDropdown({
         clearDisclosureTimer();
     };
 
+    const clearSafeAreaTimer = () => {
+        if (safeAreaTimerRef.current != null) {
+            clearTimeout(safeAreaTimerRef.current);
+            safeAreaTimerRef.current = null;
+        }
+    };
+
+    // Clear the safe-area give-up timer on unmount so it can’t fire against
+    // unmounted DOM
+    useEffect(() => clearSafeAreaTimer, []);
+
+    // The safe area is the triangle from where the pointer last sat on the
+    // open submenu’s parent (the apex) to that submenu’s two near corners.
+    // While the pointer is inside it, it’s traveling toward the submenu, so the
+    // submenu stays open even as the pointer crosses sibling items — the macOS
+    // diagonal behavior
+    const isPointerInSafeArea = (x: number, y: number): boolean => {
+        const safeArea = safeAreaRef.current;
+        if (!safeArea || !isItemExpanded(safeArea.parent)) return false;
+        const submenu = getSubmenuOfItem(safeArea.parent);
+        if (!submenu) return false;
+        const submenuRect = submenu.getBoundingClientRect();
+        const parentRect = safeArea.parent.getBoundingClientRect();
+        // Submenus can open to either side; the near edge is the one facing
+        // the parent item
+        const nearX =
+            submenuRect.left >= parentRect.right - 1
+                ? submenuRect.left
+                : submenuRect.right;
+        return isPointInTriangle(
+            { x, y },
+            safeArea.apex,
+            { x: nearX, y: submenuRect.top },
+            { x: nearX, y: submenuRect.bottom },
+        );
+    };
+
+    // The pointer left the safe area (or paused in it without reaching the
+    // submenu): stop protecting the submenu and switch to whatever the pointer
+    // is over now. Passing the target avoids an elementFromPoint read; the
+    // give-up timer has no event, so it falls back to hit-testing the pointer
+    const commitPointerTarget = (targetElement?: MaybeHTMLElement) => {
+        clearSafeAreaTimer();
+        safeAreaRef.current = null;
+        wasInSafeAreaRef.current = false;
+        const pointer = pointerRef.current;
+        const target =
+            targetElement ??
+            (pointer
+                ? (dropdownElement?.ownerDocument.elementFromPoint(
+                      pointer.x,
+                      pointer.y,
+                  ) as MaybeHTMLElement)
+                : null);
+        if (!dropdownElement || !target || !dropdownElement.contains(target)) return;
+        const item = getItemForTarget(dropdownElement, target);
+        const event = lastMouseEventRef.current;
+        // Only reachable via mouse events, so a real mouse event is on hand
+        if (item && event) {
+            setActiveItem({
+                dropdownElement,
+                element: item,
+                event,
+                onActiveItem: handleActiveItem,
+            });
+        }
+        syncSubmenuDisclosure();
+    };
+
+    // Track the pointer against the open submenu’s safe area: anchor the apex
+    // while over the parent item, and (re)arm the give-up timer while traveling
+    // toward the submenu so only a pause — not motion — ends the protection
+    const trackSafeArea = (event: ReactMouseEvent<HTMLElement>) => {
+        // Safe-area intent only applies to an open menu with items; skip the
+        // per-move DOM query otherwise (mousemove is a hot path)
+        if (!dropdownElement || !isOpenRef.current || !hasItemsRef.current) return;
+        const pointer = { x: event.clientX, y: event.clientY };
+        pointerRef.current = pointer;
+        lastMouseEventRef.current = event.nativeEvent;
+        const parent = getDeepestExpandedItem(dropdownElement);
+        if (!parent) {
+            safeAreaRef.current = null;
+            wasInSafeAreaRef.current = false;
+            clearSafeAreaTimer();
+            return;
+        }
+        const target = event.target as HTMLElement;
+        const submenu = getSubmenuOfItem(parent);
+        const isOverParent =
+            parent.contains(target) && !(submenu?.contains(target) ?? false);
+        if (isOverParent) {
+            safeAreaRef.current = { apex: pointer, parent };
+            wasInSafeAreaRef.current = false;
+            clearSafeAreaTimer();
+            return;
+        }
+        // A newly-open submenu we haven’t anchored an apex for yet
+        if (safeAreaRef.current?.parent !== parent) {
+            safeAreaRef.current = null;
+        }
+        clearSafeAreaTimer();
+        if (isPointerInSafeArea(pointer.x, pointer.y)) {
+            wasInSafeAreaRef.current = true;
+            safeAreaTimerRef.current = setTimeout(commitPointerTarget, SAFE_AREA_TIMEOUT);
+        } else if (wasInSafeAreaRef.current) {
+            // Just crossed out of the triangle. The pointer may still be over
+            // the same sibling it entered while protected, so no mouseover will
+            // fire — re-evaluate and activate whatever it’s on now
+            commitPointerTarget(target);
+        }
+    };
+
     const closeDropdown = () => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
         clearDisclosureTimer();
+        clearSafeAreaTimer();
+        safeAreaRef.current = null;
+        wasInSafeAreaRef.current = false;
         if (closingTimerRef.current != null) {
             clearTimeout(closingTimerRef.current);
             closingTimerRef.current = null;
@@ -485,8 +613,10 @@ function RootDropdown({
         dispatchToSubmenus('onSubmitItem', payload);
     };
 
-    const handleMouseMove = ({ clientX, clientY }: ReactMouseEvent<HTMLElement>) => {
+    const handleMouseMove = (event: ReactMouseEvent<HTMLElement>) => {
+        const { clientX, clientY } = event;
         currentInputMethodRef.current = 'mouse';
+        trackSafeArea(event);
         const initialPosition = mouseDownPositionRef.current;
         if (!initialPosition) return;
         if (
@@ -519,6 +649,9 @@ function RootDropdown({
             return;
         }
 
+        // Heading toward an open submenu: keep it open even over sibling items
+        if (isPointerInSafeArea(event.clientX, event.clientY)) return;
+
         const item = getItemForTarget(dropdownElement, eventTarget);
         if (!item) return;
 
@@ -533,6 +666,18 @@ function RootDropdown({
 
     const handleMouseOut = (event: ReactMouseEvent<HTMLElement>) => {
         if (!hasItemsRef.current) return;
+        // The pointer left the dropdown entirely: drop the safe area so its
+        // give-up timer can’t later fire on a stale position, and fall through
+        // to the normal collapse (mousemove has stopped, so nothing else will)
+        const relatedTarget = event.relatedTarget as Node | null;
+        const isLeavingDropdown = !dropdownElement?.contains(relatedTarget);
+        if (isLeavingDropdown) {
+            clearSafeAreaTimer();
+            safeAreaRef.current = null;
+            wasInSafeAreaRef.current = false;
+        }
+        // Heading toward an open submenu: don’t clear the active item / collapse
+        if (isPointerInSafeArea(event.clientX, event.clientY)) return;
         const activeItem = getActiveItemElement(dropdownElement);
         if (!activeItem) return;
         const eventRelatedTarget = event.relatedTarget as HTMLElement;

--- a/packages/dropdown/src/helpers.test.ts
+++ b/packages/dropdown/src/helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPointInTriangle, type Point } from './helpers.js';
+
+describe('isPointInTriangle', () => {
+    // A right triangle: apex on the left, near edge (base) vertical on the right,
+    // like a submenu opening to the inline-end of its parent item
+    const apex: Point = { x: 0, y: 5 };
+    const nearTop: Point = { x: 10, y: 0 };
+    const nearBottom: Point = { x: 10, y: 10 };
+
+    it('includes points inside the triangle', () => {
+        expect(isPointInTriangle({ x: 5, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+        expect(isPointInTriangle({ x: 8, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+    });
+
+    it('includes the vertices and edges', () => {
+        expect(isPointInTriangle(apex, apex, nearTop, nearBottom)).toBe(true);
+        expect(isPointInTriangle(nearTop, apex, nearTop, nearBottom)).toBe(true);
+        // Midpoint of the near (base) edge
+        expect(isPointInTriangle({ x: 10, y: 5 }, apex, nearTop, nearBottom)).toBe(true);
+    });
+
+    it('excludes points outside the triangle', () => {
+        // Beyond the near edge (past the submenu edge)
+        expect(isPointInTriangle({ x: 12, y: 5 }, apex, nearTop, nearBottom)).toBe(false);
+        // Straight up from the apex — a sibling above the parent, not toward the
+        // submenu
+        expect(isPointInTriangle({ x: 0, y: 0 }, apex, nearTop, nearBottom)).toBe(false);
+        // Straight down from the apex — a sibling below the parent
+        expect(isPointInTriangle({ x: 3, y: 9 }, apex, nearTop, nearBottom)).toBe(false);
+        // Behind the apex
+        expect(isPointInTriangle({ x: -5, y: 5 }, apex, nearTop, nearBottom)).toBe(false);
+    });
+
+    it('is orientation-independent (works for a mirror triangle opening left)', () => {
+        const rightApex: Point = { x: 10, y: 5 };
+        const leftTop: Point = { x: 0, y: 0 };
+        const leftBottom: Point = { x: 0, y: 10 };
+        expect(isPointInTriangle({ x: 5, y: 5 }, rightApex, leftTop, leftBottom)).toBe(
+            true,
+        );
+        expect(isPointInTriangle({ x: -2, y: 5 }, rightApex, leftTop, leftBottom)).toBe(
+            false,
+        );
+    });
+});

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -129,6 +129,20 @@ export const getActiveItemElement = (dropdownElement: MaybeHTMLElement) => {
     return actives ? actives[actives.length - 1] : null;
 };
 
+// The deepest expanded parent item — the one whose submenu is the innermost
+// open one — in document order
+export const getDeepestExpandedItem = (
+    dropdownElement: MaybeHTMLElement,
+): MaybeHTMLElement => {
+    if (!dropdownElement) return null;
+    const expanded = (
+        Array.from(
+            dropdownElement.querySelectorAll('[aria-expanded="true"]'),
+        ) as Array<HTMLElement>
+    ).filter((element) => element.matches(ITEM_SELECTOR));
+    return expanded.length ? expanded[expanded.length - 1] : null;
+};
+
 export const isItemExpanded = (item: HTMLElement) =>
     item.getAttribute('aria-expanded') === 'true';
 
@@ -376,4 +390,19 @@ export const setActiveItem = ({
     }
 
     return nextActiveItem;
+};
+
+export type Point = { x: number; y: number };
+
+// Whether a point is inside (or on an edge of) triangle a-b-c, from the sign
+// of the cross product for each edge: all the same sign ⇒ inside
+export const isPointInTriangle = (p: Point, a: Point, b: Point, c: Point): boolean => {
+    const cross = (u: Point, v: Point, w: Point) =>
+        (u.x - w.x) * (v.y - w.y) - (v.x - w.x) * (u.y - w.y);
+    const d1 = cross(p, a, b);
+    const d2 = cross(p, b, c);
+    const d3 = cross(p, c, a);
+    const hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+    const hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+    return !(hasNegative && hasPositive);
 };


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #378** (which is stacked on #377). This adds mouse-intent tracking on top of the submenu engine. Merges after #378; base retargets to `main` once the stack lands.

## The problem

When a submenu is open and you move the pointer diagonally from the parent item toward the submenu, the path usually crosses sibling items in the parent menu. The submenu collapsed the instant the pointer touched a sibling — so reaching a submenu item meant carefully tracing an L-shape (straight right, then down) instead of cutting the corner. macOS solves this with a "safe triangle" (a.k.a. menu-aim / safe polygon): while the pointer is inside the triangle between where it left the parent and the submenu's near edge, it's clearly heading for the submenu, so the submenu stays open.

## Before / after

Same diagonal drag in the `MenubarAppMenu` story — from **Open Recent** across **Close Window** to **project-c** — driven by Playwright:

| | `expanded` | active path |
| --- | --- | --- |
| **Before** (#378) | `false` | `[]` — submenu collapsed mid-drag, selection lost |
| **After** (this PR) | `true` | `[Open Recent, project-c]` — stayed open, reached the leaf |

A straight-down move onto the sibling still collapses and selects it in both (`[Close Window]`, `expanded: false`) — trajectory is what differs.

## Implementation

- **`helpers.ts`** — two pure additions: `isPointInTriangle(p, a, b, c)` (sign-of-cross-products, edge-inclusive) and `getDeepestExpandedItem(dropdownElement)` (the innermost open submenu's parent).
- **`Dropdown.tsx`** — the safe area is the triangle from the **apex** (the pointer's last position while over the open submenu's parent item) to the submenu's two **near corners**. The near edge is derived from the actual rects, so it's correct whether the submenu opened to the `inline-end` or flipped to `inline-start`.
  - `trackSafeArea` (on `mousemove`) refreshes the apex while the pointer is over the parent, and while traveling toward the submenu it (re)arms a give-up timer — reset on every move, so only a *pause* ends the protection, not motion.
  - `isPointerInSafeArea` guards `handleMouseOver` and `handleMouseOut`: inside the triangle, both early-return, so the active item and open submenu are left untouched as the pointer crosses siblings.
  - The give-up timer (`SAFE_AREA_TIMEOUT`, 300ms) fires on a pause and commits the switch to whatever the pointer is actually over (`elementFromPoint`).
  - Timer is cleared on unmount and on `closeDropdown`.
- **Pointer-only, default-on, no new API.** Keyboard navigation is untouched (the guards run only when `currentInputMethodRef` is `mouse`, via the existing `handleMouseOver` gate). No prop — it's invisible when it works and matches macOS.

## Testing

- **Unit** (`helpers.test.ts`, 4 cases): `isPointInTriangle` — interior, vertices/edges, exterior (past the near edge, straight up/down from the apex, behind it), and a mirrored left-opening triangle. **70 tests** total in the package.
- **Browser** (Playwright — happy-dom has no geometry): three trajectories against the live story — diagonal-through-sibling keeps it open and reaches the leaf; straight-down collapses and selects the sibling; pause-in-triangle keeps it open while moving then gives up to the sibling after 300ms. All verified against a clean #378 baseline (before/after table above).
- Full monorepo validation: build, tests, lint, tsc, format.

## Bundle size

Measured on top of #378 (`vite build`, then `esbuild --bundle --minify` + `gzip -9`): **+0.6 kB gzip** — Dropdown-only 8.6 → 9.2 kB, with Menubar 9.2 → 9.9 kB (+1.8 kB minified). That's the point-in-triangle helper + the pointermove branch + one `getBoundingClientRect` read; the inlined CSS is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usz1o3ztrzypEwResn7s6e