### PR TITLE
Honor the authored dropdown open-direction and fix submenu placement in Safari

### DIFF
--- a/.changeset/dropdown-prefer-authored-direction.md
+++ b/.changeset/dropdown-prefer-authored-direction.md
@@ -1,0 +1,35 @@
+---
+'@acusti/dropdown': major
+---
+
+Make the authored placement direction win whenever it fits, instead of
+letting `position-try-order: most-height` override it. The body (and each
+submenu) now uses its `--uktdd-body-position-area` primary placement — and
+then its `--uktdd-body-position-try-fallbacks` in order — accepting the
+first that fits at the box’s natural size, and only squeezing-and-scrolling
+as a last resort. Previously `position-try-order: most-height` re-sorted
+the candidates by available height, so a dropdown told to open above with
+ample room above could still open below merely because the viewport had
+more empty space there.
+
+Removed `position-try-order: most-height` from `.uktdropdown-body` and
+dropped the `100%` term from its base `max-block-size` (a placement is now
+accepted only when the body fits it at natural size, so it no longer
+silently shrinks under the primary). When the body fits nowhere at natural
+size, four appended `--uktdd-fill` fallbacks size it to the available
+block-axis space and let `.uktdropdown-content` scroll, staying as close to
+the primary placement as possible: same side first, flipping inline
+alignment only to escape a horizontal-overflow rejection, and flipping to
+the opposite block side only when the preferred side is under
+`--uktdd-body-min-height`. Submenus gained a `min-block-size` so the same
+too-short-side rejection applies to them.
+
+**Migration:** if you relied on `most-height` to auto-open a dropdown
+toward whichever side had more room (for example the README’s centered-menu
+recipe, which flipped `bottom span-all` to `top span-all` on the taller
+side), it now stays on its primary side while that side can hold the body
+and flips only when the body doesn’t fit there. Set
+`--uktdd-body-position-area` to the side you actually want as the default,
+and list the flipped side first in `--uktdd-body-position-try-fallbacks`.
+If you referenced `--uktdd-fill` as a custom `@position-try` name, rename
+yours — it’s now shipped by the package.

--- a/.changeset/dropdown-submenu-top-layer.md
+++ b/.changeset/dropdown-submenu-top-layer.md
@@ -1,0 +1,23 @@
+---
+'@acusti/dropdown': major
+---
+
+Render submenus in the top layer via `popover="manual"`, the same way the
+body already is, so no ancestor — including the body’s own top-layer
+popover box — can become the containing block for a submenu and shift its
+anchor placement. Previously each submenu was a plain `position: fixed`
+element, so its placement depended on which box the browser treated as its
+containing block. In Safari (which, per spec, shifts a `position-area` box
+back inside its containing block on both axes) the submenu was clamped into
+the parent menu’s box and rendered overlapping its parent item instead of
+flush to the item’s inline-end edge; Chrome happened to look correct only
+because of a Chromium bug that skips the inline-axis shift.
+
+The submenu’s disclosure is now driven by its popover open state
+(`showPopover`/`hidePopover`, tracked to the parent item’s expanded state)
+rather than a CSS `display` toggle, matching the body. This also makes
+submenus immune to a transformed/filtered/contained ancestor becoming their
+containing block, the same guarantee the body gained from top-layer
+rendering. Consumers styling `[data-ukt-submenu]` should not set `display`
+on it (the popover open state controls visibility) and should expect it to
+render in the top layer.

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -254,14 +254,11 @@
 }
 
 /* the four --uktdd-body-position-area / --uktdd-body-position-try-fallbacks
-   recipes from the README’s direction cheatsheet. position-try-order:
-   most-height picks whichever side of the viewport has more room, not
-   merely “enough” room, so the two rows sit close to the canvas’s top and
-   bottom edges respectively — the bottom-opening pair near the top (room
-   below dominates) and the top-opening pair near the bottom (room above
-   dominates) — so each recipe’s primary placement wins on its own terms
-   instead of most-height overriding it toward whichever edge happens to
-   have more empty canvas */
+   recipes from the README’s direction cheatsheet. Each recipe opens in its
+   named direction wherever the trigger sits, so this layout is purely
+   cosmetic: the rows sit near the canvas’s top and bottom edges — the
+   bottom-opening pair up top, the top-opening pair down low — only so each
+   menu opens into empty space instead of overlapping the other row */
 .direction-recipes {
     display: flex;
     flex-direction: column;

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -716,7 +716,7 @@ export const DirectionRecipes: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The bottom pair sits near the top of the canvas and the top pair near the bottom, so each opens toward the side with more room rather than `position-try-order: most-height` overriding it toward whichever side has more empty canvas.',
+                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
             },
         },
     },

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -123,13 +123,17 @@ CSS-first sizing model:
 - The dropdown body is an anchored shell
 - The inner content region becomes scrollable only when the content exceeds
   the available space
