### PR TITLE
@acusti/dropdown: top-layer popover rendering + margin gap knobs

### DIFF
--- a/.changeset/dropdown-top-layer-popover.md
+++ b/.changeset/dropdown-top-layer-popover.md
@@ -1,0 +1,38 @@
+---
+'@acusti/dropdown': minor
+---
+
+Render the dropdown body in the top layer and add margin-based gap knobs
+for robust anchor positioning
+
+The dropdown body now renders in the top layer via `popover="manual"`. A
+top-layer element’s containing block is always the viewport, so an ancestor
+with a `transform`, `scale`, `filter`, `backdrop-filter`, `perspective`,
+`will-change: transform`, or `contain` can no longer capture the
+`position: fixed` body and break its placement — `position-try` fallbacks
+that used to stop firing (and base `position-area` directions that could
+resolve to the wrong side) now work regardless of a consumer’s ancestors,
+so consumer-side de-transforming workarounds are no longer needed.
+
+- Dismissal stays under the component’s control (`popover="manual"` plus
+  the existing `mousedown`/`mouseup`/`focusin` listeners on `document` and
+  the owner document), so outside-click, focus, and iframe handling are
+  unchanged and searchable/text-input triggers — whose input sits outside
+  the body — keep the body open while you interact with them, which native
+  light-dismiss (`popover="auto"`) would not
+- Submenus still anchor to their parent item and escape the body’s
+  `overflow: hidden` in the top layer; the body’s `z-index` is dropped
+  since the top layer handles stacking, and the UA popover styles
+  (`inset`/`margin`/`border`/`padding`/`color`) are reset so they can’t
+  override the anchor-positioning layout
+- New `--uktdd-body-gap` and `--uktdd-submenu-gap` custom properties
+  (default `0`) express the space between the trigger and the body (as a
+  symmetric `margin-block`) and between a parent item and its submenu (as
+  `margin-inline`). Unlike the `--uktdd-body-translate`/
+  `--uktdd-submenu-translate` knobs they supersede, a margin auto-reverses
+  to the attached side when `position-try` flips the box, and establishes
+  no containing block, so it is safe on dropdowns with submenus; the
+  translate knobs remain for legacy 2-D nudges
+- README documents the top-layer rendering, the gap knobs, and that a
+  `center` `position-area` tile never flips (use a full-width `span-all`
+  tile to center over the trigger instead)

--- a/.changeset/dropdown-top-layer-popover.md
+++ b/.changeset/dropdown-top-layer-popover.md
@@ -1,5 +1,5 @@
 ---
-'@acusti/dropdown': minor
+'@acusti/dropdown': major
 ---
 
 Render the dropdown body in the top layer and add margin-based gap knobs
@@ -28,11 +28,15 @@ so consumer-side de-transforming workarounds are no longer needed.
 - New `--uktdd-body-gap` and `--uktdd-submenu-gap` custom properties
   (default `0`) express the space between the trigger and the body (as a
   symmetric `margin-block`) and between a parent item and its submenu (as
-  `margin-inline`). Unlike the `--uktdd-body-translate`/
-  `--uktdd-submenu-translate` knobs they supersede, a margin auto-reverses
-  to the attached side when `position-try` flips the box, and establishes
-  no containing block, so it is safe on dropdowns with submenus; the
-  translate knobs remain for legacy 2-D nudges
+  `margin-inline`). A margin auto-reverses to the attached side when
+  `position-try` flips the box and establishes no containing block, so it
+  is safe on dropdowns with submenus
+- **Breaking:** the `--uktdd-body-translate` and
+  `--uktdd-submenu-translate` custom properties are removed.
+  `--uktdd-body-gap`/`--uktdd-submenu-gap` cover the trigger↔body and
+  item↔submenu spacing; for an offset a gap can’t express (a horizontal
+  nudge or a deliberate overlap), set `translate` on `.uktdropdown-body`
+  directly
 - README documents the top-layer rendering, the gap knobs, and that a
   `center` `position-area` tile never flips (use a full-width `span-all`
   tile to center over the trigger instead)

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -133,11 +133,11 @@
     --uktdd-body-position-area: bottom span-left;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
