### PR TITLE
Keep a Menubar engaged when the pointer moves onto a non-menu control

### DIFF
--- a/.changeset/menubar-stay-engaged-on-non-menu-hover.md
+++ b/.changeset/menubar-stay-engaged-on-non-menu-hover.md
@@ -1,0 +1,16 @@
+---
+'@acusti/dropdown': patch
+---
+
+Keep a Menubar engaged when the pointer moves onto a non-menu control
+
+A `Menubar` now tracks an explicit menu-mode: opening a trigger’s menu (by
+click or keyboard) engages the bar, and it stays engaged until a deliberate
+dismissal (Escape, a click outside the bar, or selecting an item). While
+engaged, hovering a non-menu control placed alongside the dropdowns — e.g.
+a plain button — closes the open menu but keeps the bar engaged, so
+hovering back onto a trigger reopens a menu without another click.
+Previously such a hover did nothing (the open menu stayed put), and the bar
+was only ever “active” while a menu happened to be open. Sliding across the
+gaps between triggers still leaves the open menu alone, so menu-to-menu
+hovering stays seamless.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -766,8 +766,16 @@ Menubar behaviors:
 
 - renders `role="menubar"`; each dropdown trigger is a menubar item
 - at most one menu in the bar is open at a time
-- once any menu is open, hovering another trigger switches to that menu
-  without a click (matching macOS menubar behavior)
+- opening a trigger’s menu (by click or keyboard) engages the bar
+  (menu-mode). While engaged, hovering or focusing another trigger switches
+  to that menu without a click, matching the macOS menu bar
+- while engaged, hovering a non-menu control in the bar (e.g. a plain
+  button placed alongside the dropdowns) closes the open menu but keeps the
+  bar engaged, so hovering back onto a trigger reopens a menu; sliding
+  across the gaps between triggers leaves the open menu alone
+- a deliberate dismissal — **Escape**, a click outside the bar, or
+  selecting an item — leaves menu-mode, after which hovering a trigger no
+  longer opens its menu until a menu is opened again to re-engage the bar
 - **←/→** move between menus, wrapping at the ends: with the bar focused
   they move focus between triggers, and while a menu is open they slide the
   open menu to the adjacent trigger — unless the active item is a parent

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -461,7 +461,7 @@ function RootDropdown({
         }
     };
 