-- Placement fallbacks are handled with `position-try-order: most-height`
+- The body opens in its authored direction whenever it fits there, falling
+  back through the other placements in order and only squeezing-to-scroll
+  when it fits nowhere at its natural size (see
+  [Changing the Default Direction](#changing-the-default-direction))
 
 This means the dropdown tends to:
 
 - stay content-sized when the contents are small
-- expand to the available viewport space when more room is needed
-- become scrollable when the contents exceed that space
+- open in the direction you asked for, as long as that side can hold it
+- expand to the available viewport space, and become scrollable, only when
+  the contents exceed the room the chosen side has
 
 Internally, the dropdown renders:
 
@@ -596,6 +600,14 @@ See the [`DirectionRecipes` story][] for a live demo of all four.
 [`DirectionRecipes` story]:
     https://uikit.acusti.ca/?path=/docs/uikit-controls-Dropdown--docs#direction-recipes
 
+The primary placement wins whenever the body fits there at its natural
+size, then the fallbacks are tried in order — the body opens in the
+direction you asked for as long as that side can hold it, and never flips
+to the opposite side just because the viewport happens to have more empty
+space there. Only when the body fits in none of those placements does it
+size itself to the block-axis space its preferred side has and let the
+content scroll, so it never overflows the viewport or covers the trigger.
+
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever
 side the body attaches to and auto-reverses when `position-try` flips the
@@ -638,8 +650,9 @@ tile. A `center` tile is only as wide as the trigger, so a body wider than
 the trigger always overflows it — and `position-try` refuses to select a
 fallback that overflows, so a `bottom center` → `top center` setup never
 flips. `span-all` centers over the trigger identically but spans the full
-width, so it flips cleanly and clamps to the viewport near an edge; the
-package’s `position-try-order: most-height` then picks the taller side:
+width, so it flips cleanly and clamps to the viewport near an edge. The
+menu opens below by default and flips above only when it doesn’t fit below;
+list the flipped fallback so that flip is available:
 
 ```css
 .centered-menu {

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -728,7 +728,7 @@ Like items, submenus are ultimately declared in the DOM. A nested
 ```html
 <li data-ukt-item aria-haspopup="menu" aria-expanded="false">
     Align
-    <ul data-ukt-submenu role="menu">
+    <ul data-ukt-submenu role="menu" popover="manual">
         …
     </ul>
 </li>
@@ -740,6 +740,9 @@ compiles to the attribute form. Rules for direct authoring:
 
 - the `data-ukt-submenu` element must be a descendant of its parent item
   element
+- the submenu discloses in the top layer as a popover; the component sets
+  `popover="manual"`, and the engine adds it if your markup omits it, so
+  you don’t manage `display` (visibility follows the popover open state)
 - in a level whose items include a submenu, mark all of that level’s items
   explicitly with `data-ukt-item` or `data-ukt-value`; purely flat levels —
   including flat submenu bodies — fall back to the automatic item-detection
@@ -767,8 +770,12 @@ already discloses on hover intent — see [Submenus](#submenus) — so
 
 Submenus reuse the dropdown’s anchor-positioning layout model: the expanded
 parent item is the anchor, and the submenu opens at its inline-end,
-top-aligned, falling back to the opposite side when out of bounds.
-Placement custom properties follow the established naming scheme:
+top-aligned, falling back to the opposite side when out of bounds. Like the
+body, a submenu renders in the top layer (`popover="manual"`), so its
+containing block is the viewport — no ancestor (including the body’s own
+top-layer box) can capture it and clip or shift its placement, which keeps
+it flush to the parent item’s edge across browsers. Placement custom
+properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
 - `--uktdd-submenu-position-try-fallbacks`
@@ -790,18 +797,12 @@ theming menu colors.
 
 The active path is fully styleable: `data-ukt-active` marks one item per
 open level (a parent item stays active while you navigate its submenu), and
-`aria-expanded="true"` marks open parent items. The default submenu
-visibility rule, shown here for reference:
-
-```css
-[data-ukt-submenu] {
-    display: none;
-}
-
-[aria-expanded='true'] > [data-ukt-submenu] {
-    display: block;
-}
-```
+`aria-expanded="true"` marks open parent items. Submenu visibility is not a
+`display` rule you own: each submenu is a `popover="manual"` element the
+component shows and hides (via `showPopover`/`hidePopover`) as its parent
+item expands and collapses, so it discloses in the top layer and the UA’s
+`:popover-open` state controls whether it renders. Don’t set `display` on
+`[data-ukt-submenu]` — it would fight that state.
 
 Following macOS, the default styles distinguish the deepest active item —
 the one keyboard input operates on — from its ancestors on the active path.

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -76,10 +76,31 @@
     position: fixed;
     position-anchor: --uktdd-anchor;
     position-area: var(--uktdd-body-position-area);
-    position-try-order: most-height;
-    position-try-fallbacks: var(--uktdd-body-position-try-fallbacks);
+    /* the primary placement wins whenever the body fits there, then the
+       author’s fallbacks are tried in order (no position-try-order:
+       most-height, which would override a fitting primary with whichever
+       side of the viewport happens to be taller). The trailing --uktdd-fill
+       options are the last resort when the body fits at its natural size in
+       none of the author’s placements: --uktdd-fill sizes the body to the
+       block-axis space it has and lets the content region scroll, so a body
+       taller than the space never overflows or covers the trigger. The four
+       ordered variants keep the body as close to the primary placement as
+       possible — same side first, flipping inline alignment only to escape a
+       horizontal-overflow rejection, and flipping to the opposite block side
+       only when the preferred side is under --uktdd-body-min-height. Since
+       --uktdd-fill clamps the block size, it can only be rejected for
+       horizontal overflow (→ flip-inline) or a too-short side (→ flip-block),
+       and these four cover every combination */
+    position-try-fallbacks:
+        var(--uktdd-body-position-try-fallbacks),
+        --uktdd-fill,
+        --uktdd-fill flip-inline,
+        --uktdd-fill flip-block,
+        --uktdd-fill flip-block flip-inline;
     min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));
-    max-block-size: min(var(--uktdd-body-max-height), 100%);
+    /* no 100% clamp: a placement is only accepted when the body’s natural
+       size fits it, so squeezing is reserved for the --uktdd-fill options */
+    max-block-size: var(--uktdd-body-max-height);
     min-inline-size: min(var(--uktdd-body-min-width), var(--uktdd-body-max-width));
     max-inline-size: var(--uktdd-body-max-width);
     inline-size: max-content;
@@ -248,4 +269,29 @@ div.uktdropdown-body {
 
 @position-try --uktdd-submenu-inline-start {
     position-area: inline-start span-block-end;
+}
+
+/* The last-resort option appended after the author’s fallback list (for
+   both the body and submenus). It sets no position-area, so it inherits
+   the element’s primary placement — or its block-flipped mirror when
+   applied as `--uktdd-fill flip-block` — and sizes the element to that
+   side’s available space so the content scrolls. block-size must be a
+   definite length here, not a max-block-size clamp on the auto size:
+   position-try only accepts an option when the box it lays out fits, and
+   an auto-sized box is evaluated at its natural (unclamped) size, so a
+   clamp that would make it fit still reads as overflowing and the option
+   is never selected. 100% is the space on the attached side; subtracting
+   the symmetric --uktdd-body-gap margins keeps the margin box inside it.
+   The base max-block-size also still applies, capping the fill at
+   --uktdd-body-max-height, as does min-block-size, so a side shorter than
+   --uktdd-body-min-height is rejected as unusable and the flipped side is
+   tried instead. (No max-content clamp against stretching past the natural
+   size: intrinsic keywords hit the same natural-size evaluation quirk when
+   set inside @position-try, which would reject the option outright. The
+   stretch can only surface when the author’s fallbacks skip the flipped
+   block placement entirely and the preferred side is under
+   --uktdd-body-min-height — vanishingly rare with the recipes this
+   package documents.) */
+@position-try --uktdd-fill {
+    block-size: calc(100% - var(--uktdd-body-gap) * 2);
 }

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -170,31 +170,71 @@
         }
     }
 