-    /* a horizontal alignment nudge, not a trigger↔body gap, so it stays on
-       the legacy translate knob rather than --uktdd-body-gap */
-    --uktdd-body-translate: -14px 0;
 
     .uktdropdown-body {
+        /* a horizontal alignment nudge, not a trigger↔body gap; set as a raw
+           translate since this dropdown has no submenus for it to clip */
+        translate: -14px 0;
         inline-size: 110px;
     }
 }
@@ -186,12 +186,9 @@
 .overlapping-dropdown .uktdropdown-body {
     inline-size: 250px;
     min-block-size: 200px;
-}
-
-.overlapping-dropdown {
-    /* translate deliberately pulls the body back over the trigger; a gap only
-       ever adds distance, so this overlap needs the legacy translate knob */
-    --uktdd-body-translate: -10px -22px;
+    /* deliberately pulls the body back over the trigger — a gap only adds
+       distance, so this overlap uses a raw translate (no submenus to clip) */
+    translate: -10px -22px;
 }
 
 .out-of-bounds-example input {

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -198,6 +198,56 @@
     inline-size: 250px;
 }
 
+/* A transformed ancestor would become the containing block for a normal
+   fixed-position body and break its anchor positioning; because the body
+   renders in the top layer, this panel’s transform doesn’t affect it. */
+.transformed-ancestor-panel {
+    box-sizing: border-box;
+    align-self: center;
+    width: 320px;
+    max-width: 100%;
+    margin: 2rem 0;
+    padding: 1.5rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #f6f6f6;
+    transform: rotate(-3deg) scale(0.94);
+}
+
+.transformed-ancestor-note {
+    margin: 0 0 1rem;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #555;
+}
+
+.transformed-ancestor-note code {
+    font-size: 11px;
+}
+
+/* span-all centers the body over the trigger like `center` would, but on a
+   full-width tile that flips (a `center` tile never does — see the fallback) */
+.centered-menu {
+    /* centered in the canvas so the span-all body has room to center over the
+       trigger rather than clamping against the viewport’s left edge */
+    align-self: center;
+    --uktdd-body-position-area: bottom span-all;
+    --uktdd-body-position-try-fallbacks: --centered-menu-top;
+
+    .uktdropdown-body {
+        inline-size: 200px;
+    }
+}
+
+@position-try --centered-menu-top {
+    position-area: top span-all;
+}
+
+.gap-example {
+    --uktdd-body-gap: 10px;
+    --uktdd-submenu-gap: 8px;
+}
+
 /* ---- Fixed Header Styles ---- */
 :root {
     --ui-clr-1000: #ffffff;

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -133,6 +133,8 @@
     --uktdd-body-position-area: bottom span-left;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+    /* a horizontal alignment nudge, not a trigger↔body gap, so it stays on
+       the legacy translate knob rather than --uktdd-body-gap */
     --uktdd-body-translate: -14px 0;
 
     .uktdropdown-body {
@@ -187,6 +189,8 @@
 }
 
 .overlapping-dropdown {
+    /* translate deliberately pulls the body back over the trigger; a gap only
+       ever adds distance, so this overlap needs the legacy translate knob */
     --uktdd-body-translate: -10px -22px;
 }
 
@@ -272,7 +276,7 @@
     padding: 25px;
     display: grid;
     position: fixed;
-    height: 200px; /* position fallbacks need vertical room in offset parent to take effect */
+    height: 200px; /* fixed header height */
     inset: 0;
     bottom: auto;
     font-family: system-ui;

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -538,6 +538,60 @@ export const OutOfBoundsAtRight: Story = {
     },
 };
 
