### PR TITLE
Dropdown: reveal the current value on open + proper listbox/menu item roles

### DIFF
--- a/.changeset/dropdown-listbox-roles.md
+++ b/.changeset/dropdown-listbox-roles.md
@@ -10,5 +10,8 @@ menu — and always `menuitem` inside a submenu, which is itself a menu. The
 `<ul>`/`<ol>` wrappers around items get `role="presentation"` so the
 listbox/menu owns its items directly instead of through an intervening
 list. A natively interactive item (button, link, input) and any item with a
-consumer-set role keep their own role. (`aria-selected` on the current
-option is set by the reveal-on-open behavior.)
+consumer-set role keep their own role, and a submenu parent item in a
+listbox gets no role at all (its disclosure ARIA is invalid on an
+`option`). (`aria-selected` on the current option is set by the
+reveal-on-open behavior — unless aria-selected is consumer-authored, in
+which case selection ARIA is left entirely to the consumer.)

--- a/.changeset/dropdown-listbox-roles.md
+++ b/.changeset/dropdown-listbox-roles.md
@@ -1,0 +1,14 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add listbox and menu item roles
+
+On open, the dropdown fills in the ARIA roles a consumer hasn’t set:
+`option` on items in a searchable (listbox) dropdown and `menuitem` in a
+menu — and always `menuitem` inside a submenu, which is itself a menu. The
+`<ul>`/`<ol>` wrappers around items get `role="presentation"` so the
+listbox/menu owns its items directly instead of through an intervening
+list. A natively interactive item (button, link, input) and any item with a
+consumer-set role keep their own role. (`aria-selected` on the current
+option is set by the reveal-on-open behavior.)

--- a/.changeset/dropdown-reveal-value-on-open.md
+++ b/.changeset/dropdown-reveal-value-on-open.md
@@ -1,0 +1,12 @@
+---
+'@acusti/dropdown': minor
+---
+
+Reveal the current value when the dropdown opens
+
+A controlled dropdown now opens with the item whose `data-ukt-value`
+matches `props.value` marked `aria-selected`, made the active item (so
+keyboard navigation starts from it), and scrolled into view — so a long
+list opens showing, and scrolled to, the current selection instead of the
+top. The persistent selection tint is themeable via the new
+`--uktdd-body-bg-color-selected` custom property.

--- a/.changeset/dropdown-reveal-value-on-open.md
+++ b/.changeset/dropdown-reveal-value-on-open.md
@@ -5,8 +5,10 @@
 Reveal the current value when the dropdown opens
 
 A controlled dropdown now opens with the item whose `data-ukt-value`
-matches `props.value` marked `aria-selected`, made the active item (so
-keyboard navigation starts from it), and scrolled into view — so a long
-list opens showing, and scrolled to, the current selection instead of the
-top. The persistent selection tint is themeable via the new
+matches `props.value` made the active item (so keyboard navigation starts
+from it) and scrolled into view — so a long list opens showing, and
+scrolled to, the current selection instead of the top. In a searchable
+(listbox) dropdown the item is also marked `aria-selected` (`aria-selected`
+isn’t valid on a `menuitem`, so menus get the active highlight without it).
+The persistent selection tint is themeable via the new
 `--uktdd-body-bg-color-selected` custom property.

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -368,6 +368,40 @@ export const LabelDifferentFromValue: Story = {
     },
 };
 
