### PR TITLE
Dropdown: fall back to the placeholder for an unmatched searchable value

### DIFF
--- a/.changeset/dropdown-unmatched-value-placeholder.md
+++ b/.changeset/dropdown-unmatched-value-placeholder.md
@@ -1,0 +1,15 @@
+---
+'@acusti/dropdown': patch
+---
+
+Fall back to the placeholder for an unmatched searchable value
+
+A searchable dropdown’s displayed label derives from the child whose
+`data-ukt-value` matches the `value` prop. When no child matched, it fell
+back to rendering the raw `value` string — but a value is an identity, not
+display text, so an unmatched value put the identifier (e.g. `warm`) in the
+input instead of showing the placeholder. An unmatched `value` now falls
+back to the placeholder (an empty input). The exception is `allowCreate`,
+where an unmatched value is an entry the user created (a typed value not
+among the items) and still displays as typed. Pass a `{ label, value }`
+pair to show a specific label for a value with no matching item.

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -885,6 +885,49 @@ describe('@acusti/dropdown', () => {
             expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('None');
         });
 
+        it('shows the placeholder for an undefined value, even with an empty-valued item', () => {
+            render(
+                <Dropdown isSearchable placeholder="Mixed" value={undefined}>
+                    <ul>
+                        <li data-ukt-value="">Inherit</li>
+                        <li data-ukt-value="400">Normal</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // undefined is “no value”, distinct from the empty string (a real
+            // value that resolves to its item’s label): the input stays empty
+            // and shows its placeholder rather than the empty-valued item’s
+            // label. This is the “Mixed” state a font-weight select uses when
+            // several weights are selected at once, separate from an explicit
+            // empty-valued “Inherit” option (value: '').
+            const input = screen.getByRole('textbox') as HTMLInputElement;
+            expect(input.value).toBe('');
+            expect(input.placeholder).toBe('Mixed');
+        });
+
+        it('shows an empty-valued { label, value } pair’s label over a matching item’s', () => {
+            render(
+                <Dropdown
+                    isSearchable
+                    placeholder="Mixed"
+                    value={{ label: 'Inherit', value: '' }}
+                >
+                    <ul>
+                        <li data-ukt-value="">Inherit option</li>
+                        <li data-ukt-value="400">Normal</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // The pair states the label explicitly, so an empty-valued
+            // selection (the “Inherit” state) shows the pair’s label — not the
+            // matching item’s text, and not the placeholder.
+            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+                'Inherit',
+            );
+        });
+
         it('lets a { label, value } pair override the label derived from children', () => {
             render(
                 <Dropdown isSearchable value={{ label: 'Toasty', value: 'warm' }}>

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -855,6 +855,40 @@ describe('@acusti/dropdown', () => {
             );
         });
 
+        it('falls back to the placeholder when a bare value matches no item', () => {
+            render(
+                <Dropdown isSearchable placeholder="Pick one" value="warm">
+                    <ul>
+                        <li data-ukt-value="bold">Bold & Direct</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // A value is an identity, not display text: with no matching item
+            // there’s no known label, so the input stays empty and shows its
+            // placeholder rather than the raw identifier.
+            const input = screen.getByRole('textbox') as HTMLInputElement;
+            expect(input.value).toBe('');
+            expect(input.placeholder).toBe('Pick one');
+        });
+
+        it('shows an unmatched value verbatim when allowCreate is set', () => {
+            render(
+                <Dropdown allowCreate isSearchable value="650">
+                    <ul>
+                        <li data-ukt-value="400">Normal</li>
+                        <li data-ukt-value="700">Bold</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // allowCreate means an unmatched value is a legitimately created
+            // entry (a value the user typed that isn’t among the items), so it
+            // must still display as typed rather than fall back to the
+            // placeholder.
+            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('650');
+        });
+
         it('matches a numeric data-ukt-value against a bare string value', () => {
             render(
                 <Dropdown isSearchable value="400">

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -242,15 +242,19 @@ function RootDropdown({
     // child (data-ukt-value in the body — derivation walks the same node the
     // body renders, so a data-ukt-value in a custom trigger can’t match), so
     // children with distinct values and labels need no separate label; a
-    // { label, value } pair states it explicitly. Only a searchable dropdown
-    // displays the label, so skip the per-render walk entirely for anything
-    // else.
+    // { label, value } pair states it explicitly. A bare value that matches no
+    // child has no known label — a value is an identity, not display text — so
+    // it falls back to the placeholder (an empty input), not to the raw
+    // identifier. The exception is allowCreate, where an unmatched value is an
+    // entry the user created (a typed value not among the items) and must still
+    // show as typed. Only a searchable dropdown displays the label, so skip the
+    // per-render walk entirely for anything else.
     const valueIdentity = typeof value === 'string' ? value : value?.value;
     const valueLabel = !isSearchable
         ? undefined
         : typeof value !== 'string'
           ? value?.label
-          : (getLabelFromChildren(body, value) ?? value);
+          : (getLabelFromChildren(body, value) ?? (allowCreate ? value : undefined));
 
     const [isOpen, setIsOpen] = useState<boolean>(isOpenOnMount ?? false);
     const [isOpening, setIsOpening] = useState<boolean>(!isOpenOnMount);


### PR DESCRIPTION
Fixes #401.

## Summary

A searchable `Dropdown`'s displayed label derives from the child whose `data-ukt-value` matches the `value` prop (added in #394). When no child matched, it fell back to rendering the **raw `value` string**:

```js
valueLabel = getLabelFromChildren(body, value) ?? value;
```

But a `value` is an identity, not display text, so an unmatched value put the identifier (e.g. `warm`) in the input instead of showing the placeholder. This changes the fallback to the **placeholder** (an empty input):

```js
valueLabel = getLabelFromChildren(body, value) ?? (allowCreate ? value : undefined);
```

**`allowCreate` is the deliberate exception:** there an unmatched value is a legitimately *created* entry — a value the user typed that isn't among the items (e.g. typing `650` into a weight picker whose presets stop at `700`) — so it must still display as typed. In create mode a value's identity and its label genuinely coincide, so this keeps the identity/label model intact rather than being a carve-out.

Consumers who want a specific label for a value with no matching item pass a `{ label, value }` pair, unchanged.

## Why placeholder over raw value

The raw-value fallback is a vestige of the pre-#394 model, where `value` was a single string doing double duty as both identity and display text. Once #394 split those roles, rendering the raw identifier as a label is the one spot the old conflation leaked back in. The placeholder fallback is:

- **Consistent** with the identity/label split #394 established, and with the `{ label, value }` pair and `allowCreate` escape hatches.
- **Aligned with platform/library norms** — native `<select>` never renders an unmatched value; ARIA/editable comboboxes require a label object to show a label and otherwise show the placeholder; creatable/free-solo variants show the typed value (the `allowCreate` case).
- **The safer failure mode** — a visible blank input prompts the consumer to state intent, versus a raw id (`user_7f3a`, `warm`) silently leaking into the UI as if it were a label.

Only the displayed label changes; `valueIdentity` still drives change detection and no-op matching, so nothing about what's submitted or matched is affected.

## Semantics clarified (per the issue)

`''` is a normal value, not "no value":

- `value=""` + an empty-valued item → shows that item's label (it matches).
- `value={undefined}` (or omitted) → placeholder ("no selection").

A consumer wanting an empty/placeholder state passes `undefined`, not `""`.

## Commits

1. **Test that an undefined value shows the placeholder, unlike an empty string** — guard tests for the `undefined` (placeholder) vs `''` (real value → label) distinction the issue spells out; no code change.
2. **Fall back to the placeholder for an unmatched searchable value** — the fix, plus tests (unmatched → placeholder; unmatched + `allowCreate` → verbatim) and a patch changeset.

## Testing

- 102 tests passing in `@acusti/dropdown` (4 new/guard tests).
- `test` / `tsc` / `lint` / `format` all green.
- One `patch` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UwwqepZQDDWCSrYQr68ttV)_