+export const TransformedAncestor: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'The dropdown body renders in the top layer, so an ancestor with a `transform` (or `filter`, `contain`, etc.) can’t become its containing block and throw off placement. This card is `transform`ed — scaled and rotated — yet the menu still anchors to its trigger and renders upright at full scale instead of being captured by the card. Before top-layer rendering, an ancestor transform broke positioning and its `position-try` fallbacks, which consumers had to work around by de-transforming.',
+            },
+        },
+    },
+    render() {
+        return (
+            <div className="transformed-ancestor-panel">
+                <p className="transformed-ancestor-note">
+                    This card has <code>transform: rotate(-3deg) scale(0.94)</code>. The
+                    menu below still anchors correctly.
+                </p>
+                <Dropdown className="transformed-ancestor" onSubmitItem={fn()}>
+                    Edit
+                    <ul>
+                        <li data-ukt-value="cut">Cut</li>
+                        <li data-ukt-value="copy">Copy</li>
+                        <li data-ukt-value="paste">Paste</li>
+                        <li data-ukt-value="select-all">Select All</li>
+                        <li data-ukt-value="delete">Delete</li>
+                    </ul>
+                </Dropdown>
+            </div>
+        );
+    },
+};
+
+export const CenteredMenu: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Center a menu over its trigger with a `span-all` position-area tile. A `center` tile is only as wide as the trigger, so a wider body overflows it and `position-try` never selects a flipped fallback; `span-all` centers identically but spans the full width, so it flips cleanly (and clamps to the viewport) when there isn’t room below.',
+            },
+        },
+    },
+    render() {
+        return (
+            <Dropdown className="centered-menu" onSubmitItem={fn()}>
+                Insert
+                <ul>
+                    <li data-ukt-value="image">Image…</li>
+                    <li data-ukt-value="table">Table</li>
+                    <li data-ukt-value="chart">Chart</li>
+                    <li data-ukt-value="page-break">Page Break</li>
+                    <li data-ukt-value="horizontal-rule">Horizontal Rule</li>
+                </ul>
+            </Dropdown>
+        );
+    },
+};
+
 export const SubmenuDropdown: Story = {
     args: {
         children: [
@@ -577,6 +631,36 @@ export const SubmenuDropdown: Story = {
                 story: 'A `Dropdown` nested inside another dropdown’s body renders as a parent item that discloses a submenu. Pause on a parent item to disclose its submenu (pointer or arrow keys), press → to dive in, ← to surface back out. Parent items never submit; `onSubmitItem` fires only for leaf items, with the leaf’s ancestor `path` in the payload.',
             },
         },
+    },
+};
+
+export const WithGaps: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: '`--uktdd-body-gap` adds space between the trigger and the body (as a symmetric `margin-block`), and `--uktdd-submenu-gap` does the same between a parent item and its submenu (as `margin-inline`). Because they’re margins, the gap auto-reverses to whichever side the box attaches to when `position-try` flips it, and — unlike a `translate` — establishes no containing block, so it’s safe with submenus. This dropdown sets a 10px body gap and an 8px submenu gap.',
+            },
+        },
+    },
+    render() {
+        return (
+            <Dropdown className="gap-example" onSubmitItem={fn()}>
+                Format
+                <ul>
+                    <li data-ukt-item>Bold</li>
+                    <li data-ukt-item>Italic</li>
+                    <li data-ukt-item>Underline</li>
+                    <Dropdown label="Align">
+                        <ul>
+                            <li data-ukt-value="left">Left</li>
+                            <li data-ukt-value="center">Center</li>
+                            <li data-ukt-value="right">Right</li>
+                            <li data-ukt-value="justify">Justify</li>
+                        </ul>
+                    </Dropdown>
+                </ul>
+            </Dropdown>
+        );
     },
 };
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -482,7 +482,6 @@ CSS custom properties for the most common low-level placement controls:
 - `--uktdd-body-position-area`
 - `--uktdd-body-position-try-fallbacks`
 - `--uktdd-body-gap` (space between the trigger and the body)
-- `--uktdd-body-translate` (legacy; prefer `--uktdd-body-gap`)
 - `--uktdd-body-min-height`
 - `--uktdd-body-min-width`
 - `--uktdd-body-max-height`
