### PR TITLE
Let a Dropdown nested inside a non-menu dropdown be an independent menu

### DIFF
--- a/.changeset/dropdown-nested-independent-menu.md
+++ b/.changeset/dropdown-nested-independent-menu.md
@@ -1,0 +1,16 @@
+---
+'@acusti/dropdown': patch
+---
+
+Let a Dropdown nested inside a non-menu dropdown be an independent menu
+
+A `Dropdown` nested inside another `Dropdown`'s body was promoted to a
+submenu whenever it was itself a menu, regardless of the outer dropdown —
+so an independent, click-to-select picker embedded in a `hasItems={false}`
+dialog had no way to work (as a submenu it needed hover-intent to open, and
+the `hasItems={false}` escape hatch also disables item selection). Submenu
+context is now provided only by _menu_ dropdowns, so a `Dropdown` nested
+inside a `hasItems={false}` dropdown renders as an independent anchored
+dropdown with normal click-to-open and click-to-select on its
+`data-ukt-value` items. Nested submenus (menu-in-menu) and info popovers
+(`hasItems={false}` nested anywhere) are unchanged.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -709,12 +709,22 @@ The default rule, shown here for reference:
 }
 ```
 
-### Nested non-menu dropdowns
+### Nested independent dropdowns
 
-Nesting means submenu only for menus. A nested `Dropdown` with
-`hasItems={false}` isn’t a menu, so it renders as an independent anchored
-dropdown instead of a parent item — for example, an ℹ️ button next to an
-input in a form dropdown that opens an info popover about the input:
+Submenus are a menu concept: a `Dropdown` becomes a submenu only when it’s
+a menu nested inside another menu. Anything else nests as an
+**independent** anchored dropdown — opening on click and selecting items on
+click (no hover-disclosed parent item), with its interactions never
+touching the outer dropdown. Two cases qualify:
+
+- a `hasItems={false}` `Dropdown` (a dialog/popover) nested anywhere — e.g.
+  an ℹ️ info popover next to an input in a form dropdown (below);
+- any `Dropdown` nested inside a `hasItems={false}` dropdown — e.g. a
+  self-contained picker embedded in a larger dialog, which keeps full
+  click-to-select on its `data-ukt-value` items.
+
+For example, an ℹ️ button next to an input in a form dropdown that opens an
+info popover about the input:
 
 ```tsx
 <Dropdown hasItems={false}>

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -1569,5 +1569,45 @@ describe('@acusti/dropdown', () => {
             // the outer menu stays open
             expect(screen.getByText('Beta')).toBeTruthy();
         });
