### PR TITLE
Fix Storybook docs lag: stop serializing events on every dropdown interaction

### DIFF
--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -2,7 +2,6 @@ import type { Preview } from '@storybook/react-vite';
 
 const preview: Preview = {
     parameters: {
-        actions: { argTypesRegex: '^on[A-Z].*' },
         controls: {
             matchers: {
                 color: /(background|color)$/i,

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -36,10 +36,7 @@ function ChevronDownIcon(props: React.SVGProps<SVGSVGElement>) {
 
 const meta: Meta<typeof Dropdown> = {
     args: {
-        onClick: fn(),
         onClose: fn(),
-        onMouseDown: fn(),
-        onMouseUp: fn(),
         onOpen: fn(),
         onSubmitItem: fn(),
     },


### PR DESCRIPTION
## Summary

The Dropdown **docs** page was reliably laggy/unresponsive on every click and every hover over dropdown contents. A DevTools Performance trace (thanks to a foreground recording) showed **INP ≈ 2,678ms**, with the time going to Storybook's manager↔preview channel, not the component:

- `stringify` — **1,415ms self (23.3%)** (`runtime.js`, Storybook preview runtime)
- `send` — **1,380ms self (22.7%)**
- `Event: pointerdown` — 4,715ms total (77.7%)
- Every stack: `Event` → React `dispatchEvent` → `fn3` (the `fn()` spy) / `setActiveItem` → `handler` → `emit` → `send` → `stringify`. **~46% of the time is `stringify` + `send`; 0% is `@acusti/dropdown` or React rendering.**

## Cause

`packages/docs/.storybook/preview.ts` set `actions: { argTypesRegex: '^on[A-Z].*' }`, which wraps **every** `on*` prop in an action spy. `Dropdown` calls `onActiveItem` on **every hover** with a payload holding a **DOM element + the event**, so each hover telejson-`stringify`s a DOM node over the channel (the hover lag); the `onClick`/`onMouseDown`/`onMouseUp` spies did the same on every click (the click lag). `argTypesRegex` has been **deprecated since Storybook 8** (this repo is on 10) in favor of explicit `fn()`.

## Fix (Storybook config only — the component is untouched)

- Remove the `argTypesRegex` auto-actions rule from `preview.ts`.
- Drop the high-frequency mouse-event spies (`onClick`/`onMouseDown`/`onMouseUp`) from the Dropdown `meta.args`, keeping the cheap, meaningful ones (`onOpen`/`onClose`/`onSubmitItem`), which fire rarely.

Net: no action spy fires on hover or mouse-down/up anymore, so nothing gets serialized over the channel per-interaction.

## Verify

Reload Storybook (restart the dev server if the `preview.ts` change doesn't hot-reload) and re-record: INP should drop from ~2.7s back to normal, and hovering/clicking the docs dropdowns should be snappy.

No changeset — `@acusti/uikit-docs` isn't published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)