@@ -506,17 +505,17 @@ Example:
 This approach keeps the public React API small while still allowing precise
 placement and sizing control when a product surface needs it.
 
-Prefer `--uktdd-body-gap` for the space between the trigger and the body.
-It is applied as a symmetric `margin-block`, so the gap lands on whichever
+Use `--uktdd-body-gap` for the space between the trigger and the body. It
+is applied as a symmetric `margin-block`, so the gap lands on whichever
 side the body attaches to and auto-reverses when `position-try` flips the
-body above the trigger — a static `translate` keeps pointing the same way
-and overlaps the trigger after a flip. A margin also establishes no
-containing block, so `--uktdd-body-gap` is safe on dropdowns with submenus.
+body above the trigger. A margin establishes no containing block, so
+`--uktdd-body-gap` is safe on dropdowns with submenus.
 
-`--uktdd-body-translate` remains for fine 2-D nudges, but comes with a
-caveat for dropdowns with submenus: any value except `none` (the default)
-makes the dropdown body a containing block for its fixed-position submenus,
-which constrains and clips them — only nudge dropdowns without submenus.
+For an offset a gap can’t express — a horizontal nudge, or deliberately
+overlapping the trigger — set `translate` on `.uktdropdown-body` directly.
+A `translate` makes the body a containing block for its fixed-position
+submenus, which constrains and clips them, so reserve it for dropdowns
+without submenus.
 
 ### End-Aligned, Content-Sized Menu
 
