### PR TITLE
Rename dropdown position-try fallbacks to start/end, with logical values

### DIFF
--- a/.changeset/dropdown-rename-position-try-fallbacks.md
+++ b/.changeset/dropdown-rename-position-try-fallbacks.md
@@ -1,0 +1,53 @@
+---
+'@acusti/dropdown': major
+---
+
+Rename the body’s `@position-try` fallback blocks from `--uktdd-top-left` /
+`--uktdd-top-right` / `--uktdd-bottom-left` / `--uktdd-bottom-right` to
+`--uktdd-top-start` / `--uktdd-top-end` / `--uktdd-bottom-start` /
+`--uktdd-bottom-end`, and switch their `position-area` values (and the
+default `--uktdd-body-position-area`) from physical `top`/`bottom` +
+`span-left`/`span-right` to logical `block-start`/`block-end` +
+`span-inline-start`/`span-inline-end`.
+
+The old names described the direction the body extends toward, which reads
+backwards from what they actually mean: each block is named for the edge
+that stays flush with the trigger, not the direction the body grows —
+`top-left` opened above the trigger with their **left** edges flush, so the
+body extended toward the right. Renaming to `start`/`end` removes that
+ambiguity and matches the submenu’s fallback
+(`--uktdd-submenu-inline-start`), which already used logical keywords.
+
+Switching to logical values also makes the default direction (and all four
+named recipes) RTL-correct: the body now opens toward the trigger’s actual
+inline-end edge in RTL instead of always opening toward the physical right.
+This is a no-op for LTR documents, where `inline-end` is `right`.
+`block-start`/`block-end` replace `top`/`bottom` rather than mixing with
+the logical inline keywords — `position-area` doesn’t allow pairing a
+physical keyword on one axis with a logical one on the other — and read as
+`top`/`bottom` in the near-universal horizontal-tb writing mode.
+
+**Migration:** if you referenced any of the renamed `@position-try` block
+names in `--uktdd-body-position-try-fallbacks`, or set
+`--uktdd-body-position-area`/`--uktdd-submenu-position-area` directly with
+`top`/`bottom`/`span-left`/`span-right`, update them:
+
+```css
+/* before */
+.my-dropdown {
+    --uktdd-body-position-area: bottom span-left;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+}
+
+/* after */
+.my-dropdown {
+    --uktdd-body-position-area: block-end span-inline-start;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+}
+```
+
+See the README’s
+[Changing the Default Direction](https://github.com/acusti/uikit/blob/main/packages/dropdown/README.md#changing-the-default-direction)
+section for the full cheatsheet of the four direction pairs.

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -15,6 +15,10 @@
         height: calc(200vh - 110px);
         width: calc(200vw - 270px);
     }
