### PR TITLE
Remove the minHeightBody / minWidthBody props (@acusti/dropdown v1)

### DIFF
--- a/.changeset/dropdown-remove-min-body-props.md
+++ b/.changeset/dropdown-remove-min-body-props.md
@@ -1,0 +1,13 @@
+---
+'@acusti/dropdown': major
+---
+
+Remove the `minHeightBody` and `minWidthBody` props
+
+These props were only sugar for the `--uktdd-body-min-height` /
+`--uktdd-body-min-width` CSS custom properties, and they had no `max`
+counterparts (max sizing was already CSS-only), so they left the sizing API
+half in props and half in CSS. Placement and sizing are customized in CSS,
+so set the body’s minimum size with the CSS variables directly — e.g.
+`style={{ '--uktdd-body-min-width': '180px' }}` or a rule on the dropdown’s
+class.

--- a/.changeset/dropdown-remove-min-body-props.md
+++ b/.changeset/dropdown-remove-min-body-props.md
@@ -10,4 +10,5 @@ counterparts (max sizing was already CSS-only), so they left the sizing API
 half in props and half in CSS. Placement and sizing are customized in CSS,
 so set the body’s minimum size with the CSS variables directly — e.g.
 `style={{ '--uktdd-body-min-width': '180px' }}` or a rule on the dropdown’s
-class.
+class. The `style` prop’s type now accepts the component’s CSS custom
+properties, so that inline form type-checks without a cast.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -253,14 +253,6 @@ type Props = {
      */
     label?: ReactNode;
     /**
-     * Minimum height for the dropdown body in pixels. Defaults to 30.
-     */
-    minHeightBody?: number;
-    /**
-     * Minimum width for the dropdown body in pixels.
-     */
-    minWidthBody?: number;
-    /**
      * Name attribute for the search input (requires isSearchable: true).
      */
     name?: string;
@@ -653,10 +645,9 @@ Most props keep their meaning, scoped to the submenu:
 - `className`/`style`: applied to the parent item element
 
 Props that only make sense at the top level (`allowCreate`, `allowEmpty`,
-`isOpenOnMount`, `isSearchable`, `keepOpenOnSubmit`, `minHeightBody`,
-`minWidthBody`, `name`, `placeholder`, `tabIndex`, `value`) are ignored on
-a nested dropdown and warn (unconditionally, matching the children-count
-misuse error).
+`isOpenOnMount`, `isSearchable`, `keepOpenOnSubmit`, `name`, `placeholder`,
+`tabIndex`, `value`) are ignored on a nested dropdown and warn
+(unconditionally, matching the children-count misuse error).
 
 ### Submenu placement and styling
 

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -78,7 +78,7 @@ describe('@acusti/dropdown', () => {
     it('renders dropdown items inside .uktdropdown-content', async () => {
         const user = userEvent.setup();
         render(
-            <Dropdown minHeightBody={90}>
+            <Dropdown>
                 Menu
                 <ul data-testid="dropdown-list">
                     <li>Item</li>

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -109,7 +109,12 @@ export type Props = {
      * Used as search input’s placeholder.
      */
     placeholder?: string;
-    style?: CSSProperties;
+    /**
+     * Applied to the dropdown root element. Also accepts the component’s CSS
+     * custom properties (e.g. `--uktdd-body-min-width`) for per-instance
+     * placement and sizing, which plain `CSSProperties` rejects.
+     */
+    style?: CSSProperties & Record<`--${string}`, string | number | undefined>;
     /**
      * Only usable in conjunction with {isSearchable: true}.
      * Used as search input’s tabIndex.

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -92,8 +92,6 @@ export type Props = {
      * For a nested (submenu) Dropdown, this is the parent item’s content.
      */
     label?: ReactNode;
-    minHeightBody?: number;
-    minWidthBody?: number;
     /**
      * Only usable in conjunction with {isSearchable: true}.
      * Used as search input’s name.
@@ -173,8 +171,6 @@ function RootDropdown({
     isSearchable,
     keepOpenOnSubmit = !hasItems,
     label,
-    minHeightBody,
-    minWidthBody,
     name,
     onActiveItem,
     onClick,
@@ -1168,16 +1164,6 @@ function RootDropdown({
         );
     }
 
-    const style = {
-        ...styleFromProps,
-        ...(minHeightBody != null && minHeightBody > 0
-            ? { '--uktdd-body-min-height': `${minHeightBody}px` }
-            : null),
-        ...(minWidthBody != null && minWidthBody > 0
-            ? { '--uktdd-body-min-width': `${minWidthBody}px` }
-            : null),
-    };
-
     return (
         <Fragment>
             <style href="@acusti/dropdown/Dropdown" precedence="medium">
@@ -1196,7 +1182,7 @@ function RootDropdown({
                 onMouseOver={handleMouseOver}
                 onMouseUp={handleMouseUp}
                 ref={handleRef}
-                style={style}
+                style={styleFromProps}
             >
                 {trigger}
                 {/* TODO next version of Dropdown should use <Activity> for body https://react.dev/reference/react/Activity */}
@@ -1230,8 +1216,6 @@ const INERT_SUBMENU_PROPS = [
     'isOpenOnMount',
     'isSearchable',
     'keepOpenOnSubmit',
-    'minHeightBody',
-    'minWidthBody',
     'name',
     'placeholder',
     'tabIndex',


### PR DESCRIPTION
## Summary

Removes the `minHeightBody` and `minWidthBody` props from `@acusti/dropdown` for
the upcoming **v1** (major). They were only sugar for the
`--uktdd-body-min-height` / `--uktdd-body-min-width` CSS custom properties — the
component just injected them into the root element's `style` — and there were no
`maxHeightBody` / `maxWidthBody` counterparts (max sizing was already CSS-only).
That left body sizing split awkwardly half in props and half in CSS, against the
component's documented "customize placement and sizing in CSS" model.

## Breaking change

The `minHeightBody` / `minWidthBody` props are gone. Set the body's minimum size
with the CSS variables directly:

```tsx
// before
<Dropdown minWidthBody={180}>…</Dropdown>

// after — inline
<Dropdown style={{ '--uktdd-body-min-width': '180px' }}>…</Dropdown>

// after — or on the dropdown's own class
// .my-dropdown { --uktdd-body-min-width: 180px; }
```

Both `--uktdd-body-min-height` and `--uktdd-body-min-width` already exist (and
predate this change), so the migration is forward-compatible with `0.57.x`.

## Consumer impact (Outlyne)

Checked the main consumer: `minWidthBody` is used **once** (the analytics
date-range dropdown, `={180}`) and `minHeightBody` **zero** times. That one spot
already has its own CSS rule, so the migration is a single line moved into it —
and, being forward-compatible, it doesn't need to be coupled to the version bump.

## Changes

- Drop `minHeightBody` / `minWidthBody` from the `Props` type, the destructure,
  the root-`style` construction (now passes the consumer `style` through
  unchanged), and the `INERT_SUBMENU_PROPS` list
- Update the one incidental test usage and the two README references
- `major` changeset

## Validation

`bun run tsc` / `lint` / `format` clean; `@acusti/dropdown` build passes; 70/70
dropdown tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