@@ -672,10 +671,6 @@ Placement custom properties follow the established naming scheme:
   applied as a symmetric `margin-inline`, the inline-axis counterpart to
   `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the
   opposite side)
-- `--uktdd-submenu-translate` (default: `none`; legacy, prefer
-  `--uktdd-submenu-gap`. Like `--uktdd-body-translate`, any other value
-  makes that box a containing block that constrains and clips the submenus
-  nested inside it)
 
 Parent items render a macOS-style disclosure chevron, drawn in CSS with the
 item’s `::after` pseudo-element and colored with `currentColor` so it

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -161,6 +161,22 @@ For the most reliable anchor-positioning behavior:
 - prefer CSS variable overrides over custom `top`/`left`/`right` inset
   rules
 
+The body renders in the top layer using the
+[Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API),
+which is what makes the anchor positioning robust. A top-layer element’s
+containing block is always the viewport, so an ancestor with a `transform`,
+`scale`, `filter`, `backdrop-filter`, `perspective`,
+`will-change: transform`, or `contain` can’t capture the `position: fixed`
+body. Were the body a normal descendant instead, any such ancestor would
+become its containing block and its placement math would be measured
+against that box rather than the viewport — `position-try` fallbacks stop
+firing, and the base `position-area` can even resolve to the wrong side.
+Because the body is in the top layer, none of that applies and no
+consumer-side de-transforming is needed. The body uses `popover="manual"`,
+so this component keeps control of dismissal: outside-click, focus, and
+iframe handling are unchanged, and a searchable trigger’s input stays open
+while you interact with it.
+
 For placement recipes, see
 [Placement Customization](#placement-customization-with-css-variables)
 below. If your trigger sits near the right edge of the viewport, the
@@ -448,7 +464,8 @@ CSS custom properties for the most common low-level placement controls:
 
 - `--uktdd-body-position-area`
 - `--uktdd-body-position-try-fallbacks`
-- `--uktdd-body-translate`
+- `--uktdd-body-gap` (space between the trigger and the body)
+- `--uktdd-body-translate` (legacy; prefer `--uktdd-body-gap`)
 - `--uktdd-body-min-height`
 - `--uktdd-body-min-width`
 - `--uktdd-body-max-height`
@@ -461,7 +478,7 @@ Example:
     --uktdd-body-position-area: bottom span-left;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
-    --uktdd-body-translate: -8px 0;
+    --uktdd-body-gap: 8px;
 }
 
 .settings-dropdown .uktdropdown-body {
@@ -472,10 +489,17 @@ Example:
 This approach keeps the public React API small while still allowing precise
 placement and sizing control when a product surface needs it.
 
-One caveat for dropdowns with submenus: any `--uktdd-body-translate` value
-except `none` (the default) makes the dropdown body a containing block for
-its fixed-position submenus, which constrains and clips them — only nudge
-dropdowns without submenus.
+Prefer `--uktdd-body-gap` for the space between the trigger and the body.
+It is applied as a symmetric `margin-block`, so the gap lands on whichever
+side the body attaches to and auto-reverses when `position-try` flips the
+body above the trigger — a static `translate` keeps pointing the same way
+and overlaps the trigger after a flip. A margin also establishes no
+containing block, so `--uktdd-body-gap` is safe on dropdowns with submenus.
+
+`--uktdd-body-translate` remains for fine 2-D nudges, but comes with a
+caveat for dropdowns with submenus: any value except `none` (the default)
+makes the dropdown body a containing block for its fixed-position submenus,
+which constrains and clips them — only nudge dropdowns without submenus.
 
 ### End-Aligned, Content-Sized Menu
 
@@ -499,6 +523,28 @@ This keeps the menu:
 
 Avoid hardcoding width for this pattern unless the product explicitly needs
 a fixed-size menu.
+
+### Centered Menus
+
+To center a menu over its trigger, use a `span-all` tile, not a `center`
+tile. A `center` tile is only as wide as the trigger, so a body wider than
+the trigger always overflows it — and `position-try` refuses to select a
+fallback that overflows, so a `bottom center` → `top center` setup never
+flips. `span-all` centers over the trigger identically but spans the full
+width, so it flips cleanly and clamps to the viewport near an edge; the
+package’s `position-try-order: most-height` then picks the taller side:
+
+```css
+.centered-menu {
+    --uktdd-body-position-area: bottom span-all;
+    --uktdd-body-position-try-fallbacks: --centered-menu-top;
+}
+
+/* define the flipped fallback in your own CSS */
+@position-try --centered-menu-top {
+    position-area: top span-all;
+}
+```
 
 ## Submenus
 
@@ -605,9 +651,14 @@ Placement custom properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
 - `--uktdd-submenu-position-try-fallbacks`
-- `--uktdd-submenu-translate` (default: `none`; like
-  `--uktdd-body-translate`, any other value makes that box a containing
-  block that constrains and clips the submenus nested inside it)
+- `--uktdd-submenu-gap` (space between the parent item and the submenu;
+  applied as a symmetric `margin-inline`, the inline-axis counterpart to
+  `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the
+  opposite side)
+- `--uktdd-submenu-translate` (default: `none`; legacy, prefer
+  `--uktdd-submenu-gap`. Like `--uktdd-body-translate`, any other value
+  makes that box a containing block that constrains and clips the submenus
+  nested inside it)
 
 Parent items render a macOS-style disclosure chevron, drawn in CSS with the
 item’s `::after` pseudo-element and colored with `currentColor` so it

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -183,6 +183,23 @@ below. If your trigger sits near the right edge of the viewport, the
 [End-Aligned, Content-Sized Menu](#end-aligned-content-sized-menu) example
 is the one you want.
 
+## Browser Support
+
+`Dropdown` relies on two web-platform features, both now
+[Baseline](https://web.dev/baseline) across Chrome, Edge, Firefox, and
+Safari:
+
+- **CSS anchor positioning** (`anchor-name`, `position-area`,
+  `@position-try`) places and re-flows the body —
+  [Baseline 2026](https://developer.mozilla.org/en-US/docs/Web/CSS/anchor-name)
+- the **Popover API** (`popover` plus `showPopover()`) renders the body in
+  the top layer —
+  [Baseline 2024](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+
+These are _newly available_ Baseline features: they work in up-to-date
+browser versions but not in ones predating that support, which the
+component requires.
+
 ## API Reference
 
 ### Props

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -87,9 +87,19 @@
     max-inline-size: var(--uktdd-body-max-width);
     inline-size: max-content;
     overflow: hidden;
+    /* the body renders in the top layer via popover="manual" so an ancestor’s
+       transform / filter / contain can’t become its containing block; reset
+       the UA popover styles (inset / margin / border / padding / block-size /
+       color) that would otherwise override the anchor-positioning layout, and
+       let the top layer handle stacking instead of a z-index */
+    inset: auto;
+    block-size: auto;
     margin-block: var(--uktdd-body-gap);
+    margin-inline: 0;
+    border: 0;
+    padding: 0;
+    color: inherit;
     translate: var(--uktdd-body-translate);
-    z-index: 2;
     background-color: var(--uktdd-body-bg-color);
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
 

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -19,15 +19,10 @@
         --uktdd-top-left, --uktdd-bottom-right, --uktdd-top-right;
     /* gap between the trigger and the body, applied as a symmetric
        margin-block so it lands on whichever side the body attaches to and
-       auto-reverses when position-try flips it above/below the trigger.
-       Unlike a translate, a margin establishes no containing block, so it’s
-       safe on dropdowns with submenus — prefer it over --uktdd-body-translate */
+       auto-reverses when position-try flips it above/below the trigger. A
+       margin establishes no containing block, so it’s safe on dropdowns with
+       submenus */
     --uktdd-body-gap: 0px;
-    /* legacy static offset; any value except none makes the box a containing
-       block for its fixed-position submenus, constraining and clipping them,
-       so only set a translate on dropdowns without submenus. Prefer
-       --uktdd-body-gap, which has neither limitation */
-    --uktdd-body-translate: none;
     --uktdd-body-color: canvastext;
     --uktdd-body-bg-color-path: #dcdcdc;
     --uktdd-body-color-path: currentColor;
@@ -37,7 +32,6 @@
     /* like --uktdd-body-gap but on the inline axis, since submenus open to
        the side; auto-reverses when they flip to the opposite inline edge */
     --uktdd-submenu-gap: 0px;
-    --uktdd-submenu-translate: none;
     --uktdd-menubar-trigger-bg-color-active: rgba(0, 0, 0, 0.12);
 }
 
@@ -99,7 +93,6 @@
     border: 0;
     padding: 0;
     color: inherit;
-    translate: var(--uktdd-body-translate);
     background-color: var(--uktdd-body-bg-color);
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
 
@@ -173,7 +166,6 @@
         position-anchor: --uktdd-submenu-anchor;
         position-area: var(--uktdd-submenu-position-area);
         position-try-fallbacks: var(--uktdd-submenu-position-try-fallbacks);
-        translate: var(--uktdd-submenu-translate);
         z-index: 2;
         margin-block: 0;
         margin-inline: var(--uktdd-submenu-gap);

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -17,9 +17,16 @@
     --uktdd-body-position-area: bottom span-right;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-left, --uktdd-bottom-right, --uktdd-top-right;
-    /* any translate value except none makes the box a containing block for
-       its fixed-position submenus, constraining and clipping them, so only
-       set a translate on dropdowns without submenus */
+    /* gap between the trigger and the body, applied as a symmetric
+       margin-block so it lands on whichever side the body attaches to and
+       auto-reverses when position-try flips it above/below the trigger.
+       Unlike a translate, a margin establishes no containing block, so it’s
+       safe on dropdowns with submenus — prefer it over --uktdd-body-translate */
+    --uktdd-body-gap: 0px;
+    /* legacy static offset; any value except none makes the box a containing
+       block for its fixed-position submenus, constraining and clipping them,
+       so only set a translate on dropdowns without submenus. Prefer
+       --uktdd-body-gap, which has neither limitation */
     --uktdd-body-translate: none;
     --uktdd-body-color: canvastext;
     --uktdd-body-bg-color-path: #dcdcdc;
@@ -27,6 +34,9 @@
     --uktdd-label-pad-right: 0.625em;
     --uktdd-submenu-position-area: inline-end span-block-end;
     --uktdd-submenu-position-try-fallbacks: --uktdd-submenu-inline-start;
+    /* like --uktdd-body-gap but on the inline axis, since submenus open to
+       the side; auto-reverses when they flip to the opposite inline edge */
+    --uktdd-submenu-gap: 0px;
     --uktdd-submenu-translate: none;
     --uktdd-menubar-trigger-bg-color-active: rgba(0, 0, 0, 0.12);
 }
@@ -77,6 +87,7 @@
     max-inline-size: var(--uktdd-body-max-width);
     inline-size: max-content;
     overflow: hidden;
+    margin-block: var(--uktdd-body-gap);
     translate: var(--uktdd-body-translate);
     z-index: 2;
     background-color: var(--uktdd-body-bg-color);
@@ -154,7 +165,8 @@
         position-try-fallbacks: var(--uktdd-submenu-position-try-fallbacks);
         translate: var(--uktdd-submenu-translate);
         z-index: 2;
-        margin: 0;
+        margin-block: 0;
+        margin-inline: var(--uktdd-submenu-gap);
         padding: var(--uktdd-body-pad-top) var(--uktdd-body-pad-right)
             var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
         inline-size: max-content;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1099,9 +1099,20 @@ function RootDropdown({
         };
     };
 
-    // Fill in parent-item/submenu ARIA when the body mounts (open)
+    // When the body mounts (open): fill in parent-item/submenu ARIA, and
+    // render it in the top layer via popover so an ancestor’s transform /
+    // filter / contain can’t become the containing block for the fixed body
+    // and break its anchor positioning + fallbacks. popover="manual" keeps
+    // dismissal under this component’s own listeners (see handleRef), which
+    // preserves iframe support and searchable/text-input triggers that native
+    // light-dismiss would close on any outside pointerdown.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
-        if (ref) annotateParentItems(ref);
+        if (!ref) return;
+        annotateParentItems(ref);
+        // The Popover API is Baseline 2024, so showPopover() needs no feature
+        // detection; the body is mounted only while open, so this runs once
+        // per open and won’t throw on an already-open body.
+        ref.showPopover();
     };
 
     if (!isValidElement(trigger)) {
@@ -1195,6 +1206,7 @@ function RootDropdown({
                             'has-items': hasItems,
                         })}
                         id={bodyId}
+                        popover="manual"
                         ref={handleBodyRef}
                         role={popupRole}
                     >

--- a/vite.config.base.js
+++ b/vite.config.base.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import babel from '@rolldown/plugin-babel';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import { defineConfig as defineConfigVite } from 'vite';
@@ -49,6 +51,7 @@ export const defineConfig = (options = {}) => {
         ],
         test: {
             exclude: [...configDefaults.exclude, '**/dist/**'],
+            setupFiles: [fileURLToPath(new URL('./vitest.setup.js', import.meta.url))],
         },
     });
 };

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,5 +3,6 @@ import { configDefaults, defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         exclude: [...configDefaults.exclude, '**/dist/**'],
+        setupFiles: ['./vitest.setup.js'],
     },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,16 @@