-    const closeDropdown = () => {
+    const closeDropdown = (options?: { keepMenubarEngaged?: boolean }) => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
@@ -472,6 +472,13 @@ function RootDropdown({
         if (closingTimerRef.current != null) {
             clearTimeout(closingTimerRef.current);
             closingTimerRef.current = null;
+        }
+        // A self-dismissal — Escape, an outside click, or an item selection —
+        // takes an enclosing menubar out of menu-mode. Switching menus,
+        // clearing the open menu on hover, and focus changes pass
+        // keepMenubarEngaged to stay in menu-mode.
+        if (menubar && dropdownElement && !options?.keepMenubarEngaged) {
+            menubar.notifyClosed(dropdownElement);
         }
     };
 
@@ -491,7 +498,7 @@ function RootDropdown({
     useEffect(() => {
         if (!menubar || !dropdownElement) return;
         return menubar.registerMember({
-            close: closeDropdown,
+            close: () => closeDropdown({ keepMenubarEngaged: true }),
             element: dropdownElement,
             focusTrigger,
             isOpen: () => isOpenRef.current,
@@ -1037,7 +1044,10 @@ function RootDropdown({
                 return;
             }
 
-            closeDropdown();
+            // Losing focus — including the focus shift when the body unmounts
+            // on close — doesn’t end a menubar’s menu-mode; that takes a
+            // deliberate dismissal (Escape, outside click, item select).
+            closeDropdown({ keepMenubarEngaged: true });
         };
 
         document.addEventListener('focusin', handleGlobalFocusIn);

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -90,6 +90,102 @@ describe('@acusti/dropdown Menubar', () => {
         expect(screen.queryByTestId('edit-menu')).toBe(null);
     });
 
+    const renderMenubarWithButton = () =>
+        render(
+            <Menubar>
+                <Dropdown>
+                    File
+                    <ul data-testid="file-menu">
+                        <li data-ukt-item>New</li>
+                    </ul>
+                </Dropdown>
+                <button type="button">Run</button>
+                <Dropdown>
+                    Edit
+                    <ul data-testid="edit-menu">
+                        <li data-ukt-item>Undo</li>
+                    </ul>
+                </Dropdown>
+            </Menubar>,
+        );
+
+    it('clears the open menu when the pointer moves onto a non-menu button, staying engaged', async () => {
+        const user = userEvent.setup();
+        renderMenubarWithButton();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        // Hovering the plain button closes the open menu…
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Run' }));
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+
+        // …but the bar stays engaged, so hovering a trigger reopens a menu
+        // without another click
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.getByTestId('edit-menu')).toBeTruthy();
+    });
+
+    it('keeps the open menu when the pointer crosses the bar’s own padding', async () => {
+        const user = userEvent.setup();
+        renderMenubarWithButton();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        // The gaps between triggers aren’t interactive controls, so sliding
+        // across them leaves the open menu alone (seamless menu-to-menu hover)
+        fireEvent.mouseOver(screen.getByRole('menubar'));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+    });
+
+    it('stops reopening menus on hover once the bar is dismissed with Escape', async () => {
+        const user = userEvent.setup();
+        renderMenubarWithButton();
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.keyboard('{Escape}');
+        expect(screen.queryByTestId('file-menu')).toBe(null);
+
+        // Escape is a deliberate dismissal, so it leaves menu-mode: hovering a
+        // trigger no longer opens a menu until a click re-engages the bar
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.queryByTestId('edit-menu')).toBe(null);
+    });
+
+    it('drops engagement when the dropdown that engaged the bar unmounts', async () => {
+        const user = userEvent.setup();
+        const Bar = ({ showFile }: { showFile: boolean }) => (
+            <Menubar>
+                {showFile ? (
+                    <Dropdown>
+                        File
+                        <ul data-testid="file-menu">
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                ) : null}
+                <Dropdown>
+                    Edit
+                    <ul data-testid="edit-menu">
+                        <li data-ukt-item>Undo</li>
+                    </ul>
+                </Dropdown>
+            </Menubar>
+        );
+        const { rerender } = render(<Bar showFile />);
+
+        await user.click(screen.getByRole('button', { name: 'File' }));
+        expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+        // Remove the engaged dropdown without dismissing it. With the engaging
+        // member gone, the bar is no longer engaged, so hovering another
+        // trigger doesn’t reopen a menu.
+        rerender(<Bar showFile={false} />);
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        expect(screen.queryByTestId('edit-menu')).toBe(null);
+    });
+
     it('switches the open menu when focus moves to another trigger', async () => {
         const user = userEvent.setup();
         renderMenubar();

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -29,11 +29,20 @@ const compareDocumentOrder = (a: MenubarMember, b: MenubarMember) => {
     return 0;
 };
 
+// Matches interactive controls that live in the menubar without being dropdown
+// triggers (e.g. a plain button). Hovering one clears the open menu without
+// disengaging the menubar.
+const NON_MENU_CONTROL_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
+
 // Combines sibling Dropdowns into a single menu, like the system menu in the
 // top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
 // once any menu is open, hovering or focusing another trigger switches to it.
 export default function Menubar({ children, className, style }: MenubarProps) {
     const membersRef = useRef<Set<MenubarMember>>(new Set());
+    // The member that engaged the bar (menu-mode). It keeps pointing at that
+    // member even if that member’s menu was closed by hovering a non-menu
+    // control, which allows the bar to stay engaged even with nothing open.
+    const engagedMemberRef = useRef<HTMLElement | null>(null);
 
     const getOrderedMembersRef = useRef(() =>
         Array.from(membersRef.current).sort(compareDocumentOrder),
@@ -54,7 +63,16 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 members[nextIndex].open();
                 members[nextIndex].focusTrigger();
             },
+            notifyClosed(element: HTMLElement) {
+                // Only a dismissal of the member that engaged the bar ends
+                // menu-mode. Outside-click handling closes every mounted
+                // dropdown, so ignore the closes reported for the rest.
+                if (engagedMemberRef.current === element) {
+                    engagedMemberRef.current = null;
+                }
+            },
             notifyOpened(element: HTMLElement) {
+                engagedMemberRef.current = element;
                 for (const member of membersRef.current) {
                     if (member.element !== element && member.isOpen()) {
                         member.close();
@@ -88,15 +106,31 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         members[(index + direction + members.length) % members.length].focusTrigger();
     };
 
-    // Once any menu is open, moving hover or focus to another member’s
-    // trigger switches to it (opening notifies the menubar, which closes
-    // the other open member)
+    // Once the bar is engaged, moving hover or focus onto another member’s
+    // trigger switches to it (opening notifies the menubar, which closes the
+    // other open member), while moving onto a non-menu control clears the open
+    // menu but keeps the bar engaged.
     const switchToMemberAt = (eventTarget: HTMLElement) => {
+        if (engagedMemberRef.current == null) return;
         const members = getOrderedMembers();
-        if (!members.some((member) => member.isOpen())) return;
+        // If the member that engaged the bar is gone (e.g. it unmounted while
+        // engaged) the bar is no longer engaged, so hover can’t reopen menus
+        if (!members.some((m) => m.element === engagedMemberRef.current)) {
+            engagedMemberRef.current = null;
+            return;
+        }
         const member = members.find((m) => m.element.contains(eventTarget));
-        if (!member || member.isOpen()) return;
-        member.open();
+        if (member) {
+            if (!member.isOpen()) member.open();
+            return;
+        }
+        // Not over a menu trigger: only a real non-menu control (not the bar’s
+        // padding or the gaps between triggers) clears the open menu — this is
+        // a menubar-driven close, so the members stay engaged.
+        if (!eventTarget.closest(NON_MENU_CONTROL_SELECTOR)) return;
+        for (const openMember of members) {
+            if (openMember.isOpen()) openMember.close();
+        }
     };
 
     const handleFocus = (event: ReactFocusEvent<HTMLDivElement>) => {

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -20,6 +20,7 @@ export const DropdownContext = createContext<DropdownContextValue | null>(null);
 
 export type MenubarContextValue = {
     moveOpen: (fromElement: HTMLElement, direction: -1 | 1) => void;
+    notifyClosed: (element: HTMLElement) => void;
     notifyOpened: (element: HTMLElement) => void;
     registerMember: (member: MenubarMember) => () => void;
 };


### PR DESCRIPTION
## What

Gives `@acusti/dropdown`'s `Menubar` an explicit *menu-mode* so a plain button (or other non-menu control) placed alongside the dropdowns behaves the way you'd expect in a menu bar.

Reported from real use: a menu bar with 5 dropdowns and 2 non-dropdown buttons. Clicking a dropdown opened it and hovering another dropdown switched to it, but hovering one of the plain buttons did nothing — the last menu just stayed open. It felt wrong: hovering a non-menu control should dismiss the open menu, while the bar stays "in menu-mode" so hovering back onto a dropdown reopens it.

## Why it behaved that way

The bar had no explicit active state — "active" was synonymous with *"a member dropdown is open."* So `switchToMemberAt` returned early when nothing was open, and did nothing when the pointer wasn't over a dropdown member.

## The change (native / sticky model)

- Track menu-mode explicitly via the member that engaged the bar.
- **Engage** when any menu opens.
- **Disengage** only on a deliberate dismissal — Escape, a click outside the bar, or selecting an item — routed through a new `notifyClosed` on the menubar context that `Dropdown` calls for self-dismissals only.
- While engaged, hovering a **non-menu control** clears the open menu but keeps the bar engaged, so hovering back onto a trigger reopens a menu without another click.
- Menubar-driven closes (switching menus, the hover-to-clear) and focus-out keep the bar engaged; sliding across the **gaps** between triggers leaves the open menu alone, so menu-to-menu hovering stays seamless.

Non-menu controls are matched by `a[href], button, input, select, textarea, [tabindex]` — a real control clears the open menu, the bar's own padding/gaps don't.

## Notes / decisions worth a look

- **Tab-away stays engaged** (consistent with the sticky model, and it sidesteps a spurious disengage when the closing menu's body unmounts and focus shifts).
- **Clicking a plain button disengages** (it's a committed action / outside-the-dropdown mousedown) — the one spot where hovering and clicking a bare button differ.

## Tests

Added Menubar coverage: hovering a non-menu button clears the open menu while staying engaged; crossing the bar's padding keeps the open menu; Escape ends menu-mode so hover no longer reopens. Full package suite green (74 tests); `tsc`, `oxlint`, `oxfmt` clean. Includes a changeset and README update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)