### PR TITLE
Add an openOnHover prop to open a Dropdown on pointer hover

### DIFF
--- a/.changeset/dropdown-open-on-hover.md
+++ b/.changeset/dropdown-open-on-hover.md
@@ -1,0 +1,14 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add an `openOnHover` prop to open a Dropdown on pointer hover
+
+Setting `openOnHover` opens the dropdown as soon as the pointer hovers the
+trigger. It closes a short moment after the pointer leaves the trigger and
+body entirely — the close is delayed so crossing the gap between them, or a
+placement fallback moving the body somewhere the pointer briefly leaves,
+doesn’t flicker-close it. Click and keyboard opening (Enter/Space while
+focused) keep working as usual alongside it. The prop only applies to a
+top-level Dropdown; a submenu already discloses on hover intent, so
+`openOnHover` is ignored (and warns) on a nested Dropdown.

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -661,6 +661,41 @@ export const WithGaps: Story = {
     },
 };
 
+export const OpenOnHover: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `openOnHover`, the dropdown opens as soon as the pointer hovers the trigger and closes a short moment after the pointer leaves the trigger and body entirely (the close is delayed so crossing the gap between them, or pausing over either, doesn’t flicker-close it). Click and keyboard opening keep working alongside it. Best for a menu you can take in at a glance — an account menu, a preview — so a stray hover doesn’t reveal something the user has to click into.',
+            },
+        },
+    },
+    render() {
+        return (
+            <Dropdown className="open-on-hover-example" onSubmitItem={fn()} openOnHover>
+                <button
+                    className="uktdropdown-trigger"
+                    style={{
+                        alignItems: 'center',
+                        display: 'inline-flex',
+                        gap: '0.25rem',
+                    }}
+                    type="button"
+                >
+                    Account
+                    <ChevronDownIcon />
+                </button>
+                <ul>
+                    <li data-ukt-value="profile">Profile</li>
+                    <li data-ukt-value="settings">Settings</li>
+                    <li data-ukt-value="billing">Billing</li>
+                    <li className="separator" />
+                    <li data-ukt-value="sign-out">Sign out</li>
+                </ul>
+            </Dropdown>
+        );
+    },
+};
+
 export const MenubarAppMenu: Story = {
     parameters: {
         docs: {

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -267,6 +267,14 @@ type Props = {
     onMouseUp?: (event: React.MouseEvent<HTMLElement>) => unknown;
     onOpen?: () => unknown;
     /**
+     * Opens the dropdown when the pointer hovers the trigger, and closes it a
+     * short moment after the pointer leaves the trigger and body entirely (the
+     * close is delayed so crossing the gap between them, or pausing over
+     * either, doesn’t flicker-close it). Click and keyboard opening keep
+     * working as usual alongside it.
+     */
+    openOnHover?: boolean;
+    /**
      * Called when an item is selected. The payload includes:
      * - element: The DOM element that was clicked
      * - event: The click or keyboard event
@@ -426,6 +434,29 @@ function MultiSelectDropdown() {
     );
 }
 ```
+
+### Open on Hover
+
+```tsx
+function HoverMenu() {
+    return (
+        <Dropdown openOnHover>
+            <button type="button">Account</button>
+            <ul>
+                <li>Profile</li>
+                <li>Settings</li>
+                <li>Sign out</li>
+            </ul>
+        </Dropdown>
+    );
+}
+```
+
+Click and keyboard opening (Enter/Space while focused) still work —
+hovering is an additional way in, not a replacement. This makes the most
+sense for a dropdown whose body is inspectable at a glance (a short menu, a
+preview card); for anything the user needs to click into, keep the default
+click-to-open behavior so a stray hover doesn’t pop it open.
 
 ### Dropdown with Interactive Content
 
@@ -645,9 +676,11 @@ Most props keep their meaning, scoped to the submenu:
 - `className`/`style`: applied to the parent item element
 
 Props that only make sense at the top level (`allowCreate`, `allowEmpty`,
-`isOpenOnMount`, `isSearchable`, `keepOpenOnSubmit`, `name`, `placeholder`,
-`tabIndex`, `value`) are ignored on a nested dropdown and warn
-(unconditionally, matching the children-count misuse error).
+`isOpenOnMount`, `isSearchable`, `keepOpenOnSubmit`, `name`, `openOnHover`,
+`placeholder`, `tabIndex`, `value`) are ignored on a nested dropdown and
+warn (unconditionally, matching the children-count misuse error). A submenu
+already discloses on hover intent — see [Submenus](#submenus) — so
+`openOnHover` has nothing to add there.
 
 ### Submenu placement and styling
 

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -1610,4 +1610,95 @@ describe('@acusti/dropdown', () => {
             );
         });
     });
+
+    describe('openOnHover', () => {
+        it('does not open on hover by default', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    <ul data-testid="dropdown-list">
+                        <li>Option</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.hover(screen.getByRole('button'));
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            expect(screen.queryByTestId('dropdown-list')).toBe(null);
+        });
+
+        it('opens the dropdown immediately on hover', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown openOnHover>
+                    <ul data-testid="dropdown-list">
+                        <li>Option</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.hover(screen.getByRole('button'));
+            expect(screen.getByTestId('dropdown-list')).toBeTruthy();
+        });
+
+        it('closes after the pointer leaves the trigger and body', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown openOnHover>
+                    <ul data-testid="dropdown-list">
+                        <li>Option</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button');
+            await user.hover(trigger);
+            expect(screen.getByTestId('dropdown-list')).toBeTruthy();
+
+            await user.unhover(trigger);
+            await waitFor(
+                () => expect(screen.queryByTestId('dropdown-list')).toBe(null),
+                { timeout: 1000 },
+            );
+        });
+
+        it('stays open when the pointer moves from the trigger into the body before the close delay elapses', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown openOnHover>
+                    <ul data-testid="dropdown-list">
+                        <li>Option</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button');
+            await user.hover(trigger);
+            expect(screen.getByTestId('dropdown-list')).toBeTruthy();
+
+            await user.unhover(trigger);
+            await user.hover(screen.getByTestId('dropdown-list'));
+
+            // held well past the close-intent delay
+            await new Promise((resolve) => setTimeout(resolve, 300));
+            expect(screen.getByTestId('dropdown-list')).toBeTruthy();
+        });
+
+        it('still opens on a click without a preceding hover (e.g. touch)', () => {
+            render(
+                <Dropdown openOnHover>
+                    <ul data-testid="dropdown-list">
+                        <li>Option</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // A tap fires mousedown/mouseup with no hover in between, so the
+            // click-to-open path — not hover — is what opens it here
+            const trigger = screen.getByRole('button');
+            fireEvent.mouseDown(trigger);
+            fireEvent.mouseUp(trigger);
+            expect(screen.getByTestId('dropdown-list')).toBeTruthy();
+        });
+    });
 });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -105,6 +105,14 @@ export type Props = {
     onOpen?: () => unknown;
     onSubmitItem?: (payload: Item) => void;
     /**
+     * Opens the dropdown when the pointer hovers the trigger, and closes it a
+     * short moment after the pointer leaves the trigger and body entirely (the
+     * close is delayed so crossing the gap between them, or pausing over
+     * either, doesn’t flicker-close it). Click and keyboard opening keep
+     * working as usual alongside it.
+     */
+    openOnHover?: boolean;
+    /**
      * Only usable in conjunction with {isSearchable: true}.
      * Used as search input’s placeholder.
      */
@@ -152,6 +160,11 @@ const SUBMENU_DISCLOSURE_DELAY = 200;
 // on every move, so it only fires on a pause — motion keeps the submenu open
 const SAFE_AREA_TIMEOUT = 300;
 
+// props.openOnHover opens immediately on hover, but closing waits a beat so
+// that crossing the trigger/body gap (or a placement fallback moving the body
+// somewhere the pointer briefly leaves) doesn’t flicker-close it
+const HOVER_CLOSE_DELAY = 150;
+
 export default function Dropdown(props: Props) {
     const parentDropdown = useContext(DropdownContext);
     // A Dropdown nested inside a menu dropdown’s body renders as a submenu
@@ -183,6 +196,7 @@ function RootDropdown({
     onMouseUp,
     onOpen,
     onSubmitItem,
+    openOnHover,
     placeholder,
     style: styleFromProps,
     tabIndex,
@@ -222,6 +236,7 @@ function RootDropdown({
     const safeAreaRef = useRef<{ apex: Point; parent: HTMLElement } | null>(null);
     const safeAreaTimerRef = useRef<null | TimeoutID>(null);
     const wasInSafeAreaRef = useRef<boolean>(false);
+    const hoverCloseTimerRef = useRef<null | TimeoutID>(null);
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
@@ -461,12 +476,24 @@ function RootDropdown({
         }
     };
 
+    const clearHoverCloseTimer = () => {
+        if (hoverCloseTimerRef.current != null) {
+            clearTimeout(hoverCloseTimerRef.current);
+            hoverCloseTimerRef.current = null;
+        }
+    };
+
+    // Clear props.openOnHover’s close timer on unmount so it can’t fire against
+    // unmounted DOM
+    useEffect(() => clearHoverCloseTimer, []);
+
     const closeDropdown = (options?: { keepMenubarEngaged?: boolean }) => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
         clearDisclosureTimer();
         clearSafeAreaTimer();
+        clearHoverCloseTimer();
         safeAreaRef.current = null;
         wasInSafeAreaRef.current = false;
         if (closingTimerRef.current != null) {
@@ -480,6 +507,28 @@ function RootDropdown({
         if (menubar && dropdownElement && !options?.keepMenubarEngaged) {
             menubar.notifyClosed(dropdownElement);
         }
+    };
+
+    // The pointer entered the trigger or (if open) the body: cancel any
+    // pending close and, if props.openOnHover and not already open, open now
+    const handleDropdownMouseEnter = () => {
+        clearHoverCloseTimer();
+        if (!openOnHover || isOpenRef.current) return;
+        setIsOpen(true);
+        setIsOpening(false);
+    };
+
+    // The pointer left the trigger and body entirely: if open, arm the
+    // close-intent timer (a re-entry before it fires cancels it above, so
+    // crossing the trigger/body gap doesn’t flicker)
+    const handleDropdownMouseLeave = () => {
+        if (!openOnHover || !isOpenRef.current || hoverCloseTimerRef.current != null) {
+            return;
+        }
+        hoverCloseTimerRef.current = setTimeout(() => {
+            hoverCloseTimerRef.current = null;
+            closeDropdown();
+        }, HOVER_CLOSE_DELAY);
     };
 
     const focusTrigger = () => {
@@ -1191,6 +1240,8 @@ function RootDropdown({
                 })}
                 onClick={onClick}
                 onMouseDown={handleMouseDown}
+                onMouseEnter={handleDropdownMouseEnter}
+                onMouseLeave={handleDropdownMouseLeave}
                 onMouseMove={handleMouseMove}
                 onMouseOut={handleMouseOut}
                 onMouseOver={handleMouseOver}
@@ -1233,6 +1284,7 @@ const INERT_SUBMENU_PROPS = [
     'isSearchable',
     'keepOpenOnSubmit',
     'name',
+    'openOnHover',
     'placeholder',
     'tabIndex',
     'value',


### PR DESCRIPTION
## What

Adds an `openOnHover` prop to `<Dropdown>`. When set, the dropdown opens as soon as the pointer hovers the trigger and closes a short moment after the pointer leaves the trigger and body. Click and keyboard opening (Enter/Space while focused) keep working alongside it.

## Why

A `Dropdown` could previously only be opened by click or keyboard. Some menu-like surfaces — an account menu, a preview card — read better opening on hover, matching the macOS menu-bar feel the component already emulates for submenus and `Menubar`.

## How it works

- **Open**: immediate on hovering the trigger — no delay (this was tuned down from an earlier intent-delay design based on testing; a hover menu felt better opening at once).
- **Close**: leaving the trigger *and* body entirely arms a 150ms timer; re-entering either before it fires cancels the close, so crossing the trigger/body gap (or a placement fallback briefly moving the body out from under the pointer) doesn't flicker-close it.
- The close timer is cleared on unmount and on every close path, following the existing `disclosureTimer` / `safeAreaTimer` patterns in the component.
- Top-level only: a submenu already discloses on hover intent, so `openOnHover` is ignored (and warns) on a nested `Dropdown`, matching the other inert-on-submenu props.

## Notes for reviewers

- The feature is purely additive — default behavior is unchanged, hence a `minor` changeset.
- New tests cover: no hover-open by default, immediate open on hover, close-on-leave, staying open when the pointer moves trigger→body, and a click/tap (no preceding hover) still opening.
- Validated locally: `bun run build`, `bun run test` (233 passing), `bun run tsc`, `bun run lint`, `bun run format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)