+// happy-dom reflects the `popover` attribute but doesn’t implement the Popover
+// API methods, so components that render their content in the top layer (e.g.
+// @acusti/dropdown) can’t call showPopover() under test. Polyfill the methods
+// as no-ops in any DOM-backed test environment; node-environment tests have no
+// HTMLElement and skip it.
+if (
+    typeof HTMLElement !== 'undefined' &&
+    typeof HTMLElement.prototype.showPopover !== 'function'
+) {
+    HTMLElement.prototype.showPopover = function showPopover() {};
+    HTMLElement.prototype.hidePopover = function hidePopover() {};
+    HTMLElement.prototype.togglePopover = function togglePopover(force) {
+        const willShow = typeof force === 'boolean' ? force : true;
+        return willShow;
+    };
+}


### PR DESCRIPTION
## Summary

`@acusti/dropdown` renders its body with `position: fixed` + CSS anchor
positioning. Any ancestor with a `transform` / `scale` / `filter` /
`backdrop-filter` / `will-change: transform` / `contain` becomes the
containing block for that fixed body, which breaks the anchor math:
`position-try` fallbacks stop firing and the base `position-area` can even
resolve to the wrong side. It's easy for a consuming app to trip over — we hit
it integrating the upgrade in Outlyne and worked around it consumer-side in
`outlyne/outlyne#1869`.