+
+        it('renders a menu Dropdown nested inside a hasItems={false} dropdown as an independent, click-selectable picker', () => {
+            const handleSubmitItem = vi.fn();
+            render(
+                <Dropdown hasItems={false}>
+                    <button type="button">Score report</button>
+                    <div>
+                        <Dropdown onSubmitItem={handleSubmitItem}>
+                            <button type="button">Page goal</button>
+                            <ul>
+                                <li data-ukt-value="gamma">Gamma</li>
+                                <li data-ukt-value="delta">Delta</li>
+                            </ul>
+                        </Dropdown>
+                    </div>
+                </Dropdown>,
+            );
+
+            const outer = screen.getByText('Score report');
+            fireEvent.mouseDown(outer);
+            fireEvent.mouseUp(outer);
+
+            // the inner menu isn’t promoted to a submenu, so its list isn’t in
+            // the DOM until it’s opened (a submenu renders its items eagerly)
+            expect(document.body.querySelector('[data-ukt-value="delta"]')).toBe(null);
+
+            const inner = screen.getByText('Page goal');
+            fireEvent.mouseDown(inner);
+            fireEvent.mouseUp(inner);
+
+            // plain click-to-select on a data-ukt-value item fires onSubmitItem
+            const item = screen.getByText('Delta');
+            fireEvent.mouseOver(item);
+            fireEvent.mouseDown(item);
+            fireEvent.mouseUp(item);
+
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ value: 'delta' }),
+            );
+        });
     });
 });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -154,11 +154,10 @@ const SAFE_AREA_TIMEOUT = 300;
 
 export default function Dropdown(props: Props) {
     const parentDropdown = useContext(DropdownContext);
-    // A Dropdown nested inside another dropdown’s body is a submenu: it
-    // renders as a parent item and delegates to the root dropdown’s engine.
-    // A nested Dropdown with hasItems={false} isn’t a menu, so it renders as
-    // an independent anchored dropdown instead (e.g. an info popover inside
-    // a form dropdown)
+    // A Dropdown nested inside a menu dropdown’s body renders as a submenu
+    // (a parent item delegating to the root engine). A hasItems={false}
+    // dropdown provides no submenu context, so a Dropdown nested inside one —
+    // or a hasItems={false} Dropdown anywhere — renders independently instead.
     if (parentDropdown && props.hasItems !== false) {
         return <SubmenuDropdown {...props} parentDropdown={parentDropdown} />;
     }
@@ -1202,7 +1201,9 @@ function RootDropdown({
                         role={popupRole}
                     >
                         <div className="uktdropdown-content">
-                            <DropdownContext.Provider value={dropdownContextValue}>
+                            <DropdownContext.Provider
+                                value={hasItems ? dropdownContextValue : null}
+                            >
                                 {childrenCount > 1
                                     ? (children as ChildrenTuple)[1]
                                     : children}

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -14,8 +14,8 @@ export type SubmenuRegistration = {
     onSubmitItem?: (payload: Item) => void;
 };
 
-// Provided by the root Dropdown; a Dropdown that finds this context renders
-// as a submenu (parent item + data-ukt-submenu) instead of a root dropdown.
+// Provided by a menu Dropdown; a Dropdown that finds this context renders as a
+// submenu (parent item + data-ukt-submenu) instead of a root dropdown.
 export const DropdownContext = createContext<DropdownContextValue | null>(null);
 
 export type MenubarContextValue = {


### PR DESCRIPTION
## Bug (reported migrating Outlyne to `@acusti/dropdown@1.0.0-alpha.0`)

A `Dropdown` nested inside another `Dropdown`'s body was promoted to a **submenu** whenever it was itself a menu — regardless of the outer dropdown or the DOM around it — because the submenu `DropdownContext` was provided by *every* open dropdown, menu or dialog. The only escape, `hasItems={false}`, avoids the submenu but (by design) also disables the built-in click→`onSubmitItem` wiring. So an **independent, click-to-select picker embedded in a `hasItems={false}` dialog** (e.g. Outlyne's page-goal control inside a score-report Dropdown) had no way to work: as a submenu it needed hover-intent to open, and as `hasItems={false}` its `data-ukt-value` items never submitted.

## Fix

Submenus are a menu concept, so **only a menu provides submenu context**:

```tsx
<DropdownContext.Provider value={hasItems ? dropdownContextValue : null}>
```

A `Dropdown` nested inside a `hasItems={false}` dropdown now sees no parent context and renders as an independent `RootDropdown` — normal click-to-open and click-to-select on its `data-ukt-value` items, no hover-disclosed parent item.

**Consumer migration:** drop `hasItems={false}` from the *inner* picker (it has items → it's a menu); keep it on the *outer* dialog. No per-item `onClick` needed.

Unchanged: menu-in-menu submenus (parent is a menu → still promoted) and `hasItems={false}` info popovers (independent either way). The one behavior change is the buggy case — a menu nested in a *dialog* was a hover-submenu, now an independent click-menu — fine pre-stable.

## Also in this PR
- Updated the "Nested independent dropdowns" README section and the two source comments.
- Added a regression test (an adaptation of the reporter's repro, with the inner as a proper menu): nested inside a `hasItems={false}` outer, the inner isn't pre-rendered as a submenu and click-to-select fires `onSubmitItem`.
- `patch` changeset (→ `1.0.0-alpha.1` in pre mode).

Green: 71/71 dropdown tests, tsc / lint / build.
🤖 Generated with [Claude Code](https://claude.com/claude-code)