### PR TITLE
Dropdown: add an options prop for a data-driven body

### DIFF
--- a/.changeset/dropdown-options-prop.md
+++ b/.changeset/dropdown-options-prop.md
@@ -1,0 +1,16 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add an `options` prop for a data-driven dropdown body
+
+Rendering the body yourself means writing the `<li data-ukt-value>` items
+and, for a controlled searchable dropdown whose labels differ from their
+values, resolving the current value’s label to display and mapping the
+submitted label back to a value. `options` — a
+`ReadonlyArray<{ label, value }>` — does both: the dropdown renders the
+list from it and derives the searchable input’s displayed label from the
+option matching `props.value`, so `value` can be the bare identifier.
+`onSubmitItem` still reports the `{ label, value }` pair. With `options`,
+`children` is optional and, if provided, is the trigger. Keep rendering
+`children` yourself when items need custom markup, grouping, or submenus.

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -368,6 +368,29 @@ export const LabelDifferentFromValue: Story = {
     },
 };
 
+export const OptionsProp: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Instead of hand-writing the body, pass the selectable items as `options` ({ label, value } pairs): the dropdown renders the list and derives the searchable input’s label from `props.value`, so `value` is just the bare identifier (the country code) — no looking its label up and no `<li>` items to write. `onSubmitItem` still reports { label, value }. Reach for children instead when items need custom markup, grouping, or submenus.',
+            },
+        },
+    },
+    render() {
+        const [country, setCountry] = React.useState('US');
+        return (
+            <Dropdown
+                isSearchable
+                label="Country"
+                onSubmitItem={({ value }) => setCountry(value)}
+                options={COUNTRIES}
+                placeholder="Search countries…"
+                value={country}
+            />
+        );
+    },
+};
+
 export const CSSValueInputTrigger: Story = {
     args: {
         allowCreate: true,

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -225,8 +225,10 @@ type Props = {
      * Can take a single React element or exactly two renderable children.
      * - Single child: The dropdown body (trigger will be auto-generated button)
      * - Two children: [trigger, body]
+     * Optional only when `options` is provided (which renders the body), in
+     * which case a single child is used as the trigger.
      */
-    children: ReactNode | [ReactNode, ReactNode];
+    children?: ReactNode | [ReactNode, ReactNode];
     className?: string;
     disabled?: boolean;
     /**
@@ -282,6 +284,16 @@ type Props = {
      * - value: The value attribute or text content
      */
     onSubmitItem?: (payload: Item) => void;
+    /**
+     * A data-driven alternative to rendering the dropdown body yourself: pass
+     * the selectable items as { label, value } pairs and the dropdown renders
+     * the list (each as `<li data-ukt-value={value}>{label}</li>`) and derives
+     * the searchable input’s displayed label from the option matching
+     * props.value — so props.value can be the bare value identifier. With
+     * options, children (if any) is the trigger. Provide your own body via
+     * children instead when items need custom markup, grouping, or submenus.
+     */
+    options?: ReadonlyArray<{ label: string; value: string }>;
     /**
      * Placeholder text for the search input (requires isSearchable: true).
      */

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -850,6 +850,65 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('options prop', () => {
+        const OPTIONS = [
+            { label: 'United States', value: 'US' },
+            { label: 'Canada', value: 'CA' },
+            { label: 'Germany', value: 'DE' },
+        ];
+
+        it('renders the list from options and derives the input label from a bare value', async () => {
+            const user = userEvent.setup();
+            render(<Dropdown isSearchable options={OPTIONS} value="CA" />);
+
+            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+                'Canada',
+            );
+
+            await user.click(screen.getByRole('textbox'));
+            const values = Array.from(
+                screen.getByRole('listbox').querySelectorAll('[data-ukt-value]'),
+            ).map((item) => item.getAttribute('data-ukt-value'));
+            expect(values).toEqual(['US', 'CA', 'DE']);
+        });
+
+        it('submits the selected option’s value and label', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <Dropdown
+                    isSearchable
+                    onSubmitItem={handleSubmitItem}
+                    options={OPTIONS}
+                    value="US"
+                />,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+            await user.click(
+                screen.getByRole('listbox').querySelector('[data-ukt-value="DE"]')!,
+            );
+
+            expect(handleSubmitItem).toHaveBeenCalledWith(
+                expect.objectContaining({ label: 'Germany', value: 'DE' }),
+            );
+        });
+
+        it('uses a provided child as the trigger alongside options', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown options={OPTIONS} value="US">
+                    <button type="button">Country</button>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Country' }));
+            expect(
+                screen.getByRole('menu').querySelector('[data-ukt-value="DE"]'),
+            ).toBeTruthy();
+        });
+    });
+
     describe('submitting with no active item', () => {
         it('does not call onSubmitItem when a non-searchable dropdown is submitted with nothing selected', async () => {
             const handleSubmitItem = vi.fn();

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -62,6 +62,14 @@ export type Item = {
 
 export type ItemPathEntry = { label: string; value: string };
 
+/**
+ * A selectable option as a { label, value } pair: `value` is the stored value
+ * (mirrored into the item’s data-ukt-value) and `label` is the displayed text.
+ * Used by the `options` prop and accepted by the `value` prop when an item’s
+ * value and label differ.
+ */
+export type DropdownOption = { label: string; value: string };
+
 export type Props = {
     /**
      * Boolean indicating if the user can submit a value not already in the
@@ -80,8 +88,10 @@ export type Props = {
     allowEmpty?: boolean;
     /**
      * Can take a single React element or exactly two renderable children.
+     * Optional only when `options` is provided (which renders the body), in
+     * which case a single child is used as the trigger.
      */
-    children: ChildrenTuple | ReactElement;
+    children?: ChildrenTuple | ReactElement;
     className?: string;
     disabled?: boolean;
     hasItems?: boolean;
@@ -114,6 +124,16 @@ export type Props = {
      */
     openOnHover?: boolean;
     /**
+     * A data-driven alternative to rendering the dropdown body yourself: pass
+     * the selectable items as { label, value } pairs and the dropdown renders
+     * the list (each as `<li data-ukt-value={value}>{label}</li>`) and derives
+     * the searchable input’s displayed label from the option matching
+     * props.value — so props.value can be the bare value identifier. With
+     * options, children (if any) is the trigger. Provide your own body via
+     * children instead when items need custom markup, grouping, or submenus.
+     */
+    options?: ReadonlyArray<DropdownOption>;
+    /**
      * Only usable in conjunction with {isSearchable: true}.
      * Used as search input’s placeholder.
      */
@@ -137,11 +157,11 @@ export type Props = {
      * value determines whether the value has changed, to avoid triggering
      * onSubmitItem when the already-selected item is re-submitted; the label is
      * used as the search input’s value when props.isSearchable === true. A bare
-     * identifier is resolved to its label from the matching child’s
-     * data-ukt-value in the body — so children whose value and label differ
-     * need no explicit label; a { label, value } pair states it.
+     * identifier is resolved to its label from props.options, or else from the
+     * matching child’s data-ukt-value in the body — so children whose value and
+     * label differ need no explicit label; a { label, value } pair states it.
      */
-    value?: string | { label: string; value: string };
+    value?: DropdownOption | string;
 };
 
 type ChildrenTuple = [ReactNode, ReactNode] | readonly [ReactNode, ReactNode];
@@ -206,21 +226,33 @@ function RootDropdown({
     onOpen,
     onSubmitItem,
     openOnHover,
+    options,
     placeholder,
     style: styleFromProps,
     tabIndex,
     value,
 }: Props) {
     const childrenCount = Children.count(children);
-    if (childrenCount !== 1 && childrenCount !== 2) {
-        if (childrenCount === 0) {
-            throw new Error(CHILDREN_ERROR + ' Received no children.');
+    if (options == null) {
+        if (childrenCount !== 1 && childrenCount !== 2) {
+            if (childrenCount === 0) {
+                throw new Error(CHILDREN_ERROR + ' Received no children.');
+            }
+            console.error(`${CHILDREN_ERROR} Received ${childrenCount} children.`);
         }
-        console.error(`${CHILDREN_ERROR} Received ${childrenCount} children.`);
+    } else if (childrenCount > 1) {
+        console.error(
+            `@acusti/dropdown: with \`options\`, children is only the optional trigger, but received ${childrenCount} children.`,
+        );
     }
 
+    // With options, the (optional) single child is the trigger and the body is
+    // rendered from the options; otherwise the trigger is the first of two
+    // children.
     let trigger: React.ReactNode;
-    if (childrenCount > 1) {
+    if (options != null) {
+        if (childrenCount >= 1) trigger = Children.toArray(children)[0];
+    } else if (childrenCount > 1) {
         trigger = (children as ChildrenTuple)[0];
     }
 
@@ -229,14 +261,16 @@ function RootDropdown({
     // differ. valueIdentity drives change detection / no-op matching against an
     // item’s data-ukt-value; valueLabel is what a searchable dropdown shows in
     // its input. For a bare identifier, the label is resolved from the matching
-    // child (data-ukt-value in the body), so children with distinct values and
-    // labels need no separate label; a { label, value } pair states it
-    // explicitly.
+    // option (with props.options) or the matching child (data-ukt-value in the
+    // body), so children with distinct values and labels need no separate
+    // label; a { label, value } pair states it explicitly.
     const valueIdentity = typeof value === 'string' ? value : value?.value;
     const valueLabel =
         typeof value !== 'string'
             ? value?.label
-            : (getLabelFromChildren(children, value) ?? value);
+            : ((options
+                  ? options.find((option) => option.value === value)?.label
+                  : getLabelFromChildren(children, value)) ?? value);
 
     const [isOpen, setIsOpen] = useState<boolean>(isOpenOnMount ?? false);
     const [isOpening, setIsOpening] = useState<boolean>(!isOpenOnMount);
@@ -510,7 +544,7 @@ function RootDropdown({
     // unmounted DOM
     useEffect(() => clearHoverCloseTimer, []);
 
-    const closeDropdown = (options?: { keepMenubarEngaged?: boolean }) => {
+    const closeDropdown = (closeOptions?: { keepMenubarEngaged?: boolean }) => {
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
@@ -527,7 +561,7 @@ function RootDropdown({
         // takes an enclosing menubar out of menu-mode. Switching menus,
         // clearing the open menu on hover, and focus changes pass
         // keepMenubarEngaged to stay in menu-mode.
-        if (menubar && dropdownElement && !options?.keepMenubarEngaged) {
+        if (menubar && dropdownElement && !closeOptions?.keepMenubarEngaged) {
             menubar.notifyClosed(dropdownElement);
         }
     };
@@ -1288,9 +1322,22 @@ function RootDropdown({
                             <DropdownContext.Provider
                                 value={hasItems ? dropdownContextValue : null}
                             >
-                                {childrenCount > 1
-                                    ? (children as ChildrenTuple)[1]
-                                    : children}
+                                {options ? (
+                                    <ul>
+                                        {options.map((option) => (
+                                            <li
+                                                data-ukt-value={option.value}
+                                                key={option.value}
+                                            >
+                                                {option.label}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : childrenCount > 1 ? (
+                                    (children as ChildrenTuple)[1]
+                                ) : (
+                                    children
+                                )}
                             </DropdownContext.Provider>
                         </div>
                     </div>
@@ -1308,6 +1355,7 @@ const INERT_SUBMENU_PROPS = [
     'keepOpenOnSubmit',
     'name',
     'openOnHover',
+    'options',
     'placeholder',
     'tabIndex',
     'value',


### PR DESCRIPTION
Stacked on #394 (base `dropdown-value-label-pair`). Split out of #394 so the value/label + derive-from-children work can land while this is weighed on its own.

## Summary

A data-driven alternative to rendering the dropdown body yourself: pass the selectable items as `options` (`ReadonlyArray<{ label, value }>`) and the dropdown renders the `<li data-ukt-value={value}>{label}</li>` list _and_ derives the searchable input's displayed label from the option matching `props.value` — so `value` stays the bare identifier. `onSubmitItem` still reports the `{ label, value }` pair. With `options`, `children` becomes optional and, when provided, is the trigger.

## Open design questions (the reason this is its own PR)

1. **It reinterprets `children`.** Without `options`, a single child is the body; with it, a single child is the trigger. The same JSX shape has an opposite meaning based on a prop that doesn't intuitively suggest it would cause that change — and it breaks the README's 2nd DX rule ("single child = body").
2. **It creates a second authoring model that will attract feature requests.** Today `options` is `{ label, value }`, but someone will need `disabled`, then groups, then a per-option render callback — all reasonable asks, and all already answered today by "use children."

Since #394's derive-from-children landed, a bare `value` + hand-written `<li>` children already covers the ergonomic need `options` was reaching for, which weakens the case for a second model.

## Testing

- 3 tests: options list rendering + label derivation from a bare value; option submit reports `{ label, value }`; a provided child works as the trigger. Full suite: **247 passing**.
- `minor` changeset; `OptionsProp` Storybook story.
- `build` / `test` / `tsc` / `lint` / `format` all green.
- Includes the `closeDropdown` param rename (`options` → `closeOptions`) to avoid shadowing the new prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