This PR fixes the whole class of bug upstream by rendering the body in the top
layer, and adds a margin-based gap primitive. It lands as the `@acusti/dropdown`
**v1** (major) alongside the submenu/menubar work.

## Breaking changes

- The `--uktdd-body-translate` / `--uktdd-submenu-translate` CSS custom
  properties are **removed**. Use `--uktdd-body-gap` / `--uktdd-submenu-gap`
  for spacing, or set `translate` on `.uktdropdown-body` directly for a custom
  2-D nudge or overlap.
- The body now renders in the **top layer** (Popover API) and no longer sets a
  `z-index`, so consumer CSS that relied on the body being a normal, in-flow,
  z-indexed descendant may need adjusting.

## Changes

1. **Margin-based gap knobs** — new `--uktdd-body-gap` (applied as
   `margin-block`) and `--uktdd-submenu-gap` (`margin-inline`), default `0`.
   Unlike the removed `--uktdd-*-translate` knobs, a symmetric margin
   auto-reverses to the attached side when `position-try` flips the box and
   establishes no containing block, so a gap is safe on dropdowns with submenus.
2. **Top-layer popover** — the body now renders in the top layer via
   `popover="manual"`, calling `showPopover()` directly (the Popover API is
   Baseline 2024, so no feature detection). A top-layer
   element's containing block is always the viewport regardless of ancestor
   transforms/filters/clipping, so consumer-side de-transforming is no longer
   needed. Dropped the body's `z-index` (the top layer handles stacking) and
   reset the UA popover styles (`inset`/`margin`/`border`/`padding`/
   `block-size`/`color`) that would otherwise override the anchor layout.
   happy-dom doesn't implement `showPopover()`, so a `vitest.setup.js`
   polyfills the Popover API for tests (wired into the root and shared vitest
   configs).