+
+    &:has(.direction-recipes) {
+        height: 480px;
+    }
 }
 
 .sb-story {
@@ -119,9 +123,9 @@
 
 .searchable-with-label,
 .searchable-and-allow-create {
-    --uktdd-body-position-area: bottom span-left;
+    --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 
     input,
     .uktdropdown-body {
@@ -130,9 +134,9 @@
 }
 
 .css-value-input-trigger {
-    --uktdd-body-position-area: bottom span-left;
+    --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 
     .uktdropdown-body {
         /* a horizontal alignment nudge, not a trigger↔body gap; set as a raw
@@ -247,6 +251,57 @@
 .gap-example {
     --uktdd-body-gap: 10px;
     --uktdd-submenu-gap: 8px;
+}
+
+/* the four --uktdd-body-position-area / --uktdd-body-position-try-fallbacks
+   recipes from the README’s direction cheatsheet. position-try-order:
+   most-height picks whichever side of the viewport has more room, not
+   merely “enough” room, so the two rows sit close to the canvas’s top and
+   bottom edges respectively — the bottom-opening pair near the top (room
+   below dominates) and the top-opening pair near the bottom (room above
+   dominates) — so each recipe’s primary placement wins on its own terms
+   instead of most-height overriding it toward whichever edge happens to
+   have more empty canvas */
+.direction-recipes {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    block-size: 100%;
+    padding-block: 1.5rem;
+}
+
+.direction-recipes-row {
+    display: flex;
+    justify-content: center;
+    gap: 5rem;
+}
+
+.direction-recipes .uktdropdown-body {
+    inline-size: 140px;
+}
+
+.direction-bottom-start {
+    --uktdd-body-position-area: block-end span-inline-end;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end;
+}
+
+.direction-bottom-end {
+    --uktdd-body-position-area: block-end span-inline-start;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+}
+
+.direction-top-start {
+    --uktdd-body-position-area: block-start span-inline-end;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end;
+}
+
+.direction-top-end {
+    --uktdd-body-position-area: block-start span-inline-start;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
 }
 
 /* ---- Fixed Header Styles ---- */
@@ -393,9 +448,9 @@
     }
 
     .avatar-menu {
-        --uktdd-body-position-area: bottom span-left;
+        --uktdd-body-position-area: block-end span-inline-start;
         --uktdd-body-position-try-fallbacks:
-            --uktdd-top-right, --uktdd-top-left, --uktdd-bottom-right;
+            --uktdd-top-end, --uktdd-top-start, --uktdd-bottom-end;
 
         .avatar-profile,
         .avatar-edit {

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -589,6 +589,51 @@ export const CenteredMenu: Story = {
     },
 };
 
+const DIRECTION_RECIPE_ROWS = [
+    [
+        { className: 'direction-bottom-start', label: 'Bottom Start (default)' },
+        { className: 'direction-bottom-end', label: 'Bottom End' },
+    ],
+    [
+        { className: 'direction-top-start', label: 'Top Start' },
+        { className: 'direction-top-end', label: 'Top End' },
+    ],
+] as const;
+
+export const DirectionRecipes: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The bottom pair sits near the top of the canvas and the top pair near the bottom, so each opens toward the side with more room rather than `position-try-order: most-height` overriding it toward whichever side has more empty canvas.',
+            },
+        },
+    },
+    render() {
+        return (
+            <div className="direction-recipes">
+                {DIRECTION_RECIPE_ROWS.map((row) => (
+                    <div className="direction-recipes-row" key={row[0].className}>
+                        {row.map(({ className, label }) => (
+                            <Dropdown
+                                className={className}
+                                key={className}
+                                onSubmitItem={fn()}
+                            >
+                                {label}
+                                <ul>
+                                    <li data-ukt-value="one">Item one</li>
+                                    <li data-ukt-value="two">Item two</li>
+                                    <li data-ukt-value="three">Item three</li>
+                                </ul>
+                            </Dropdown>
+                        ))}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+};
+
 export const SubmenuDropdown: Story = {
     args: {
         children: [

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -514,9 +514,9 @@ Example:
 
 ```css
 .settings-dropdown {
-    --uktdd-body-position-area: bottom span-left;
+    --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
     --uktdd-body-gap: 8px;
 }
 
@@ -527,6 +527,54 @@ Example:
 
 This approach keeps the public React API small while still allowing precise
 placement and sizing control when a product surface needs it.
+
+### Changing the Default Direction
+
+`--uktdd-body-position-area` and `--uktdd-body-position-try-fallbacks`
+always change together. `--uktdd-body-position-area` is the primary
+placement, used whenever it fits in the viewport — that’s what actually
+determines the direction a dropdown opens by default. The fallbacks list is
+only consulted when the primary placement doesn’t fit, so overriding it
+alone changes nothing in the common case where the primary already fits.
+Overriding the primary alone works, but leaves behind a fallback cascade
+tuned for the old primary — in a cramped viewport, the dropdown can fall
+back toward the direction you just moved away from.
+
+The four `@position-try` blocks the component ships (`--uktdd-top-start`,
+`--uktdd-top-end`, `--uktdd-bottom-start`, `--uktdd-bottom-end`) are named
+for the aligned edge, not the direction the body extends toward: `start`
+opens with the body’s inline-start edge flush with the trigger’s
+inline-start edge (extending toward inline-end), and `end` is the mirror
+image. This also means they’re RTL-safe — `start`/`end` follow the
+document’s writing direction the way `left`/`right` wouldn’t. The values
+pair `block-start`/`block-end` with `span-inline-start`/`span-inline-end`
+rather than `top`/`bottom` — `position-area` doesn’t allow mixing a
+physical keyword on one axis with a logical one on the other — though
+`block-start`/`block-end` read as `top`/`bottom` in the near-universal
+horizontal-tb writing mode.
+
+Pick the row matching the direction you want, and set both variables to its
+pair:
+
+| Direction                           | `--uktdd-body-position-area`    | `--uktdd-body-position-try-fallbacks`                         |
+| ----------------------------------- | ------------------------------- | ------------------------------------------------------------- |
+| Bottom, start-aligned (the default) | `block-end span-inline-end`     | `--uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end`      |
+| Bottom, end-aligned                 | `block-end span-inline-start`   | `--uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start`    |
+| Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end`   |
+| Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start` |
+
+For example, to make a dropdown open upward and end-aligned (useful for a
+trigger pinned to the bottom of the viewport, near the inline-end edge):
+
+```css
+.bottom-toolbar-dropdown {
+    --uktdd-body-position-area: block-start span-inline-start;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
+}
+```
+
+See the `DirectionRecipes` story for a live demo of all four.
 
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever
@@ -548,9 +596,9 @@ the menu size itself from its contents.
 
 ```css
 .avatar-menu {
-    --uktdd-body-position-area: bottom span-left;
+    --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-right, --uktdd-top-left, --uktdd-bottom-right;
+        --uktdd-top-end, --uktdd-top-start, --uktdd-bottom-end;
 }
 ```
 

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -14,9 +14,9 @@
     --uktdd-body-pad-right: 0.6875em;
     --uktdd-body-pad-top: 0.5em;
     --uktdd-body-min-width: min(50px, 100%);
-    --uktdd-body-position-area: bottom span-right;
+    --uktdd-body-position-area: block-end span-inline-end;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-left, --uktdd-bottom-right, --uktdd-top-right;
+        --uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end;
     /* gap between the trigger and the body, applied as a symmetric
        margin-block so it lands on whichever side the body attaches to and
        auto-reverses when position-try flips it above/below the trigger. A
@@ -214,20 +214,29 @@ div.uktdropdown-body {
         var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
 }
 
-@position-try --uktdd-top-left {
-    position-area: top span-right;
+/* Named for the aligned edge (start/end), not the direction the body
+   extends toward — e.g. top-start opens above the trigger with their
+   inline-start edges flush, and the body can extend past the trigger’s
+   inline-end edge. Both axes use logical keywords (block-start/-end,
+   span-inline-start/-end rather than top/bottom, span-left/-right):
+   position-area doesn’t allow mixing a physical keyword on one axis with a
+   logical one on the other, and logical keeps the alignment correct in
+   RTL. block-start/block-end read as top/bottom in the near-universal
+   horizontal-tb writing mode. */
+@position-try --uktdd-top-start {
+    position-area: block-start span-inline-end;
 }
 
-@position-try --uktdd-bottom-left {
-    position-area: bottom span-right;
+@position-try --uktdd-bottom-start {
+    position-area: block-end span-inline-end;
 }
 
-@position-try --uktdd-bottom-right {
-    position-area: bottom span-left;
+@position-try --uktdd-bottom-end {
+    position-area: block-end span-inline-start;
 }
 
-@position-try --uktdd-top-right {
-    position-area: top span-left;
+@position-try --uktdd-top-end {
+    position-area: block-start span-inline-start;
 }
 
 @position-try --uktdd-submenu-inline-start {


### PR DESCRIPTION
## Summary

- **Breaking:** rename the body's `@position-try` fallback blocks from `--uktdd-top-left`/`--uktdd-top-right`/`--uktdd-bottom-left`/`--uktdd-bottom-right` to `--uktdd-top-start`/`--uktdd-top-end`/`--uktdd-bottom-start`/`--uktdd-bottom-end`. The old names described the direction the body extends toward, which reads backwards from what they mean — `top-left` opened above the trigger with their **left** edges flush, so the body extended toward the right.
- Switch `position-area` (default + all four named recipes) from physical `top`/`bottom` + `span-left`/`span-right` to logical `block-start`/`block-end` + `span-inline-start`/`span-inline-end`, matching the submenu's already-logical `--uktdd-submenu-inline-start` convention and making the default direction RTL-correct. (`position-area` doesn't allow mixing a physical keyword on one axis with a logical one on the other, so `block-start`/`block-end` replace `top`/`bottom` rather than pairing with the logical inline keywords — they still read as `top`/`bottom` in the near-universal horizontal-tb writing mode.)
- Add a "Changing the Default Direction" README section explaining why `--uktdd-body-position-area` and `--uktdd-body-position-try-fallbacks` must change together, plus a cheatsheet of the four direction pairs, and fix the pre-existing recipe examples for the rename.
- Add a `DirectionRecipes` story demonstrating all four placement recipes live.

## Test plan

- [x] `bun run build`
- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run tsc`
- [x] `bun run format:check`
- [x] Verified all four direction recipes visually in a real browser (Storybook + Playwright), confirming each opens in the documented direction


---
_Generated by [Claude Code](https://claude.ai/code/session_01UrvQmnep2MJtJ8b7kfwaoo)_