+export const OpensToCurrentValue: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A controlled dropdown opens with the item matching `props.value` marked `aria-selected`, made the active item (so keyboard navigation starts there), and scrolled into view. Here the value sits far down a long list, so opening jumps straight to it rather than the top. Theme the persistent selection tint with the `--uktdd-body-bg-color-selected` custom property.',
+            },
+        },
+    },
+    render() {
+        const items = Array.from({ length: 40 }, (_, index) => ({
+            label: `Item ${index + 1}`,
+            value: String(index + 1),
+        }));
+        const [value, setValue] = React.useState('31');
+        return (
+            <Dropdown
+                isSearchable
+                label="Item"
+                onSubmitItem={({ value: submitted }) => setValue(submitted)}
+                placeholder="Search items…"
+                value={value}
+            >
+                <ul>
+                    {items.map(({ label, value: itemValue }) => (
+                        <li data-ukt-value={itemValue} key={itemValue}>
+                            {label}
+                        </li>
+                    ))}
+                </ul>
+            </Dropdown>
+        );
+    },
+};
+
 export const CSSValueInputTrigger: Story = {
     args: {
         allowCreate: true,

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -959,8 +959,10 @@ Opening also reveals the current selection: the item matching `props.value`
 becomes the active item (so keyboard navigation starts from the current
 selection) and is scrolled into view. In a searchable (listbox) dropdown it
 additionally receives `aria-selected="true"` (`aria-selected` isn’t valid
-on a `menuitem`); the persistent tint on the selected item is themeable via
-the `--uktdd-body-bg-color-selected` custom property.
+on a `menuitem`) — unless you author `aria-selected` on items yourself, in
+which case the component leaves selection ARIA entirely to you, as with any
+ARIA you set. The persistent tint on the selected item is themeable via the
+`--uktdd-body-bg-color-selected` custom property.
 
 Submenus and menubars extend the same pattern automatically:
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -947,6 +947,21 @@ readers can associate the trigger with its popup. If your custom trigger
 already specifies any of these ARIA props, your values win — the component
 only fills in what you haven’t set.
 
+Item roles are filled in the same way when the body opens: items receive
+`role="option"` in a searchable (listbox) dropdown or `role="menuitem"` in
+a menu (always `menuitem` inside a submenu), and the `<ul>`/`<ol>` wrappers
+around them receive `role="presentation"` so the listbox or menu owns its
+items directly rather than through an intervening list. A natively
+interactive item (a button, link, or input) or one with a role you set
+yourself keeps its own role.
+
+Opening also reveals the current selection: the item matching `props.value`
+becomes the active item (so keyboard navigation starts from the current
+selection) and is scrolled into view. In a searchable (listbox) dropdown it
+additionally receives `aria-selected="true"` (`aria-selected` isn’t valid
+on a `menuitem`); the persistent tint on the selected item is themeable via
+the `--uktdd-body-bg-color-selected` custom property.
+
 Submenus and menubars extend the same pattern automatically:
 
 - parent items receive `aria-haspopup="menu"` and `aria-expanded`, and

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -5,6 +5,9 @@
     --uktdd-body-bg-color: #fff;
     --uktdd-body-bg-color-hover: rgb(105, 162, 249);
     --uktdd-body-color-hover: #fff;
+    /* the persistent tint on the item matching props.value (the current
+       selection), shown even after the active/hover highlight moves off it */
+    --uktdd-body-bg-color-selected: rgba(0, 0, 0, 0.06);
     --uktdd-body-buffer: 10px;
     --uktdd-body-max-height: calc(100dvh - var(--uktdd-body-buffer));
     --uktdd-body-max-width: calc(100dvw - var(--uktdd-body-buffer));
@@ -92,6 +95,10 @@
 
     &.has-items {
         user-select: none;
+    }
+
+    [aria-selected="true"] {
+        background-color: var(--uktdd-body-bg-color-selected);
     }
 
     [data-ukt-active] {

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -900,6 +900,52 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('revealing the current value on open', () => {
+        it('marks the item matching value active and aria-selected when opened', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown value="bold">
+                    Voice
+                    <ul>
+                        <li data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Voice' }));
+
+            const bold = screen.getByTestId('bold');
+            expect(bold.hasAttribute('data-ukt-active')).toBe(true);
+            expect(bold.getAttribute('aria-selected')).toBe('true');
+            expect(screen.getByTestId('warm').hasAttribute('data-ukt-active')).toBe(
+                false,
+            );
+        });
+
+        it('activates no item when the value matches none', async () => {
+            const user = userEvent.setup();
+            const { container } = render(
+                <Dropdown value="unknown">
+                    Voice
+                    <ul>
+                        <li data-ukt-value="warm">Warm</li>
+                        <li data-ukt-value="bold">Bold</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Voice' }));
+
+            expect(container.querySelector('[data-ukt-active]')).toBeNull();
+            expect(container.querySelector('[aria-selected="true"]')).toBeNull();
+        });
+    });
+
     describe('submitting with no active item', () => {
         it('does not call onSubmitItem when a non-searchable dropdown is submitted with nothing selected', async () => {
             const handleSubmitItem = vi.fn();

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -992,6 +992,93 @@ describe('@acusti/dropdown', () => {
             expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
         });
 
+        it('does not give a listbox submenu parent item role=option', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <ul>
+                        <li data-testid="plain" data-ukt-value="plain">
+                            Plain
+                        </li>
+                        <li data-testid="parent" data-ukt-item>
+                            Fruits
+                            <ul data-ukt-submenu="">
+                                <li data-testid="nested" data-ukt-value="apple">
+                                    Apple
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByTestId('plain').getAttribute('role')).toBe('option');
+            // A parent item’s aria-haspopup/aria-expanded are invalid on an
+            // option, so its role is left to the consumer
+            expect(screen.getByTestId('parent').hasAttribute('role')).toBe(false);
+            expect(screen.getByTestId('parent').getAttribute('aria-haspopup')).toBe(
+                'menu',
+            );
+            expect(screen.getByTestId('nested').getAttribute('role')).toBe('menuitem');
+        });
+
+        it('leaves selection ARIA alone when the consumer authors aria-selected', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable value="bold">
+                    <ul>
+                        <li aria-selected="true" data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            // The consumer marked warm selected, so the reveal must not add a
+            // second selected option for the item matching props.value
+            expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
+            expect(screen.getByTestId('warm').getAttribute('aria-selected')).toBe('true');
+        });
+
+        it('scopes the aria-selected move on submit to the popup body', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable keepOpenOnSubmit value="bold">
+                    <button aria-selected="true" data-testid="trigger" type="button">
+                        Voice
+                    </button>
+                    <ul>
+                        <li data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByTestId('trigger'));
+            expect(screen.getByTestId('bold').getAttribute('aria-selected')).toBe('true');
+
+            await user.click(screen.getByTestId('warm'));
+
+            expect(screen.getByTestId('warm').getAttribute('aria-selected')).toBe('true');
+            expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
+            // The move never reaches outside the popup body (e.g. a custom
+            // trigger’s own aria-selected)
+            expect(screen.getByTestId('trigger').getAttribute('aria-selected')).toBe(
+                'true',
+            );
+        });
+
         it('moves aria-selected to the submitted item when the body stays open', async () => {
             const user = userEvent.setup();
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -992,6 +992,30 @@ describe('@acusti/dropdown', () => {
             expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
         });
 
+        it('moves aria-selected to the submitted item when the body stays open', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable keepOpenOnSubmit value="bold">
+                    <ul>
+                        <li data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+            expect(screen.getByTestId('bold').getAttribute('aria-selected')).toBe('true');
+
+            await user.click(screen.getByTestId('warm'));
+
+            expect(screen.getByTestId('warm').getAttribute('aria-selected')).toBe('true');
+            expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
+        });
+
         it('does not override a consumer-set item role', async () => {
             const user = userEvent.setup();
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -901,7 +901,7 @@ describe('@acusti/dropdown', () => {
     });
 
     describe('revealing the current value on open', () => {
-        it('marks the item matching value active and aria-selected when opened', async () => {
+        it('makes the item matching value the active item when opened', async () => {
             const user = userEvent.setup();
             render(
                 <Dropdown value="bold">
@@ -919,9 +919,7 @@ describe('@acusti/dropdown', () => {
 
             await user.click(screen.getByRole('button', { name: 'Voice' }));
 
-            const bold = screen.getByTestId('bold');
-            expect(bold.hasAttribute('data-ukt-active')).toBe(true);
-            expect(bold.getAttribute('aria-selected')).toBe('true');
+            expect(screen.getByTestId('bold').hasAttribute('data-ukt-active')).toBe(true);
             expect(screen.getByTestId('warm').hasAttribute('data-ukt-active')).toBe(
                 false,
             );
@@ -943,6 +941,72 @@ describe('@acusti/dropdown', () => {
 
             expect(container.querySelector('[data-ukt-active]')).toBeNull();
             expect(container.querySelector('[aria-selected="true"]')).toBeNull();
+        });
+    });
+
+    describe('listbox and menu item roles', () => {
+        it('gives searchable dropdown items role=option and neutralizes the list', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable value="bold">
+                    <ul data-testid="list">
+                        <li data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByTestId('list').getAttribute('role')).toBe('presentation');
+            expect(screen.getByTestId('warm').getAttribute('role')).toBe('option');
+            expect(screen.getByTestId('bold').getAttribute('role')).toBe('option');
+            expect(screen.getByTestId('bold').getAttribute('aria-selected')).toBe('true');
+            expect(screen.getByTestId('warm').hasAttribute('aria-selected')).toBe(false);
+        });
+
+        it('gives menu dropdown items role=menuitem and no aria-selected', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown value="bold">
+                    Menu
+                    <ul>
+                        <li data-testid="warm" data-ukt-value="warm">
+                            Warm
+                        </li>
+                        <li data-testid="bold" data-ukt-value="bold">
+                            Bold
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+
+            expect(screen.getByTestId('warm').getAttribute('role')).toBe('menuitem');
+            expect(screen.getByTestId('bold').getAttribute('role')).toBe('menuitem');
+            expect(screen.getByTestId('bold').hasAttribute('aria-selected')).toBe(false);
+        });
+
+        it('does not override a consumer-set item role', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <ul>
+                        <li data-testid="item" data-ukt-value="x" role="menuitemradio">
+                            X
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByTestId('item').getAttribute('role')).toBe('menuitemradio');
         });
     });
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -670,6 +670,25 @@ function RootDropdown({
         // If parent is controlling Dropdown via props.value and nextValue is the same, do nothing
         if (valueRef.current && valueRef.current === nextValue) return;
 
+        // When the body stays open after submit (keepOpenOnSubmit), move
+        // aria-selected to the submitted option so the open-time annotation
+        // doesn’t go stale; a closing body unmounts, so reopening re-derives
+        // it from props.value. Listbox only — aria-selected isn’t valid on a
+        // menuitem.
+        if (
+            element &&
+            dropdownElement &&
+            keepOpenOnSubmitRef.current &&
+            popupRole === 'listbox'
+        ) {
+            for (const selected of Array.from(
+                dropdownElement.querySelectorAll('[aria-selected="true"]'),
+            )) {
+                selected.removeAttribute('aria-selected');
+            }
+            element.setAttribute('aria-selected', 'true');
+        }
+
         // If the item is clickable or contains exactly one clickable element, invoke it
         // (but only if the event didn’t already originate from that element)
         if (element) {
@@ -1202,6 +1221,10 @@ function RootDropdown({
     // dismissal under this component’s own listeners (see handleRef), which
     // preserves iframe support and searchable/text-input triggers that native
     // light-dismiss would close on any outside pointerdown.
+    // These annotations run once per open (the body unmounts on close and is
+    // annotated fresh each time); items rendered into an already-open body —
+    // async-loaded or consumer-filtered — aren’t annotated until the next
+    // open. Known limitation until it’s needed.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
         annotateParentItems(ref);

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -259,6 +259,12 @@ function RootDropdown({
     const popupRole = isSearchable ? 'listbox' : hasItems ? 'menu' : 'dialog';
     const menubar = useContext(MenubarContext);
     const inputElementRef = useRef<HTMLInputElement | null>(null);
+    // Whether the consumer authors aria-selected in the body themselves, in
+    // which case this component’s aria-selected fill-ins stand down (set per
+    // open in handleBodyRef)
+    const consumerOwnsAriaSelectedRef = useRef(false);
+    // Body elements already annotated this open (see handleBodyRef)
+    const annotatedBodiesRef = useRef<WeakSet<HTMLElement>>(new WeakSet());
     const closingTimerRef = useRef<null | TimeoutID>(null);
     const isOpeningTimerRef = useRef<null | TimeoutID>(null);
     const currentInputMethodRef = useRef<'keyboard' | 'mouse'>('mouse');
@@ -674,15 +680,18 @@ function RootDropdown({
         // aria-selected to the submitted option so the open-time annotation
         // doesn’t go stale; a closing body unmounts, so reopening re-derives
         // it from props.value. Listbox only — aria-selected isn’t valid on a
-        // menuitem.
+        // menuitem — scoped to the popup body (never a custom trigger’s own
+        // aria-selected), and skipped entirely when the consumer authors
+        // aria-selected themselves.
         if (
             element &&
-            dropdownElement &&
             keepOpenOnSubmitRef.current &&
-            popupRole === 'listbox'
+            popupRole === 'listbox' &&
+            !consumerOwnsAriaSelectedRef.current
         ) {
+            const bodyElement = element.closest('.uktdropdown-body');
             for (const selected of Array.from(
-                dropdownElement.querySelectorAll('[aria-selected="true"]'),
+                bodyElement?.querySelectorAll('[aria-selected="true"]') ?? [],
             )) {
                 selected.removeAttribute('aria-selected');
             }
@@ -1227,6 +1236,21 @@ function RootDropdown({
     // open. Known limitation until it’s needed.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
+        // An inline ref callback re-attaches (and re-runs) on every re-render
+        // while the body is open, but everything below must run exactly once
+        // per open: showPopover() throws on an already-shown popover, and the
+        // ownership check would read the reveal’s own aria-selected annotation
+        // back as consumer-authored. Each open mounts a fresh body element, so
+        // latch per element (a WeakSet, to hold no unmounted bodies alive).
+        if (annotatedBodiesRef.current.has(ref)) return;
+        annotatedBodiesRef.current.add(ref);
+        // A consumer-authored aria-selected anywhere in the just-mounted body
+        // (whether "true" or "false") means the consumer manages selection
+        // ARIA themselves: the reveal below and the keepOpenOnSubmit move in
+        // handleSubmitItem both stand down, so a single-select listbox never
+        // ends up with two selected options (the usual your-values-win rule).
+        consumerOwnsAriaSelectedRef.current =
+            ref.querySelector('[aria-selected]') != null;
         annotateParentItems(ref);
         if (popupRole !== 'dialog') annotateItemRoles(ref, popupRole);
         // The Popover API is Baseline 2024, so showPopover() needs no feature
@@ -1247,7 +1271,7 @@ function RootDropdown({
                 (item) => item.dataset.uktValue === valueIdentity,
             );
             if (selectedItem) {
-                if (popupRole === 'listbox') {
+                if (popupRole === 'listbox' && !consumerOwnsAriaSelectedRef.current) {
                     selectedItem.setAttribute('aria-selected', 'true');
                 }
                 setActiveItem({ dropdownElement, element: selectedItem });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1237,7 +1237,11 @@ function RootDropdown({
         // aria-selected (listbox only — aria-selected isn’t valid on a
         // menuitem), make it the active item (so keyboard navigation starts
         // there), and scroll it into view — so a controlled dropdown opens
-        // showing (and at) its current selection.
+        // showing (and at) its current selection. The lookup is deliberately
+        // top-level only (getItemElements filters to the root level):
+        // search/typeahead also match per level, and no native menu opens
+        // with submenus pre-expanded, so a value matching only a submenu
+        // item is a graceful no-op, like a value matching nothing.
         if (valueIdentity != null && dropdownElement) {
             const selectedItem = getItemElements(dropdownElement)?.find(
                 (item) => item.dataset.uktValue === valueIdentity,

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -29,6 +29,7 @@ import {
 } from './context.js';
 import styles from './Dropdown.css?inline';
 import {
+    annotateItemRoles,
     annotateParentItems,
     collapseItem,
     collapseItemsOutsidePath,
@@ -1204,20 +1205,24 @@ function RootDropdown({
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
         annotateParentItems(ref);
+        if (popupRole !== 'dialog') annotateItemRoles(ref, popupRole);
         // The Popover API is Baseline 2024, so showPopover() needs no feature
         // detection; the body is mounted only while open, so this runs once
         // per open and won’t throw on an already-open body.
         ref.showPopover();
-        // Reveal the current value on open: mark the item whose data-ukt-value
-        // matches it aria-selected, make it the active item (so keyboard
-        // navigation starts there), and scroll it into view — so a controlled
-        // dropdown opens showing (and at) its current selection.
+        // Reveal the current value on open: mark the matching option
+        // aria-selected (listbox only — aria-selected isn’t valid on a
+        // menuitem), make it the active item (so keyboard navigation starts
+        // there), and scroll it into view — so a controlled dropdown opens
+        // showing (and at) its current selection.
         if (valueIdentity != null && dropdownElement) {
             const selectedItem = getItemElements(dropdownElement)?.find(
                 (item) => item.dataset.uktValue === valueIdentity,
             );
             if (selectedItem) {
-                selectedItem.setAttribute('aria-selected', 'true');
+                if (popupRole === 'listbox') {
+                    selectedItem.setAttribute('aria-selected', 'true');
+                }
                 setActiveItem({ dropdownElement, element: selectedItem });
             }
         }

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1208,6 +1208,19 @@ function RootDropdown({
         // detection; the body is mounted only while open, so this runs once
         // per open and won’t throw on an already-open body.
         ref.showPopover();
+        // Reveal the current value on open: mark the item whose data-ukt-value
+        // matches it aria-selected, make it the active item (so keyboard
+        // navigation starts there), and scroll it into view — so a controlled
+        // dropdown opens showing (and at) its current selection.
+        if (valueIdentity != null && dropdownElement) {
+            const selectedItem = getItemElements(dropdownElement)?.find(
+                (item) => item.dataset.uktValue === valueIdentity,
+            );
+            if (selectedItem) {
+                selectedItem.setAttribute('aria-selected', 'true');
+                setActiveItem({ dropdownElement, element: selectedItem });
+            }
+        }
     };
 
     if (!isValidElement(trigger)) {

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -309,7 +309,10 @@ const setActiveChain = (dropdownElement: HTMLElement, element: HTMLElement) => {
 type BaseSetActiveItemPayload = {
     dropdownElement: HTMLElement;
     element?: null;
-    event: Event | SyntheticEvent<HTMLElement>;
+    // Optional so an item can be activated programmatically (e.g. revealing the
+    // current value on open); it’s only used to build the onActiveItem payload,
+    // which is skipped when there’s no event to report.
+    event?: Event | SyntheticEvent<HTMLElement>;
     index?: null;
     indexAddend?: null;
     isExactMatch?: null;
@@ -406,15 +409,18 @@ export const setActiveItem = ({
     }
 
     setActiveChain(dropdownElement, nextActiveItem);
-    const label = getItemLabel(nextActiveItem);
-    const value = nextActiveItem.dataset.uktValue ?? label;
-    onActiveItem?.({
-        element: nextActiveItem,
-        event,
-        label,
-        path: getItemPath(nextActiveItem),
-        value,
-    });
+    // A programmatic activation (no event) still moves the highlight and scrolls
+    // the item into view, but has no event to report to onActiveItem.
+    if (event) {
+        const label = getItemLabel(nextActiveItem);
+        onActiveItem?.({
+            element: nextActiveItem,
+            event,
+            label,
+            path: getItemPath(nextActiveItem),
+            value: nextActiveItem.dataset.uktValue ?? label,
+        });
+    }
     // Find closest scrollable parent and ensure that next active item is visible
     let { parentElement } = nextActiveItem;
     let scrollableParent = null;

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -222,6 +222,38 @@ export const annotateParentItems = (bodyElement: MaybeHTMLElement) => {
     }
 };
 
+// Fill in the item roles the consumer hasn’t set: options in a searchable
+// (listbox) dropdown, menuitems in a menu — and always menuitems inside a
+// submenu, which is itself a menu (annotateParentItems gives it role="menu").
+// The <ul>/<ol> wrappers around the items get role="presentation" so their
+// implicit list role doesn’t sit between the listbox/menu and its items; a
+// submenu already carries role="menu", so its own role is left intact.
+export const annotateItemRoles = (
+    bodyElement: MaybeHTMLElement,
+    popupRole: 'listbox' | 'menu',
+) => {
+    if (!bodyElement) return;
+    for (const list of Array.from(bodyElement.querySelectorAll('ul, ol'))) {
+        if (!list.hasAttribute('role') && list.querySelector(ITEM_SELECTOR)) {
+            list.setAttribute('role', 'presentation');
+        }
+    }
+    for (const item of Array.from(
+        bodyElement.querySelectorAll(ITEM_SELECTOR),
+    ) as Array<HTMLElement>) {
+        // Leave a consumer-set role, and a natively interactive item’s own role
+        // (a button/link/input item keeps its element semantics), alone.
+        if (
+            item.hasAttribute('role') ||
+            item.matches('a[href], button, input, select, textarea')
+        ) {
+            continue;
+        }
+        const isMenuItem = popupRole === 'menu' || getLevelRoot(item) != null;
+        item.setAttribute('role', isMenuItem ? 'menuitem' : 'option');
+    }
+};
+
 export const expandItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmenu) => {
     const submenu = getSubmenuOfItem(item);
     if (!submenu) return;

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -250,6 +250,12 @@ export const annotateItemRoles = (
             continue;
         }
         const isMenuItem = popupRole === 'menu' || getLevelRoot(item) != null;
+        // A top-level parent item in a listbox would pair role="option" with
+        // the aria-haspopup/aria-expanded that annotateParentItems gives it —
+        // invalid ARIA (an option can’t disclose a popup), and no valid role
+        // exists for a submenu parent inside a listbox, so leave its role to
+        // the consumer. (In a menu, menuitem is correct for parents.)
+        if (!isMenuItem && getSubmenuOfItem(item)) continue;
         item.setAttribute('role', isMenuItem ? 'menuitem' : 'option');
     }
 };


### PR DESCRIPTION
## Summary

Two related improvements for controlled dropdowns.

### Reveal the current value on open

On open, the item whose `data-ukt-value` matches `props.value` is made the **active item** (so keyboard navigation starts from the current selection) and **scrolled into view** — a long list opens at the current value instead of the top. In a listbox it&#39;s also marked `aria-selected="true"` (with a themeable `--uktdd-body-bg-color-selected` tint). The lookup is deliberately top-level only: search/typeahead also match per level, and no native menu opens with submenus pre-expanded, so a value matching only a submenu item is a graceful no-op.

### Proper listbox / menu item roles

The dropdown set the container role (`listbox`/`menu`/`dialog`) but left its items as plain `<li>`s. On open it now fills in the roles the consumer hasn&#39;t set:

- `role="option"` for a searchable (listbox) dropdown, `role="menuitem"` for a menu — and always `menuitem` inside a submenu (itself a menu).
- The `<ul>`/`<ol>` wrappers get `role="presentation"` so the listbox/menu owns its items directly rather than through an intervening list.
- The selected option gets `aria-selected`, and with `keepOpenOnSubmit` it moves to the newly submitted option (scoped to the popup body).
- A natively interactive item (button/link/input) or one with a consumer-set role keeps its own role; a submenu parent item in a listbox gets no role at all (its disclosure ARIA is invalid on an `option`).
- Consumer-authored `aria-selected` anywhere in the body (true or false) means the consumer manages selection ARIA — the reveal marking and the `keepOpenOnSubmit` move both stand down, so a single-select listbox never shows two selected options.

## Details

- Both run in the body-mount (open) path, alongside the existing `annotateParentItems` (which already gives submenus `role=&#34;menu&#34;`). The per-open work is latched per body element (a WeakSet), since an inline ref callback re-attaches on every re-render while open and must not re-run `showPopover()` or read its own `aria-selected` annotation back as consumer-authored.
- `setActiveItem`&#39;s `event` becomes optional — it&#39;s only used to build the `onActiveItem` payload, which is skipped without an event — so an item can be activated programmatically on open without a synthetic event or a spurious callback.
- `aria-selected` is listbox-only (it isn&#39;t valid on a `menuitem`); menus get the visual active highlight but no `aria-selected`.

## Testing

- 9 new tests: reveal (active item on open; no-match activates nothing), roles (listbox options + neutralized list + aria-selected; menu menuitems; consumer role preserved; listbox submenu parent keeps no role), and selection ARIA (aria-selected moves on submit with `keepOpenOnSubmit`, scoped to the popup body; consumer-authored aria-selected wins). Full suite: **251 passing**.
- Two `minor` changesets.
- README: the ARIA attributes section documents the item roles, reveal-on-open, and the selected tint.
- `OpensToCurrentValue` Storybook story — a long list with the value far down, so opening scrolls straight to it.
- `build` / `test` / `tsc` / `lint` / `format` all green.

## Follow-up (not here)

`aria-activedescendant` on the searchable input (announcing the active option as you arrow through it) is the natural next a11y step for the combobox interaction — left out to keep this focused on roles + reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)