3. **Docs + changeset** — README documents the top-layer rendering, the gap
   knobs, and that a `center` `position-area` tile never flips (use a
   full-width `span-all` tile to center over the trigger instead).

## Why `manual`, not `auto`

`popover="auto"` would provide free light-dismiss, but it light-dismisses on
any outside `pointerdown` — including clicks into a searchable dropdown's
trigger input, which sits *outside* the popover body — so it would break
searching (a headline feature) and drop the deliberate iframe support. Manual
keeps all existing dismissal semantics (the existing `document` /
`ownerDocument` `mousedown`/`mouseup`/`focusin` listeners) and just adds the
top-layer benefit.

## Validation

- `bun run build` / `test` (223/223) / `lint` / `tsc` / `format` all pass.
- Verified in a real browser (Storybook): top-layer rendering
  (`:popover-open`), anchor positioning + fallback flip under an
  identity-`transform` ancestor (rects identical to the no-transform
  baseline), submenu anchoring + overflow escape in the top layer, searchable
  manual-dismiss (stays open on input interaction; genuine outside clicks still
  dismiss), gap auto-reverse on flip, `span-all` centering, and nested
  popover-in-popover (info popover) with Escape closing the innermost first.

## Storybook

New stories cover the new behaviors (and every existing story keeps working):

- **TransformedAncestor** — a dropdown inside a rotated/scaled card; the menu
  still anchors to its trigger and renders upright in the top layer.
- **WithGaps** — `--uktdd-body-gap` (10px) and `--uktdd-submenu-gap` (8px) on a
  submenu dropdown.
- **CenteredMenu** — the `span-all` recipe for centering a menu over its
  trigger (which, unlike a `center` tile, still flips).

Plus small updates: clarifying comments on the two stories that still use
`--uktdd-body-translate` (a horizontal nudge and an intentional overlap —
neither is a gap), and dropping a now-stale `FixedHeader` comment about
fallbacks needing offset-parent room.

Once this lands, the Outlyne consumer-side workarounds in `outlyne/outlyne#1869`
become unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