+    /* the expanded item anchors its submenu; its disclosure is driven by the
+       submenu’s popover open state (showPopover on expand), not a display
+       toggle here */
     [data-ukt-item][aria-expanded="true"] {
         anchor-name: --uktdd-submenu-anchor;
+    }
 
-        > [data-ukt-submenu] {
-            display: block;
-        }
+    /* the submenu renders in the top layer via popover="manual", like the
+       body, so no ancestor — including the body’s own popover box — can
+       become the containing block for the fixed submenu and clip or shift its
+       anchor placement. (Safari shifts a position-area box back inside its
+       containing block on both axes, which pulled the submenu in over its
+       parent menu when the body was that containing block.) The popover
+       attribute plus its UA `:not(:popover-open)` rule handle hide-when-
+       collapsed, so there’s no display toggle; showPopover/hidePopover track
+       the item’s expanded state. The UA-popover box reset (inset/border) lives
+       here — the selector already outweighs a bare [popover] on specificity —
+       while the cosmetics stay overridable. */
+
+    /* Until popover="manual" is applied — SubmenuDropdown sets it on render,
+       ensureSubmenuARIA adds it when the body opens — a submenu has no UA
+       :not(:popover-open) rule to hide it. Keep it hidden here so raw
+       data-ukt-submenu markup inserted into an already-open body (annotated
+       only on the next open) doesn’t flash visible and uncontrolled. Once the
+       attribute is present this stops matching, leaving visibility to the
+       popover open state (no author display to fight :popover-open). */
+    [data-ukt-submenu]:not([popover]) {
+        display: none;
     }
 
     [data-ukt-submenu] {
         box-sizing: border-box;
-        display: none;
+        inset: auto;
+        border: 0;
+        block-size: auto;
         /* an explicit color so items don’t inherit the white highlight color
            from their active parent item (the submenu is its DOM child) */
         color: var(--uktdd-body-color);
         position: fixed;
         position-anchor: --uktdd-submenu-anchor;
         position-area: var(--uktdd-submenu-position-area);
-        position-try-fallbacks: var(--uktdd-submenu-position-try-fallbacks);
+        /* same strict-fit + fill-last-resort model as the body (see the
+           .uktdropdown-body rule): a too-tall submenu sizes to its block-axis
+           space and scrolls instead of clipping past the viewport edge, and
+           the four --uktdd-fill variants keep it as near the primary
+           placement as possible before flipping inline or block */
+        position-try-fallbacks:
+            var(--uktdd-submenu-position-try-fallbacks),
+            --uktdd-fill,
+            --uktdd-fill flip-inline,
+            --uktdd-fill flip-block,
+            --uktdd-fill flip-block flip-inline;
         z-index: 2;
         margin-block: 0;
         margin-inline: var(--uktdd-submenu-gap);
+        /* the shared --uktdd-fill subtracts --uktdd-body-gap to keep the body’s
+           block-axis margins inside the fill region; a submenu’s block margins
+           are 0 (its gap is inline), so zero it here to avoid shortening a
+           filled submenu when a consumer sets a body gap */
+        --uktdd-body-gap: 0;
         padding: var(--uktdd-body-pad-top) var(--uktdd-body-pad-right)
             var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
         inline-size: max-content;
         max-inline-size: var(--uktdd-body-max-width);
+        min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));
         max-block-size: var(--uktdd-body-max-height);
         overflow: auto;
         overscroll-behavior: contain;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -364,6 +364,16 @@ function RootDropdown({
     };
 
     const handleToggleSubmenu = (item: HTMLElement, isExpanded: boolean) => {
+        // Show/hide the submenu in the top layer (popover="manual"), like the
+        // body, so no ancestor can become its containing block and shift its
+        // anchor placement. Gate on the current state so a redundant toggle is
+        // a no-op instead of a showPopover/hidePopover that throws.
+        const submenu = getSubmenuOfItem(item);
+        if (submenu) {
+            const isShown = submenu.matches(':popover-open');
+            if (isExpanded && !isShown) submenu.showPopover();
+            else if (!isExpanded && isShown) submenu.hidePopover();
+        }
         for (const registration of submenuRegistrationsRef.current) {
             if (registration.element === item) {
                 (isExpanded ? registration.onOpen : registration.onClose)?.();
@@ -1446,12 +1456,19 @@ function SubmenuDropdown(props: Props & { parentDropdown: DropdownContextValue }
         body = (children as ChildrenTuple)[1];
     }
 
+    // popover="manual" renders the submenu in the top layer (see the
+    // [data-ukt-submenu] CSS and handleToggleSubmenu), escaping the body’s
+    // containing block so its anchor placement is correct across browsers. The
+    // root dropdown’s engine calls showPopover/hidePopover as the item toggles.
     const submenu = isValidElement(body) ? (
         cloneElement(body as ReactElement<Record<string, unknown>>, {
             'data-ukt-submenu': '',
+            popover: 'manual',
         })
     ) : (
-        <div data-ukt-submenu="">{body}</div>
+        <div data-ukt-submenu="" popover="manual">
+            {body}
+        </div>
     );
 
     return (

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -206,6 +206,12 @@ let submenuIdCounter = 0;
 const ensureSubmenuARIA = (item: HTMLElement, submenu: HTMLElement) => {
     if (!submenu.hasAttribute('role')) submenu.setAttribute('role', 'menu');
     if (!submenu.id) submenu.id = `uktdd-submenu-${++submenuIdCounter}`;
+    // Normalize the submenu to a manual popover for consumers who author raw
+    // data-ukt-submenu markup (SubmenuDropdown already sets it); a bare or auto
+    // popover would light-dismiss and desync from the engine’s show/hidePopover.
+    if (submenu.getAttribute('popover') !== 'manual') {
+        submenu.setAttribute('popover', 'manual');
+    }
     if (!item.hasAttribute('aria-haspopup')) item.setAttribute('aria-haspopup', 'menu');
     if (!item.hasAttribute('aria-expanded')) item.setAttribute('aria-expanded', 'false');
     if (!item.hasAttribute('aria-controls')) {


### PR DESCRIPTION
Two independent dropdown placement fixes, each with its own `major` changeset.

## 1. Prefer the authored open-direction over `most-height`

The body leaned on `position-try-order: most-height`, which re-sorts placement candidates by available height — it picks whichever side of the viewport has *more* room, not merely enough. So a dropdown told to open above, with ample room above, would still flip below whenever the viewport happened to have more empty space there (visible in the `DirectionRecipes` story, where all four recipes rendered below on a tall window).

Dropped `most-height`. The body now uses its primary `position-area`, then its authored fallbacks in order, accepting the first that fits at natural size — so it opens in the direction you asked for whenever that side can hold it, and never flips just because the other side is emptier. When it fits nowhere at natural size, appended `--uktdd-fill` options size it to the available block-axis space and let the content scroll, so it never overflows or covers the trigger.

## 2. Render submenus in the top layer (Safari fix)

A submenu was a plain `position: fixed` element, so its containing block — and thus its anchor placement — depended on which box the browser chose. Safari (correctly, per spec) shifts a `position-area` box back inside its containing block on both axes, clamping the submenu into the body box so it overlapped its parent item; Chrome only looked right because of a Chromium bug that skips the inline-axis shift.

Each submenu now renders in the top layer via `popover="manual"`, exactly like the body, so its containing block is always the viewport. Disclosure drives `showPopover`/`hidePopover` from the parent item's expanded state instead of a CSS `display` toggle. This also makes submenus immune to a transformed/filtered/contained ancestor becoming their containing block — the same guarantee the body already had.

## Testing

- `bun run test` (98 pass), `build`, `lint`, `tsc`, `format:check` — all green.
- Direction fix verified in-browser across viewport sizes (primary placement wins when it fits; fill-and-scroll as last resort).
- Submenu fix verified in Chrome (flush placement, three-level nesting, clean popover teardown) and **confirmed fixed in Safari 26.5** by the reporter.

The ARIA acronym-casing cleanup that came up alongside this work landed separately on `main` (rename-only, no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
