### PR TITLE
Budget dropdown fill fallbacks to the position-try evaluation limit

### DIFF
--- a/.changeset/dropdown-fill-cover-option.md
+++ b/.changeset/dropdown-fill-cover-option.md
@@ -1,0 +1,19 @@
+---
+'@acusti/dropdown': minor
+---
+
+Add the opt-in `--uktdd-fill-cover` last-resort placement (in no default
+list): where the block-side fills loosen the inline axis and keep the body
+beside the trigger, the cover fill keeps the strict start-aligned inline
+edge (compose `--uktdd-fill-cover flip-inline` for end alignment) and
+loosens the block axis instead, sizing the body to the viewport’s full
+block size — covering the trigger — so a too-tall menu gets the whole
+viewport to scroll in rather than one side of it. It is rejected whenever
+the body is too wide for the trigger-to-viewport-edge inline region, so
+listing it before the guaranteed pair
+(`--uktdd-body-fill-fallbacks: --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top`)
+applies it only when the body already fits horizontally, with the pair
+still rescuing corner triggers. Requires budget headroom: at most two
+author fallbacks alongside the three fills (one, to stay within the spec’s
+guaranteed floor). Avoid it on searchable dropdowns — the body overlays the
+trigger’s input while open.

--- a/.changeset/dropdown-fill-cover-option.md
+++ b/.changeset/dropdown-fill-cover-option.md
@@ -13,7 +13,9 @@ the body is too wide for the trigger-to-viewport-edge inline region, so
 listing it before the guaranteed pair
 (`--uktdd-body-fill-fallbacks: --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top`)
 applies it only when the body already fits horizontally, with the pair
-still rescuing corner triggers. Requires budget headroom: at most two
-author fallbacks alongside the three fills (one, to stay within the spec’s
-guaranteed floor). Avoid it on searchable dropdowns — the body overlays the
-trigger’s input while open.
+still rescuing corner triggers. Three fills leaves room for at most two
+author fallback slots — six position options total, within the limit every
+current engine evaluates (Chromium caps at six; Safari and Firefox go well
+beyond). Drop to one author fallback to keep the whole list within the
+spec’s guaranteed floor of five. Avoid it on searchable dropdowns — the
+body overlays the trigger’s input while open.

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -22,11 +22,14 @@ exactly five. Each fill pairs a single-side `position-area`
 rejected for horizontal overflow) with `justify-self: anchor-center`, which
 centers the body over the trigger and shifts it inward as needed to stay
 on-screen (the explicitness matters: `span-all`’s default alignment centers
-without that shift, so near a corner it would overflow and be rejected).
-Because a fill can only be rejected when its side is shorter than
-`--uktdd-body-min-height` and the two sides sum to the viewport, at least
-one of the pair always fits — for every trigger position, including
-corners, with no height cap needed. The pair is appended via the new
+without that shift, so near a corner it would overflow and be rejected). A
+fill is only rejected when its side is shorter than the body’s
+min-block-size floor — what sends a cramped side’s fill to the roomier
+opposite side — and each fill caps that floor at the worst-case larger side
+(half the viewport minus the trigger, the most a block-centered trigger can
+guarantee), so at least one of the pair always fits — for every trigger
+position, including corners and a `--uktdd-body-min-height` above half the
+viewport, with no height cap needed. The pair is appended via the new
 `--uktdd-body-fill-fallbacks` custom property, so upward-opening dropdowns
 can flip its order to keep the last-resort fill on their preferred side.
 

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -6,18 +6,23 @@ Keep the last-resort fill placements within the `position-try` evaluation
 limit so a too-tall body flips and scrolls instead of opening off-screen
 (fixes #399)
 
-The CSS anchor positioning spec lets engines cap how many
-`position-try-fallbacks` options they evaluate, as low as five — and
-Chromium evaluates exactly five, silently ignoring the rest. The body’s
-previous list was three author fallbacks plus four `--uktdd-fill` tactic
-variants (seven options), so the block-flipped fills that rescue a
-near-viewport-height body at a block-axis viewport edge were never
-evaluated: the body opened toward the edge and ran off-screen, and
-consumers had to cap `--uktdd-body-max-height` to work around it.
+The CSS anchor positioning spec lets engines cap the position options list
+at an implementation-defined length with a floor of five — and the list
+includes the element’s base position, so only four fallbacks past it are
+guaranteed. Chromium evaluates five fallbacks past the base, silently
+ignoring the rest. The body’s previous list was three author fallbacks plus
+four `--uktdd-fill` tactic variants (seven fallbacks), so the block-flipped
+fills that rescue a near-viewport-height body at a block-axis viewport edge
+were never evaluated: the body opened toward the edge and ran off-screen,
+and consumers had to cap `--uktdd-body-max-height` to work around it.
 
 The four appended tactic fills are replaced by two new named options —
 `--uktdd-fill-bottom` and `--uktdd-fill-top` — bringing the default list to
-exactly five. Each fill pairs a single-side `position-area`
+exactly five fallbacks, Chromium’s evaluated budget. That is one past the
+spec’s guaranteed floor: an engine at the exact floor would evaluate only
+four and drop the second fill. The design is validated in Chromium — the
+engine whose limit bites — and untested at the floor, since no known engine
+sits there. Each fill pairs a single-side `position-area`
 (`block-end`/`block-start`, spanning all inline tiles so it can never be
 rejected for horizontal overflow) with `justify-self: anchor-center`, which
 centers the body over the trigger and shifts it inward as needed to stay
@@ -31,15 +36,20 @@ guarantee), so at least one of the pair always fits — for every trigger
 position, including corners and a `--uktdd-body-min-height` above half the
 viewport, with no height cap needed. The pair is appended via the new
 `--uktdd-body-fill-fallbacks` custom property, so upward-opening dropdowns
-can flip its order to keep the last-resort fill on their preferred side.
+can flip its order to keep the last-resort fill on their preferred side;
+submenus reuse the pair as their own final rescue, so the flip carries into
+a body’s submenus as well.
 
 In the fill placements the body now spans the trigger (anchor-centered,
 shifted to fit) instead of keeping the primary placement’s edge alignment.
 Consumer fallback lists must stay within the same budget: at most three
-options in `--uktdd-body-position-try-fallbacks`, and a single option in
+options in `--uktdd-body-position-try-fallbacks` (two, to stay within the
+spec floor), and a single option in
 `--uktdd-submenu-position-try-fallbacks` (the submenu list is now its
 author fallback, `--uktdd-fill`, `--uktdd-fill flip-inline`, then the two
-block-side fills — also exactly five).
+block-side fills — also exactly five fallbacks; unlike the body’s list it
+can’t shrink below five without losing side coverage, so submenu rescue
+inherently relies on engines evaluating past the spec floor).
 
 Also fixes the submenu rule’s `--uktdd-body-gap: 0` override: the unitless
 zero made the fill options’ `calc(100% - var(--uktdd-body-gap) * 2)`

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -9,12 +9,14 @@ limit so a too-tall body flips and scrolls instead of opening off-screen
 The CSS anchor positioning spec lets engines cap the position options list
 at an implementation-defined length with a floor of five — and the list
 includes the element’s base position, so only four fallbacks past it are
-guaranteed. Chromium evaluates five fallbacks past the base, silently
-ignoring the rest. The body’s previous list was three author fallbacks plus
-four `--uktdd-fill` tactic variants (seven fallbacks), so the block-flipped
-fills that rescue a near-viewport-height body at a block-axis viewport edge
-were never evaluated: the body opened toward the edge and ran off-screen,
-and consumers had to cap `--uktdd-body-max-height` to work around it.
+guaranteed. In practice Chromium is the tightest, evaluating six options
+(five fallbacks past the base) and silently ignoring the rest, while Safari
+and Firefox evaluate many more. The body’s previous list was three author
+fallbacks plus four `--uktdd-fill` tactic variants (seven fallbacks), so
+the block-flipped fills that rescue a near-viewport-height body at a
+block-axis viewport edge were never evaluated: the body opened toward the
+edge and ran off-screen, and consumers had to cap `--uktdd-body-max-height`
+to work around it.
 
 The four appended tactic fills are replaced by two new named options —
 `--uktdd-fill-bottom` and `--uktdd-fill-top` — and the default author

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -1,0 +1,47 @@
+---
+'@acusti/dropdown': minor
+---
+
+Keep the last-resort fill placements within the `position-try` evaluation
+limit so a too-tall body flips and scrolls instead of opening off-screen
+(fixes #399)
+
+The CSS anchor positioning spec lets engines cap how many
+`position-try-fallbacks` options they evaluate, as low as five — and
+Chromium evaluates exactly five, silently ignoring the rest. The body’s
+previous list was three author fallbacks plus four `--uktdd-fill` tactic
+variants (seven options), so the block-flipped fills that rescue a
+near-viewport-height body at a block-axis viewport edge were never
+evaluated: the body opened toward the edge and ran off-screen, and
+consumers had to cap `--uktdd-body-max-height` to work around it.
+
+The four appended tactic fills are replaced by two new named options —
+`--uktdd-fill-bottom` and `--uktdd-fill-top` — bringing the default list to
+exactly five. Each fill pairs a single-side `position-area`
+(`block-end`/`block-start`, spanning all inline tiles so it can never be
+rejected for horizontal overflow) with `justify-self: anchor-center`, which
+centers the body over the trigger and shifts it inward as needed to stay
+on-screen (the explicitness matters: `span-all`’s default alignment centers
+without that shift, so near a corner it would overflow and be rejected).
+Because a fill can only be rejected when its side is shorter than
+`--uktdd-body-min-height` and the two sides sum to the viewport, at least
+one of the pair always fits — for every trigger position, including
+corners, with no height cap needed. The pair is appended via the new
+`--uktdd-body-fill-fallbacks` custom property, so upward-opening dropdowns
+can flip its order to keep the last-resort fill on their preferred side.
+
+In the fill placements the body now spans the trigger (anchor-centered,
+shifted to fit) instead of keeping the primary placement’s edge alignment.
+Consumer fallback lists must stay within the same budget: at most three
+options in `--uktdd-body-position-try-fallbacks`, and a single option in
+`--uktdd-submenu-position-try-fallbacks` (the submenu list is now its
+author fallback, `--uktdd-fill`, `--uktdd-fill flip-inline`, then the two
+block-side fills — also exactly five).
+
+Also fixes the submenu rule’s `--uktdd-body-gap: 0` override: the unitless
+zero made the fill options’ `calc(100% - var(--uktdd-body-gap) * 2)`
+block-size invalid (`<percentage> - <number>`), so every fill option was
+evaluated at natural size and rejected — submenu fill fallbacks never
+applied, and a submenu taller than the space beside its parent item
+overflowed the viewport instead of filling and scrolling. The zero now
+carries a unit (`0px`).

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -17,39 +17,42 @@ were never evaluated: the body opened toward the edge and ran off-screen,
 and consumers had to cap `--uktdd-body-max-height` to work around it.
 
 The four appended tactic fills are replaced by two new named options —
-`--uktdd-fill-bottom` and `--uktdd-fill-top` — bringing the default list to
-exactly five fallbacks, Chromium’s evaluated budget. That is one past the
-spec’s guaranteed floor: an engine at the exact floor would evaluate only
-four and drop the second fill. The design is validated in Chromium — the
-engine whose limit bites — and untested at the floor, since no known engine
-sits there. Each fill pairs a single-side `position-area`
-(`block-end`/`block-start`, spanning all inline tiles so it can never be
-rejected for horizontal overflow) with `justify-self: anchor-center`, which
-centers the body over the trigger and shifts it inward as needed to stay
-on-screen (the explicitness matters: `span-all`’s default alignment centers
-without that shift, so near a corner it would overflow and be rejected). A
-fill is only rejected when its side is shorter than the body’s
-min-block-size floor — what sends a cramped side’s fill to the roomier
-opposite side — and each fill caps that floor at the worst-case larger side
-(half the viewport minus the trigger, the most a block-centered trigger can
-guarantee), so at least one of the pair always fits — for every trigger
-position, including corners and a `--uktdd-body-min-height` above half the
-viewport, with no height cap needed. The pair is appended via the new
-`--uktdd-body-fill-fallbacks` custom property, so upward-opening dropdowns
-can flip its order to keep the last-resort fill on their preferred side;
-submenus reuse the pair as their own final rescue, so the flip carries into
-a body’s submenus as well.
+`--uktdd-fill-bottom` and `--uktdd-fill-top` — and the default author
+fallback list drops from three options to two (the block flip and inline
+flip of the primary; the both-axes diagonal is dropped). The full list is
+now two author fallbacks plus the two fills — four fallbacks past the base
+position, exactly the spec’s guaranteed floor of five options, so no engine
+can silently drop a fill. The cost of dropping the diagonal is that a
+trigger crammed into the corner diagonal to the primary opening direction
+lands in a fill rather than a fourth natural placement, which for a
+corner-pinned trigger is a re-tune-the-primary case anyway. Each fill pairs
+a single-side `position-area` (`block-end`/`block-start`, spanning all
+inline tiles so it can never be rejected for horizontal overflow) with
+`justify-self: anchor-center`, which centers the body over the trigger and
+shifts it inward as needed to stay on-screen (the explicitness matters:
+`span-all`’s default alignment centers without that shift, so near a corner
+it would overflow and be rejected). A fill is only rejected when its side
+is shorter than the body’s min-block-size floor — what sends a cramped
+side’s fill to the roomier opposite side — and each fill caps that floor at
+the worst-case larger side (half the viewport minus the trigger, the most a
+block-centered trigger can guarantee), so at least one of the pair always
+fits — for every trigger position, including corners and a
+`--uktdd-body-min-height` above half the viewport, with no height cap
+needed. The pair is appended via the new `--uktdd-body-fill-fallbacks`
+custom property, so upward-opening dropdowns can flip its order to keep the
+last-resort fill on their preferred side; submenus reuse the pair as their
+own final rescue, so the flip carries into a body’s submenus as well.
 
 In the fill placements the body now spans the trigger (anchor-centered,
 shifted to fit) instead of keeping the primary placement’s edge alignment.
-Consumer fallback lists must stay within the same budget: at most three
-options in `--uktdd-body-position-try-fallbacks` (two, to stay within the
-spec floor), and a single option in
-`--uktdd-submenu-position-try-fallbacks` (the submenu list is now its
-author fallback, `--uktdd-fill`, `--uktdd-fill flip-inline`, then the two
-block-side fills — also exactly five fallbacks; unlike the body’s list it
-can’t shrink below five without losing side coverage, so submenu rescue
-inherently relies on engines evaluating past the spec floor).
+Consumer fallback lists must stay within the budget: at most two options in
+`--uktdd-body-position-try-fallbacks` (matching the new floor-safe
+default), and a single option in `--uktdd-submenu-position-try-fallbacks`
+(the submenu list is now its author fallback, `--uktdd-fill`,
+`--uktdd-fill flip-inline`, then the two block-side fills — also exactly
+five fallbacks; unlike the body’s list it can’t shrink below five without
+losing side coverage, so submenu rescue inherently relies on engines
+evaluating past the spec floor).
 
 Also fixes the submenu rule’s `--uktdd-body-gap: 0` override: the unitless
 zero made the fill options’ `calc(100% - var(--uktdd-body-gap) * 2)`

--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -40,19 +40,15 @@ fits — for every trigger position, including corners and a
 `--uktdd-body-min-height` above half the viewport, with no height cap
 needed. The pair is appended via the new `--uktdd-body-fill-fallbacks`
 custom property, so upward-opening dropdowns can flip its order to keep the
-last-resort fill on their preferred side; submenus reuse the pair as their
-own final rescue, so the flip carries into a body’s submenus as well.
+last-resort fill on their preferred side. (Submenus have their own
+last-resort fills, `--uktdd-submenu-fill-fallbacks`, rather than reusing
+this pair — see the separate submenu changeset.)
 
 In the fill placements the body now spans the trigger (anchor-centered,
 shifted to fit) instead of keeping the primary placement’s edge alignment.
 Consumer fallback lists must stay within the budget: at most two options in
 `--uktdd-body-position-try-fallbacks` (matching the new floor-safe
-default), and a single option in `--uktdd-submenu-position-try-fallbacks`
-(the submenu list is now its author fallback, `--uktdd-fill`,
-`--uktdd-fill flip-inline`, then the two block-side fills — also exactly
-five fallbacks; unlike the body’s list it can’t shrink below five without
-losing side coverage, so submenu rescue inherently relies on engines
-evaluating past the spec floor).
+default), and a single option in `--uktdd-submenu-position-try-fallbacks`.
 
 Also fixes the submenu rule’s `--uktdd-body-gap: 0` override: the unitless
 zero made the fill options’ `calc(100% - var(--uktdd-body-gap) * 2)`

--- a/.changeset/dropdown-submenu-fills-beside-parent.md
+++ b/.changeset/dropdown-submenu-fills-beside-parent.md
@@ -4,7 +4,7 @@
 
 Keep a too-tall submenu beside its parent instead of covering the parent
 menu, and give submenus their own last-resort fills decoupled from the
-body’s
+body’s fills
 
 Previously a submenu that fit nowhere beside its parent fell back to the
 body’s block-side fills (`--uktdd-body-fill-fallbacks`), which cover the

--- a/.changeset/dropdown-submenu-fills-beside-parent.md
+++ b/.changeset/dropdown-submenu-fills-beside-parent.md
@@ -1,0 +1,34 @@
+---
+'@acusti/dropdown': minor
+---
+
+Keep a too-tall submenu beside its parent instead of covering the parent
+menu, and give submenus their own last-resort fills decoupled from the
+body’s
+
+Previously a submenu that fit nowhere beside its parent fell back to the
+body’s block-side fills (`--uktdd-body-fill-fallbacks`), which cover the
+anchor — wrong for a submenu, since macOS never covers a parent menu with
+its submenu, and it coupled the two: flipping the body’s fill pair for an
+upward-opening dropdown silently reordered its submenus’ rescue too. That
+list was also five fallbacks, one past the spec’s guaranteed floor.
+
+Submenus now use a new `--uktdd-submenu-fill-fallbacks` (default
+`--uktdd-submenu-fill, --uktdd-submenu-fill flip-inline`) and a new
+`--uktdd-submenu-fill` placement: a full-height fill on each inline side
+that spans the viewport’s block axis (a bare `inline-end` keyword, the
+block-axis mirror of `--uktdd-fill-bottom`) and anchor-centers on the block
+axis, so a submenu taller than the room beside its parent fills the
+viewport height next to the parent item and scrolls — shifting on-screen
+even when the parent sits near the block-end edge — rather than covering
+the parent menu. The submenu list is now one author fallback plus these two
+fills, three past the base and within the spec’s five-option floor (no
+reliance on an engine evaluating past it), and independent of
+`--uktdd-body-fill-fallbacks`.
+
+The one case this gives up versus covering the parent — a submenu wider
+than the space on either side of its parent — is out of scope for the
+narrow columns of a macOS-style menu; a consumer who needs it can append
+`--uktdd-fill-bottom, --uktdd-fill-top` to `--uktdd-submenu-fill-fallbacks`
+(keeping `--uktdd-submenu-position-try-fallbacks` to a single option to
+stay within the evaluation limit).

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -312,6 +312,18 @@
     inline-size: 180px;
 }
 
+/* SubmenuFillsBesideParent: the trigger is pinned near the block-end edge
+   so its (short) menu — and the parent item within it — sit low in the
+   viewport. The parent item’s tall submenu has too little room below to
+   open top-aligned, so --uktdd-submenu-fill fills the full viewport height
+   beside the parent and scrolls, staying next to it rather than covering
+   the parent menu */
+.submenu-beside-demo {
+    position: fixed;
+    inset-block-end: 8px;
+    inset-inline-start: 8px;
+}
+
 /* the mid-viewport trigger whose --uktdd-body-min-height: 300px (set on
    its style prop, so “Show code” displays it) exceeds either ~195px side
    of the 420px canvas — the fills cap the floor at the worst-case side,

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -120,8 +120,7 @@
 .searchable-with-label,
 .searchable-and-allow-create {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
 
     input,
     .uktdropdown-body {
@@ -131,8 +130,7 @@
 
 .css-value-input-trigger {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
 
     .uktdropdown-body {
         /* a horizontal alignment nudge, not a trigger↔body gap; set as a raw
@@ -290,8 +288,7 @@
 
 .too-tall {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
 }
 
 /* CoverFillRecipe: the cover fill trades trigger coverage for full

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -301,11 +301,18 @@
    the overflowing primary placement */
 .too-tall-center-min {
     position: fixed;
-    inset-block-start: 50%;
+    /* mid-viewport without a translate: anchor positioning tracks the
+       trigger's layout box, and a transform moves only its painted box, so
+       a `translate: 0 -50%` centering shifts the trigger away from where
+       the body attaches (and here flipped which fill was accepted). Sitting
+       just above center also keeps the below side clearly the larger one,
+       so the accepted fill is deterministically the below one the story
+       description narrates, rather than a rounding-order tie at dead
+       center */
+    inset-block-start: calc(50% - 30px);
     inset-inline: 0;
     margin-inline: auto;
     inline-size: max-content;
-    translate: 0 -50%;
 }
 
 /* ---- Fixed Header Styles ---- */

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -294,6 +294,20 @@
         --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 }
 
+/* the mid-viewport trigger whose --uktdd-body-min-height: 300px (set on
+   its style prop, so “Show code” displays it) exceeds either ~195px side
+   of the 420px canvas — the fills cap the floor at the worst-case side,
+   so the body fills below the trigger and scrolls instead of reverting to
+   the overflowing primary placement */
+.too-tall-center-min {
+    position: fixed;
+    inset-block-start: 50%;
+    inset-inline: 0;
+    margin-inline: auto;
+    inline-size: max-content;
+    translate: 0 -50%;
+}
+
 /* ---- Fixed Header Styles ---- */
 :root {
     --ui-clr-1000: #ffffff;

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -289,16 +289,39 @@
         --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 }
 
+/* the top-opening recipes also flip the last-resort fill pair so a body too
+   tall to fit anywhere fills and scrolls on the upward side first */
 .direction-top-start {
     --uktdd-body-position-area: block-start span-inline-end;
     --uktdd-body-position-try-fallbacks:
         --uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end;
+    --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
 }
 
 .direction-top-end {
     --uktdd-body-position-area: block-start span-inline-start;
     --uktdd-body-position-try-fallbacks:
         --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
+    --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
+}
+
+/* FillsWhenTooTall: the issue-#399 shape — a menu taller than the viewport,
+   triggers pinned to the bottom edge and corners, no max-height cap. Nothing
+   fits at natural size, the below side is under --uktdd-body-min-height, so
+   --uktdd-fill-top lands the body above, filled and scrolling (centered over
+   the trigger, shifted inward at the corners) */
+.too-tall-demo {
+    position: fixed;
+    inset-block-end: 2px;
+    inset-inline: 8px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.too-tall {
+    --uktdd-body-position-area: block-end span-inline-start;
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 }
 
 /* ---- Fixed Header Styles ---- */

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -15,10 +15,6 @@
         height: calc(200vh - 110px);
         width: calc(200vw - 270px);
     }
-
-    &:has(.direction-recipes) {
-        height: 480px;
-    }
 }
 
 .sb-story {
@@ -253,17 +249,19 @@
     --uktdd-submenu-gap: 8px;
 }
 
-/* the four --uktdd-body-position-area / --uktdd-body-position-try-fallbacks
-   recipes from the README’s direction cheatsheet. Each recipe opens in its
-   named direction wherever the trigger sits, so this layout is purely
-   cosmetic: the rows sit near the canvas’s top and bottom edges — the
-   bottom-opening pair up top, the top-opening pair down low — only so each
-   menu opens into empty space instead of overlapping the other row */
+/* the recipe variables live on each Dropdown’s style prop in the story (so
+   the docs “Show code” panel displays them); this layout is purely
+   cosmetic. The fixed block-size (rather than 100% of a sized canvas)
+   holds in the docs page’s inline rendering too, keeping the rows near the
+   top and bottom edges — the bottom-opening pair up top, the top-opening
+   pair down low — so each menu opens into empty space instead of
+   overlapping the other row */
 .direction-recipes {
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    block-size: 100%;
+    block-size: 420px;
     padding-block: 1.5rem;
 }
 
@@ -275,34 +273,6 @@
 
 .direction-recipes .uktdropdown-body {
     inline-size: 140px;
-}
-
-.direction-bottom-start {
-    --uktdd-body-position-area: block-end span-inline-end;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end;
-}
-
-.direction-bottom-end {
-    --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
-}
-
-/* the top-opening recipes also flip the last-resort fill pair so a body too
-   tall to fit anywhere fills and scrolls on the upward side first */
-.direction-top-start {
-    --uktdd-body-position-area: block-start span-inline-end;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end;
-    --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
-}
-
-.direction-top-end {
-    --uktdd-body-position-area: block-start span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
-    --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
 }
 
 /* FillsWhenTooTall: the issue-#399 shape — a menu taller than the viewport,

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -294,6 +294,27 @@
         --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
 }
 
+/* CoverFillRecipe: the cover fill trades trigger coverage for full
+   viewport height when the body fits horizontally (the recipe lives on
+   each Dropdown’s style prop so “Show code” displays it). The mid-height
+   start-edge trigger fits the cover’s inline region, so its body covers
+   the trigger and fills the whole canvas height; the right-corner
+   trigger’s 180px body overflows its trigger-to-edge region, so the
+   cover is rejected and the guaranteed pair fills one side instead */
+.cover-fill-demo {
+    position: fixed;
+    /* mid-viewport without a translate, which would shift the triggers
+       away from where their bodies attach — see .too-tall-center-min */
+    inset-block-start: calc(50% - 30px);
+    inset-inline: 8px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.cover-fill .uktdropdown-body {
+    inline-size: 180px;
+}
+
 /* the mid-viewport trigger whose --uktdd-body-min-height: 300px (set on
    its style prop, so “Show code” displays it) exceeds either ~195px side
    of the 420px canvas — the fills cap the floor at the worst-case side,

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -789,7 +789,7 @@ export const FillsWhenTooTall: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'A menu taller than the viewport whose trigger sits at the bottom edge (the shape from issue #399), with no `--uktdd-body-max-height` cap. The body fits at natural size in none of the authored placements, so the last-resort `--uktdd-body-fill-fallbacks` placements take over: the below side is under `--uktdd-body-min-height`, so `--uktdd-fill-bottom` is rejected and `--uktdd-fill-top` flips the body above the trigger, sizes it to that side, and lets the content scroll. Fill placements center the body over the trigger and shift it inward as needed to stay on-screen — that shift is what keeps the corner menus inside the viewport. The center menu nests a tall submenu, which likewise fills and scrolls beside its parent item instead of running past the viewport edge.',
+                story: 'A menu taller than the viewport whose trigger sits at the bottom edge (the shape from issue #399), with no `--uktdd-body-max-height` cap. The body fits at natural size in none of the authored placements, so the last-resort `--uktdd-body-fill-fallbacks` placements take over: the below side is under `--uktdd-body-min-height`, so `--uktdd-fill-bottom` is rejected and `--uktdd-fill-top` flips the body above the trigger, sizes it to that side, and lets the content scroll. Fill placements center the body over the trigger and shift it inward as needed to stay on-screen — that shift is what keeps the corner menus inside the viewport. The center menu nests a tall submenu, which likewise fills and scrolls beside its parent item instead of running past the viewport edge. The mid-viewport trigger sets `--uktdd-body-min-height: 300px` — taller than either ~195px side of this 420px-tall canvas. The fills cap that floor at the worst-case side (half the viewport minus the trigger), so instead of both fills being rejected and the body reverting to the overflowing primary placement, it fills below the trigger and scrolls.',
             },
             story: { height: '420px', inline: false },
         },
@@ -817,6 +817,14 @@ export const FillsWhenTooTall: Story = {
                 </Dropdown>
                 <Dropdown className="too-tall" onSubmitItem={fn()}>
                     Near right corner
+                    <ul>{items}</ul>
+                </Dropdown>
+                <Dropdown
+                    className="too-tall too-tall-center-min"
+                    onSubmitItem={fn()}
+                    style={{ '--uktdd-body-min-height': '300px' }}
+                >
+                    Centered, 300px min-height
                     <ul>{items}</ul>
                 </Dropdown>
             </div>

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -785,6 +785,13 @@ export const DirectionRecipes: Story = {
     },
 };
 
+const renderTallMenuItems = () =>
+    Array.from({ length: 30 }, (_, index) => (
+        <li data-ukt-value={`item-${index + 1}`} key={index}>
+            Menu item {index + 1}
+        </li>
+    ));
+
 export const FillsWhenTooTall: Story = {
     parameters: {
         docs: {
@@ -795,11 +802,7 @@ export const FillsWhenTooTall: Story = {
         },
     },
     render() {
-        const items = Array.from({ length: 30 }, (_, index) => (
-            <li data-ukt-value={`item-${index + 1}`} key={index}>
-                Menu item {index + 1}
-            </li>
-        ));
+        const items = renderTallMenuItems();
         return (
             <div className="too-tall-demo">
                 <Dropdown className="too-tall" onSubmitItem={fn()}>
@@ -825,6 +828,50 @@ export const FillsWhenTooTall: Story = {
                     style={{ '--uktdd-body-min-height': '300px' }}
                 >
                     Centered, 300px min-height
+                    <ul>{items}</ul>
+                </Dropdown>
+            </div>
+        );
+    },
+};
+
+// the recipe inline on the style prop (like DIRECTION_RECIPE_ROWS) so the
+// docs “Show code” panel displays it: the cover fill listed before the
+// guaranteed pair, with two authored fallbacks — the budget headroom the
+// three-fill list needs
+const COVER_FILL_STYLE = {
+    '--uktdd-body-fill-fallbacks':
+        '--uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top',
+    '--uktdd-body-position-try-fallbacks': '--uktdd-top-start, --uktdd-bottom-end',
+} as const;
+
+export const CoverFillRecipe: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'The opt-in `--uktdd-fill-cover` recipe: `--uktdd-body-fill-fallbacks: --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top`, with at most two authored fallbacks for the budget headroom the three-fill list needs. Where the default fills keep the body beside the trigger — bounding their height by where the trigger sits — the cover fill keeps the strict start-aligned inline edge and loosens the block axis instead, sizing the body to the full viewport height, covering the trigger. It is rejected when the body overflows the region between the trigger’s inline-start edge and the viewport edge: the first menu fits horizontally, so its body covers the mid-height trigger and scrolls the whole canvas height; the right-corner menu’s 180px body does not fit, so the cover is rejected and the guaranteed block-side fills take over as usual.',
+            },
+            story: { height: '420px', inline: false },
+        },
+    },
+    render() {
+        const items = renderTallMenuItems();
+        return (
+            <div className="cover-fill-demo">
+                <Dropdown
+                    className="cover-fill"
+                    onSubmitItem={fn()}
+                    style={COVER_FILL_STYLE}
+                >
+                    Mid-height, start edge
+                    <ul>{items}</ul>
+                </Dropdown>
+                <Dropdown
+                    className="cover-fill"
+                    onSubmitItem={fn()}
+                    style={COVER_FILL_STYLE}
+                >
+                    Near right corner
                     <ul>{items}</ul>
                 </Dropdown>
             </div>

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -879,6 +879,32 @@ export const CoverFillRecipe: Story = {
     },
 };
 
+export const SubmenuFillsBesideParent: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A parent item pinned near the block-end (bottom) edge with a submenu taller than the space beside it. Its natural placement (open to the inline-end, top-aligned) has too little room below, so the last-resort `--uktdd-submenu-fill-fallbacks` take over: `--uktdd-submenu-fill` fills the full viewport height beside the parent and anchor-centers to stay on-screen, then scrolls — staying next to the parent item rather than covering the parent menu (the macOS behavior). Contrast the body’s block-side fills, which cover the trigger; a submenu never covers its parent.',
+            },
+            story: { height: '420px', inline: false },
+        },
+    },
+    render() {
+        return (
+            <div className="submenu-beside-demo">
+                <Dropdown onSubmitItem={fn()}>
+                    Bottom-pinned menu
+                    <ul>
+                        <li data-ukt-item>An item</li>
+                        <Dropdown label="Tall submenu">
+                            <ul>{renderTallMenuItems()}</ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>
+            </div>
+        );
+    },
+};
+
 export const SubmenuDropdown: Story = {
     args: {
         children: [

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -701,14 +701,52 @@ export const CenteredMenu: Story = {
     },
 };
 
+// each recipe inline on the style prop (which accepts --uktdd-* custom
+// properties) so the docs “Show code” panel displays the actual variable
+// pairs; the top-opening pair also flips --uktdd-body-fill-fallbacks so
+// the last-resort fill prefers the upward side
 const DIRECTION_RECIPE_ROWS = [
     [
-        { className: 'direction-bottom-start', label: 'Bottom Start (default)' },
-        { className: 'direction-bottom-end', label: 'Bottom End' },
+        {
+            className: 'direction-bottom-start',
+            label: 'Bottom Start (default)',
+            style: {
+                '--uktdd-body-position-area': 'block-end span-inline-end',
+                '--uktdd-body-position-try-fallbacks':
+                    '--uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end',
+            },
+        },
+        {
+            className: 'direction-bottom-end',
+            label: 'Bottom End',
+            style: {
+                '--uktdd-body-position-area': 'block-end span-inline-start',
+                '--uktdd-body-position-try-fallbacks':
+                    '--uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start',
+            },
+        },
     ],
     [
-        { className: 'direction-top-start', label: 'Top Start' },
-        { className: 'direction-top-end', label: 'Top End' },
+        {
+            className: 'direction-top-start',
+            label: 'Top Start',
+            style: {
+                '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
+                '--uktdd-body-position-area': 'block-start span-inline-end',
+                '--uktdd-body-position-try-fallbacks':
+                    '--uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end',
+            },
+        },
+        {
+            className: 'direction-top-end',
+            label: 'Top End',
+            style: {
+                '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
+                '--uktdd-body-position-area': 'block-start span-inline-start',
+                '--uktdd-body-position-try-fallbacks':
+                    '--uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start',
+            },
+        },
     ],
 ] as const;
 
@@ -716,7 +754,7 @@ export const DirectionRecipes: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The top-opening pair also flips `--uktdd-body-fill-fallbacks` so the last-resort fill prefers the upward side. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
+                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each dropdown carries its recipe on its `style` prop, so “Show code” below displays the exact variable pairs. Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The top-opening pair also flips `--uktdd-body-fill-fallbacks` so the last-resort fill prefers the upward side. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
             },
         },
     },
@@ -725,11 +763,12 @@ export const DirectionRecipes: Story = {
             <div className="direction-recipes">
                 {DIRECTION_RECIPE_ROWS.map((row) => (
                     <div className="direction-recipes-row" key={row[0].className}>
-                        {row.map(({ className, label }) => (
+                        {row.map(({ className, label, style }) => (
                             <Dropdown
                                 className={className}
                                 key={className}
                                 onSubmitItem={fn()}
+                                style={style}
                             >
                                 {label}
                                 <ul>

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -713,7 +713,7 @@ const DIRECTION_RECIPE_ROWS = [
             style: {
                 '--uktdd-body-position-area': 'block-end span-inline-end',
                 '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end',
+                    '--uktdd-top-start, --uktdd-bottom-end',
             },
         },
         {
@@ -722,7 +722,7 @@ const DIRECTION_RECIPE_ROWS = [
             style: {
                 '--uktdd-body-position-area': 'block-end span-inline-start',
                 '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start',
+                    '--uktdd-top-end, --uktdd-bottom-start',
             },
         },
     ],
@@ -734,7 +734,7 @@ const DIRECTION_RECIPE_ROWS = [
                 '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
                 '--uktdd-body-position-area': 'block-start span-inline-end',
                 '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end',
+                    '--uktdd-bottom-start, --uktdd-top-end',
             },
         },
         {
@@ -744,7 +744,7 @@ const DIRECTION_RECIPE_ROWS = [
                 '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
                 '--uktdd-body-position-area': 'block-start span-inline-start',
                 '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start',
+                    '--uktdd-bottom-end, --uktdd-top-start',
             },
         },
     ],

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -837,8 +837,8 @@ export const FillsWhenTooTall: Story = {
 
 // the recipe inline on the style prop (like DIRECTION_RECIPE_ROWS) so the
 // docs “Show code” panel displays it: the cover fill listed before the
-// guaranteed pair, with two authored fallbacks — the budget headroom the
-// three-fill list needs
+// guaranteed pair, with two authored fallbacks — the most a three-fill list
+// has room for (six options, the limit every current engine clears)
 const COVER_FILL_STYLE = {
     '--uktdd-body-fill-fallbacks':
         '--uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top',
@@ -849,7 +849,7 @@ export const CoverFillRecipe: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'The opt-in `--uktdd-fill-cover` recipe: `--uktdd-body-fill-fallbacks: --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top`, with at most two authored fallbacks for the budget headroom the three-fill list needs. Where the default fills keep the body beside the trigger — bounding their height by where the trigger sits — the cover fill keeps the strict start-aligned inline edge and loosens the block axis instead, sizing the body to the full viewport height, covering the trigger. It is rejected when the body overflows the region between the trigger’s inline-start edge and the viewport edge: the first menu fits horizontally, so its body covers the mid-height trigger and scrolls the whole canvas height; the right-corner menu’s 180px body does not fit, so the cover is rejected and the guaranteed block-side fills take over as usual.',
+                story: 'The opt-in `--uktdd-fill-cover` recipe: `--uktdd-body-fill-fallbacks: --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top`, with at most two authored fallbacks — the most a three-fill list has room for (six options, within the limit every current engine evaluates). Where the default fills keep the body beside the trigger — bounding their height by where the trigger sits — the cover fill keeps the strict start-aligned inline edge and loosens the block axis instead, sizing the body to the full viewport height, covering the trigger. It is rejected when the body overflows the region between the trigger’s inline-start edge and the viewport edge: the first menu fits horizontally, so its body covers the mid-height trigger and scrolls the whole canvas height; the right-corner menu’s 180px body does not fit, so the cover is rejected and the guaranteed block-side fills take over as usual.',
             },
             story: { height: '420px', inline: false },
         },

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -716,7 +716,7 @@ export const DirectionRecipes: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
+                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The top-opening pair also flips `--uktdd-body-fill-fallbacks` so the last-resort fill prefers the upward side. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
             },
         },
     },
@@ -741,6 +741,45 @@ export const DirectionRecipes: Story = {
                         ))}
                     </div>
                 ))}
+            </div>
+        );
+    },
+};
+
+export const FillsWhenTooTall: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A menu taller than the viewport whose trigger sits at the bottom edge (the shape from issue #399), with no `--uktdd-body-max-height` cap. The body fits at natural size in none of the authored placements, so the last-resort `--uktdd-body-fill-fallbacks` placements take over: the below side is under `--uktdd-body-min-height`, so `--uktdd-fill-bottom` is rejected and `--uktdd-fill-top` flips the body above the trigger, sizes it to that side, and lets the content scroll. Fill placements center the body over the trigger and shift it inward as needed to stay on-screen — that shift is what keeps the corner menus inside the viewport. The center menu nests a tall submenu, which likewise fills and scrolls beside its parent item instead of running past the viewport edge.',
+            },
+            story: { height: '420px', inline: false },
+        },
+    },
+    render() {
+        const items = Array.from({ length: 30 }, (_, index) => (
+            <li data-ukt-value={`item-${index + 1}`} key={index}>
+                Menu item {index + 1}
+            </li>
+        ));
+        return (
+            <div className="too-tall-demo">
+                <Dropdown className="too-tall" onSubmitItem={fn()}>
+                    Near left corner
+                    <ul>{items}</ul>
+                </Dropdown>
+                <Dropdown className="too-tall" onSubmitItem={fn()}>
+                    Center (with submenu)
+                    <ul>
+                        <Dropdown label="Jump to">
+                            <ul>{items}</ul>
+                        </Dropdown>
+                        {items}
+                    </ul>
+                </Dropdown>
+                <Dropdown className="too-tall" onSubmitItem={fn()}>
+                    Near right corner
+                    <ul>{items}</ul>
+                </Dropdown>
             </div>
         );
     },

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -539,7 +539,7 @@ Example:
 .settings-dropdown {
     --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+        --uktdd-top-end, --uktdd-bottom-start;
     --uktdd-body-gap: 8px;
 }
 
@@ -579,12 +579,12 @@ horizontal-tb writing mode.
 Pick the row matching the direction you want, and set both variables to its
 pair:
 
-| Direction                           | `--uktdd-body-position-area`    | `--uktdd-body-position-try-fallbacks`                         |
-| ----------------------------------- | ------------------------------- | ------------------------------------------------------------- |
-| Bottom, start-aligned (the default) | `block-end span-inline-end`     | `--uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end`      |
-| Bottom, end-aligned                 | `block-end span-inline-start`   | `--uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start`    |
-| Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end`   |
-| Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start` |
+| Direction                           | `--uktdd-body-position-area`    | `--uktdd-body-position-try-fallbacks`   |
+| ----------------------------------- | ------------------------------- | --------------------------------------- |
+| Bottom, start-aligned (the default) | `block-end span-inline-end`     | `--uktdd-top-start, --uktdd-bottom-end` |
+| Bottom, end-aligned                 | `block-end span-inline-start`   | `--uktdd-top-end, --uktdd-bottom-start` |
+| Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start, --uktdd-top-end` |
+| Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end, --uktdd-top-start` |
 
 The two Top rows should also flip the last-resort fill pair to match:
 `--uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom`.
@@ -596,7 +596,7 @@ trigger pinned to the bottom of the viewport, near the inline-end edge):
 .bottom-toolbar-dropdown {
     --uktdd-body-position-area: block-start span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
+        --uktdd-bottom-end, --uktdd-top-start;
     --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
 }
 ```
@@ -638,19 +638,21 @@ trigger can guarantee — so a min-height above half the viewport (honored in
 full by the named placements) can’t reject both fills: the body fills the
 roomier side and scrolls rather than overflowing.
 
-Keep `--uktdd-body-position-try-fallbacks` to at most three options. The
-spec lets engines cap the position options list at an
-implementation-defined length with a floor of five — but that list includes
-the element’s base position, so only four fallbacks past it are guaranteed.
-Chromium evaluates five fallbacks and silently ignores the rest, and the
-component appends the two fill placements after your list: three author
-fallbacks exactly fill Chromium’s budget, and a fourth pushes a fill past
-it, so a trigger near a viewport edge can open off-screen instead of
-flipping and scrolling. Note that even the default list relies on engines
-evaluating one fallback past the spec’s floor — validated in Chromium, the
-engine whose limit bites; an engine at the exact floor would drop the
-second fill. Keep your list to two options if you want both fills within
-the guaranteed floor.
+Keep `--uktdd-body-position-try-fallbacks` to at most two options. The spec
+lets engines cap the position options list at an implementation-defined
+length with a floor of five — and that list includes the element’s base
+position, so only four fallbacks past it are guaranteed. The component
+appends the two fill placements after your list, so two author fallbacks
+plus the two fills is exactly four — within the floor on every conformant
+engine. A third author fallback pushes a fill past the floor into
+Chromium-only territory, and a fourth pushes it past even Chromium, so a
+trigger near a viewport edge can open off-screen instead of flipping and
+scrolling. The default’s two fallbacks are the single-axis flips of the
+primary (a block flip and an inline flip); it drops the both-axes diagonal
+to stay within the floor, so a trigger crammed into the corner diagonal to
+the primary opening direction lands in a fill rather than a natural
+placement — re-tune the primary (per the recipes above) for triggers pinned
+to a viewport corner.
 
 ### Trading Trigger Coverage for a Full-Height Menu
 
@@ -704,7 +706,7 @@ the menu size itself from its contents.
 .avatar-menu {
     --uktdd-body-position-area: block-end span-inline-start;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-top-start, --uktdd-bottom-end;
+        --uktdd-top-end, --uktdd-top-start;
 }
 ```
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -626,6 +626,9 @@ opens upward should flip the pair
 the last-resort fill also prefers the upward side. In these fill placements
 the body spans the trigger (centered over it, shifted inward as needed to
 stay on-screen) rather than keeping the primary placement’s edge alignment.
+Submenus reuse the pair as their own final rescue, so flipping it for the
+body also flips its submenus’ fill order — nested menus share their menu’s
+directional preference.
 
 In the fills, `--uktdd-body-min-height` marks a side as too cramped to
 bother with: a fill whose side is shorter than it is rejected so the
@@ -636,11 +639,18 @@ full by the named placements) can’t reject both fills: the body fills the
 roomier side and scrolls rather than overflowing.
 
 Keep `--uktdd-body-position-try-fallbacks` to at most three options. The
-limit at which browsers stop evaluating `position-try` options can be as
-low as five (e.g. in Chromium) and the component appends the two fill
-placements after your list. A fourth author fallback pushes a fill past
-that limit, and a trigger near a viewport edge can then open off-screen
-instead of flipping and scrolling.
+spec lets engines cap the position options list at an
+implementation-defined length with a floor of five — but that list includes
+the element’s base position, so only four fallbacks past it are guaranteed.
+Chromium evaluates five fallbacks and silently ignores the rest, and the
+component appends the two fill placements after your list: three author
+fallbacks exactly fill Chromium’s budget, and a fourth pushes a fill past
+it, so a trigger near a viewport edge can open off-screen instead of
+flipping and scrolling. Note that even the default list relies on engines
+evaluating one fallback past the spec’s floor — validated in Chromium, the
+engine whose limit bites; an engine at the exact floor would drop the
+second fill. Keep your list to two options if you want both fills within
+the guaranteed floor.
 
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever
@@ -813,9 +823,11 @@ properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
 - `--uktdd-submenu-position-try-fallbacks` (keep it to a single option: the
-  component appends four last-resort placements after it, and browsers may
-  evaluate as few as five `position-try` options, e.g. Chromium, so a
-  second author fallback pushes the final rescue placement out of reach)
+  component appends four last-resort placements after it, and Chromium
+  evaluates at most five fallbacks — the spec floor guarantees only four —
+  so a second author fallback pushes the final rescue placement out of
+  reach, and the submenu list already relies on engines evaluating one
+  fallback past the floor)
 - `--uktdd-submenu-gap` (space between the parent item and the submenu;
   applied as a symmetric `margin-inline`, the inline-axis counterpart to
   `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -652,6 +652,36 @@ engine whose limit bites; an engine at the exact floor would drop the
 second fill. Keep your list to two options if you want both fills within
 the guaranteed floor.
 
+### Trading Trigger Coverage for a Full-Height Menu
+
+The block-side fills never cover the trigger, which bounds their height by
+where the trigger sits. When the body already fits horizontally, the opt-in
+`--uktdd-fill-cover` placement (in no default list) can trade that
+guarantee away: it keeps the strict start-aligned inline edge (compose
+`--uktdd-fill-cover flip-inline` for end alignment) and loosens the block
+axis instead, sizing the body to the viewport’s full block size — covering
+the trigger — so a too-tall menu gets the whole viewport to scroll in
+rather than one side of it.
+
+```css
+.tall-menu {
+    --uktdd-body-position-try-fallbacks:
+        --uktdd-top-start, --uktdd-bottom-end;
+    --uktdd-body-fill-fallbacks:
+        --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top;
+}
+```
+
+The cover fill is rejected whenever the body is too wide for the region
+between the trigger’s inline-start edge and the viewport edge, so the
+guaranteed pair still rescues corner triggers — but the pair must stay
+within the evaluation budget: at most two author fallbacks alongside the
+three fills (a single author fallback keeps the whole list within the
+spec’s guaranteed floor). Two caveats: don’t use it on searchable
+dropdowns, since the body overlays the trigger’s input while open; and
+while the body covers the trigger, clicking the trigger’s position hits the
+body instead — dismiss with Escape or a click elsewhere outside.
+
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever
 side the body attaches to and auto-reverses when `position-try` flips the

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -627,6 +627,14 @@ the last-resort fill also prefers the upward side. In these fill placements
 the body spans the trigger (centered over it, shifted inward as needed to
 stay on-screen) rather than keeping the primary placement’s edge alignment.
 
+In the fills, `--uktdd-body-min-height` marks a side as too cramped to
+bother with: a fill whose side is shorter than it is rejected so the
+roomier opposite side is tried. That floor is capped at the worst-case side
+— half the viewport minus the trigger, the most a vertically centered
+trigger can guarantee — so a min-height above half the viewport (honored in
+full by the named placements) can’t reject both fills: the body fills the
+roomier side and scrolls rather than overflowing.
+
 Keep `--uktdd-body-position-try-fallbacks` to at most three options. The
 limit at which browsers stop evaluating `position-try` options can be as
 low as five (e.g. in Chromium) and the component appends the two fill

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -645,15 +645,16 @@ length with a floor of five — and that list includes the element’s base
 position, so only four fallbacks past it are guaranteed. The component
 appends the two fill placements after your list, so two author fallbacks
 plus the two fills is exactly four — within the floor on every conformant
-engine. A third author fallback pushes a fill past the floor into
-Chromium-only territory, and a fourth pushes it past even Chromium, so a
-trigger near a viewport edge can open off-screen instead of flipping and
-scrolling. The default’s two fallbacks are the single-axis flips of the
-primary (a block flip and an inline flip); it drops the both-axes diagonal
-to stay within the floor, so a trigger crammed into the corner diagonal to
-the primary opening direction lands in a fill rather than a natural
-placement — re-tune the primary (per the recipes above) for triggers pinned
-to a viewport corner.
+engine. A third author fallback (six options) still works on every current
+engine but leans past the spec floor onto their real limits (Chromium
+evaluates exactly six; Safari and Firefox more); a fourth pushes a fill
+past even Chromium, so a trigger near a viewport edge can open off-screen
+instead of flipping and scrolling. The default’s two fallbacks are the
+single-axis flips of the primary (a block flip and an inline flip); it
+drops the both-axes diagonal to stay within the floor, so a trigger crammed
+into the corner diagonal to the primary opening direction lands in a fill
+rather than a natural placement — re-tune the primary (per the recipes
+above) for triggers pinned to a viewport corner.
 
 ### Trading Trigger Coverage for a Full-Height Menu
 
@@ -678,12 +679,15 @@ rather than one side of it.
 The cover fill is rejected whenever the body is too wide for the region
 between the trigger’s inline-start edge and the viewport edge, so the
 guaranteed pair still rescues corner triggers — but the pair must stay
-within the evaluation budget: at most two author fallbacks alongside the
-three fills (a single author fallback keeps the whole list within the
-spec’s guaranteed floor). Two caveats: don’t use it on searchable
-dropdowns, since the body overlays the trigger’s input while open; and
-while the body covers the trigger, clicking the trigger’s position hits the
-body instead — dismiss with Escape or a click elsewhere outside.
+within the evaluation budget: with three fills you get at most two author
+fallback slots, for six position options total. That’s the ceiling every
+current engine clears (Chromium evaluates exactly six; Safari and Firefox
+go well beyond), though only five are spec-guaranteed — drop to one author
+fallback if you want the whole list within that floor. Two caveats: don’t
+use it on searchable dropdowns, since the body overlays the trigger’s input
+while open; and while the body covers the trigger, clicking the trigger’s
+position hits the body instead — dismiss with Escape or a click elsewhere
+outside.
 
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -525,6 +525,8 @@ CSS custom properties for the most common low-level placement controls:
 
 - `--uktdd-body-position-area`
 - `--uktdd-body-position-try-fallbacks`
+- `--uktdd-body-fill-fallbacks` (the last-resort fill placements, tried
+  when the body fits nowhere at its natural size)
 - `--uktdd-body-gap` (space between the trigger and the body)
 - `--uktdd-body-min-height`
 - `--uktdd-body-min-width`
@@ -584,6 +586,9 @@ pair:
 | Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start, --uktdd-top-end, --uktdd-bottom-end`   |
 | Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start` |
 
+The two Top rows should also flip the last-resort fill pair to match:
+`--uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom`.
+
 For example, to make a dropdown open upward and end-aligned (useful for a
 trigger pinned to the bottom of the viewport, near the inline-end edge):
 
@@ -592,8 +597,14 @@ trigger pinned to the bottom of the viewport, near the inline-end edge):
     --uktdd-body-position-area: block-start span-inline-start;
     --uktdd-body-position-try-fallbacks:
         --uktdd-bottom-end, --uktdd-top-start, --uktdd-bottom-start;
+    --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
 }
 ```
+
+The last line flips the last-resort fill pair to match the recipe’s
+direction: when the body is too tall to fit anywhere at its natural size,
+it fills and scrolls on the upward side first (more on the fill pair
+below).
 
 See the [`DirectionRecipes` story][] for a live demo of all four.
 
@@ -604,9 +615,24 @@ The primary placement wins whenever the body fits there at its natural
 size, then the fallbacks are tried in order — the body opens in the
 direction you asked for as long as that side can hold it, and never flips
 to the opposite side just because the viewport happens to have more empty
-space there. Only when the body fits in none of those placements does it
-size itself to the block-axis space its preferred side has and let the
-content scroll, so it never overflows the viewport or covers the trigger.
+space there. Only when the body fits in none of those placements do the
+`--uktdd-body-fill-fallbacks` placements
+(`--uktdd-fill-bottom, --uktdd-fill-top` by default) take over: the body
+sizes itself to the block-axis space below the trigger — or above it,
+whichever the pair lists first that has room — and lets the content scroll,
+so it never overflows the viewport or covers the trigger. A dropdown that
+opens upward should flip the pair
+(`--uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom`) so
+the last-resort fill also prefers the upward side. In these fill placements
+the body spans the trigger (centered over it, shifted inward as needed to
+stay on-screen) rather than keeping the primary placement’s edge alignment.
+
+Keep `--uktdd-body-position-try-fallbacks` to at most three options. The
+limit at which browsers stop evaluating `position-try` options can be as
+low as five (e.g. in Chromium) and the component appends the two fill
+placements after your list. A fourth author fallback pushes a fill past
+that limit, and a trigger near a viewport edge can then open off-screen
+instead of flipping and scrolling.
 
 Use `--uktdd-body-gap` for the space between the trigger and the body. It
 is applied as a symmetric `margin-block`, so the gap lands on whichever
@@ -778,7 +804,10 @@ it flush to the parent item’s edge across browsers. Placement custom
 properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
-- `--uktdd-submenu-position-try-fallbacks`
+- `--uktdd-submenu-position-try-fallbacks` (keep it to a single option: the
+  component appends four last-resort placements after it, and browsers may
+  evaluate as few as five `position-try` options, e.g. Chromium, so a
+  second author fallback pushes the final rescue placement out of reach)
 - `--uktdd-submenu-gap` (space between the parent item and the submenu;
   applied as a symmetric `margin-inline`, the inline-axis counterpart to
   `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -626,9 +626,10 @@ opens upward should flip the pair
 the last-resort fill also prefers the upward side. In these fill placements
 the body spans the trigger (centered over it, shifted inward as needed to
 stay on-screen) rather than keeping the primary placement’s edge alignment.
-Submenus reuse the pair as their own final rescue, so flipping it for the
-body also flips its submenus’ fill order — nested menus share their menu’s
-directional preference.
+Submenus have their own last-resort fills
+([`--uktdd-submenu-fill-fallbacks`](#submenu-placement-and-styling)) that
+keep them beside the parent rather than covering it, so this pair applies
+to the body alone.
 
 In the fills, `--uktdd-body-min-height` marks a side as too cramped to
 bother with: a fill whose side is shorter than it is rejected so the
@@ -854,12 +855,25 @@ it flush to the parent item’s edge across browsers. Placement custom
 properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
-- `--uktdd-submenu-position-try-fallbacks` (keep it to a single option: the
-  component appends four last-resort placements after it, and Chromium
-  evaluates at most five fallbacks — the spec floor guarantees only four —
-  so a second author fallback pushes the final rescue placement out of
-  reach, and the submenu list already relies on engines evaluating one
-  fallback past the floor)
+- `--uktdd-submenu-position-try-fallbacks` (default:
+  `--uktdd-submenu-inline-start`; keep it to a single option — the
+  component appends two last-resort fills after it, and the spec guarantees
+  only four evaluated fallbacks, so a second author fallback would push a
+  fill out of reach)
+- `--uktdd-submenu-fill-fallbacks` (the last-resort fills for a submenu too
+  tall to open beside its parent at natural size; default
+  `--uktdd-submenu-fill, --uktdd-submenu-fill flip-inline` — a full-height
+  fill on each inline side that anchor-centers on the block axis, so the
+  submenu fills the viewport height beside the parent and scrolls rather
+  than covering the parent menu, the way macOS never covers a parent with
+  its submenu. Flip the pair for a submenu that opens `inline-start` by
+  default. A submenu wider than the space on either side of its parent —
+  out of scope for a macOS-style menu’s narrow columns — is the one case
+  this gives up versus covering the parent; append
+  `--uktdd-fill-bottom, --uktdd-fill-top` here to restore the
+  parent-covering rescue if you need it, keeping
+  `--uktdd-submenu-position-try-fallbacks` empty to stay within the
+  evaluation limit)
 - `--uktdd-submenu-gap` (space between the parent item and the submenu;
   applied as a symmetric `margin-inline`, the inline-axis counterpart to
   `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -94,8 +94,9 @@
        side, each unrejectable on the inline axis (span-all can’t overflow
        horizontally, and anchor-center shifts the body as needed to keep it
        inside the viewport). A fill can only be rejected when its side is
-       shorter than --uktdd-body-min-height, and the sides sum to the
-       viewport, so at least one of the pair always fits. Authors
+       shorter than its min-block-size floor, and the fills cap that floor
+       at the worst-case larger side (see their @position-try rules), so at
+       least one of the pair always fits. Authors
        overriding --uktdd-body-position-try-fallbacks must keep it to three
        options so these fills stay within the limit */
     position-try-fallbacks:
@@ -328,9 +329,13 @@ div.uktdropdown-body {
    overflowing and the option is never selected (the same quirk rejects
    intrinsic keywords like max-content set inside @position-try). 100% is
    the space on the attached side; subtracting the symmetric
-   --uktdd-body-gap margins keeps the margin box inside it. The base
-   min-block-size still applies, so a side shorter than
-   --uktdd-body-min-height is rejected and the other side’s fill is tried.
+   --uktdd-body-gap margins keeps the margin box inside it. min-block-size
+   still applies, so a side shorter than --uktdd-body-min-height is
+   rejected and the other side’s fill is tried — but capped at the
+   worst-case larger side, (100dvb - anchor)/2 (an anchor centered on the
+   block axis splits the rest of the viewport evenly), so a min above
+   ~half the viewport can no longer reject both sides and strand the body
+   at the overflowing primary placement.
 
    --uktdd-fill-bottom/-top must be unrejectable on the inline axis so
    whichever block side can hold the element is always accepted — what
@@ -344,12 +349,22 @@ div.uktdropdown-body {
 @position-try --uktdd-fill-bottom {
     position-area: block-end;
     block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    min-block-size: min(
+        var(--uktdd-body-min-height),
+        var(--uktdd-body-max-height),
+        calc((100dvb - anchor-size(block)) / 2 - var(--uktdd-body-gap) * 2)
+    );
     justify-self: anchor-center;
 }
 
 @position-try --uktdd-fill-top {
     position-area: block-start;
     block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    min-block-size: min(
+        var(--uktdd-body-min-height),
+        var(--uktdd-body-max-height),
+        calc((100dvb - anchor-size(block)) / 2 - var(--uktdd-body-gap) * 2)
+    );
     justify-self: anchor-center;
 }
 

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -386,3 +386,23 @@ div.uktdropdown-body {
 @position-try --uktdd-fill {
     block-size: calc(100% - var(--uktdd-body-gap) * 2);
 }
+
+/* The opt-in cover fill (in no default list): where the block-side fills
+   loosen the inline axis and keep the body beside the trigger, this keeps
+   the strict start-aligned inline edge (span-inline-end, like the -start
+   placements; compose `--uktdd-fill-cover flip-inline` for end alignment)
+   and loosens the block axis instead — span-all sizes the body to the
+   viewport’s full block axis, covering the trigger, and anchor-center
+   keeps a shorter body (an authored max-block-size) centered over the
+   trigger and shifted on-screen. Overflowing the trigger-to-viewport-edge
+   inline region rejects it, so it applies only when the body fits
+   horizontally as aligned: list it before the guaranteed pair
+   (--uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top) with at
+   most two author fallbacks so the pair stays within Chromium’s budget
+   (one for the spec floor — see the .uktdropdown-body rule). Avoid it on
+   searchable dropdowns: the body overlays the trigger’s input */
+@position-try --uktdd-fill-cover {
+    position-area: span-all span-inline-end;
+    block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    align-self: anchor-center;
+}

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -427,9 +427,11 @@ div.uktdropdown-body {
    inline region rejects it, so it applies only when the body fits
    horizontally as aligned: list it before the guaranteed pair
    (--uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top) with at
-   most two author fallbacks so the pair stays within Chromium’s budget
-   (one for the spec floor — see the .uktdropdown-body rule). Avoid it on
-   searchable dropdowns: the body overlays the trigger’s input */
+   most two author fallbacks, for six options total — the ceiling every
+   current engine clears (Chromium evaluates six; Safari and Firefox go
+   further). One author fallback keeps it within the spec floor of five
+   (see the .uktdropdown-body rule). Avoid it on searchable dropdowns: the
+   body overlays the trigger’s input */
 @position-try --uktdd-fill-cover {
     position-area: span-all span-inline-end;
     block-size: calc(100% - var(--uktdd-body-gap) * 2);

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -20,6 +20,11 @@
     --uktdd-body-position-area: block-end span-inline-end;
     --uktdd-body-position-try-fallbacks:
         --uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end;
+    /* the last-resort fill placements appended after the fallbacks above
+       (see the .uktdropdown-body rule). Overridable so a dropdown that
+       prefers opening upward can flip the pair’s order to keep the fill
+       on its preferred side: --uktdd-fill-top, --uktdd-fill-bottom */
+    --uktdd-body-fill-fallbacks: --uktdd-fill-bottom, --uktdd-fill-top;
     /* gap between the trigger and the body, applied as a symmetric
        margin-block so it lands on whichever side the body attaches to and
        auto-reverses when position-try flips it above/below the trigger. A
@@ -77,26 +82,24 @@
     position-anchor: --uktdd-anchor;
     position-area: var(--uktdd-body-position-area);
     /* the primary placement wins whenever the body fits there, then the
-       author’s fallbacks are tried in order (no position-try-order:
-       most-height, which would override a fitting primary with whichever
-       side of the viewport happens to be taller). The trailing --uktdd-fill
-       options are the last resort when the body fits at its natural size in
-       none of the author’s placements: --uktdd-fill sizes the body to the
-       block-axis space it has and lets the content region scroll, so a body
-       taller than the space never overflows or covers the trigger. The four
-       ordered variants keep the body as close to the primary placement as
-       possible — same side first, flipping inline alignment only to escape a
-       horizontal-overflow rejection, and flipping to the opposite block side
-       only when the preferred side is under --uktdd-body-min-height. Since
-       --uktdd-fill clamps the block size, it can only be rejected for
-       horizontal overflow (→ flip-inline) or a too-short side (→ flip-block),
-       and these four cover every combination */
+       fallbacks are tried in order (no position-try-order: most-height,
+       which would move the body to the viewport’s taller side even when
+       the primary placement fits). The trailing fill options are the last
+       resort when the body fits in none of the placements: each sizes the
+       body to the block-axis space on one side of the trigger so the
+       content region scrolls. The limit at which engines may stop
+       evaluating position options can be as low as five (Chromium
+       evaluates five and silently ignores the rest). The default budget is
+       the three named author fallbacks plus these two fills: one per block
+       side, each unrejectable on the inline axis (span-all can’t overflow
+       horizontally, and anchor-center shifts the body as needed to keep it
+       inside the viewport). A fill can only be rejected when its side is
+       shorter than --uktdd-body-min-height, and the sides sum to the
+       viewport, so at least one of the pair always fits. Authors
+       overriding --uktdd-body-position-try-fallbacks must keep it to three
+       options so these fills stay within the limit */
     position-try-fallbacks:
-        var(--uktdd-body-position-try-fallbacks),
-        --uktdd-fill,
-        --uktdd-fill flip-inline,
-        --uktdd-fill flip-block,
-        --uktdd-fill flip-block flip-inline;
+        var(--uktdd-body-position-try-fallbacks), var(--uktdd-body-fill-fallbacks);
     min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));
     /* no 100% clamp: a placement is only accepted when the body’s natural
        size fits it, so squeezing is reserved for the --uktdd-fill options */
@@ -213,23 +216,29 @@
         position-area: var(--uktdd-submenu-position-area);
         /* same strict-fit + fill-last-resort model as the body (see the
            .uktdropdown-body rule): a too-tall submenu sizes to its block-axis
-           space and scrolls instead of clipping past the viewport edge, and
-           the four --uktdd-fill variants keep it as near the primary
-           placement as possible before flipping inline or block */
+           space and scrolls instead of clipping past the viewport edge. The
+           list is budgeted to the five-option evaluation limit like the
+           body’s: the author fallback, a same-side fill, its opposite-side
+           mirror (submenus open sideways, so the mirror flips inline), then
+           the two block-side fills as the final rescue when neither side of
+           the parent item can hold the submenu column */
         position-try-fallbacks:
             var(--uktdd-submenu-position-try-fallbacks),
             --uktdd-fill,
             --uktdd-fill flip-inline,
-            --uktdd-fill flip-block,
-            --uktdd-fill flip-block flip-inline;
+            var(--uktdd-body-fill-fallbacks);
         z-index: 2;
         margin-block: 0;
         margin-inline: var(--uktdd-submenu-gap);
-        /* the shared --uktdd-fill subtracts --uktdd-body-gap to keep the body’s
+        /* the fill options subtract --uktdd-body-gap to keep the body’s
            block-axis margins inside the fill region; a submenu’s block margins
            are 0 (its gap is inline), so zero it here to avoid shortening a
-           filled submenu when a consumer sets a body gap */
-        --uktdd-body-gap: 0;
+           filled submenu when a consumer sets a body gap. The unit is load-
+           bearing: a bare 0 is a <number>, making the fills’
+           calc(100% - <number>) invalid so the whole block-size declaration
+           drops and every fill option is evaluated at natural size — and
+           rejected */
+        --uktdd-body-gap: 0px;
         padding: var(--uktdd-body-pad-top) var(--uktdd-body-pad-right)
             var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
         inline-size: max-content;
@@ -311,27 +320,44 @@ div.uktdropdown-body {
     position-area: inline-start span-block-end;
 }
 
-/* The last-resort option appended after the author’s fallback list (for
-   both the body and submenus). It sets no position-area, so it inherits
-   the element’s primary placement — or its block-flipped mirror when
-   applied as `--uktdd-fill flip-block` — and sizes the element to that
-   side’s available space so the content scrolls. block-size must be a
-   definite length here, not a max-block-size clamp on the auto size:
-   position-try only accepts an option when the box it lays out fits, and
-   an auto-sized box is evaluated at its natural (unclamped) size, so a
-   clamp that would make it fit still reads as overflowing and the option
-   is never selected. 100% is the space on the attached side; subtracting
-   the symmetric --uktdd-body-gap margins keeps the margin box inside it.
-   The base max-block-size also still applies, capping the fill at
-   --uktdd-body-max-height, as does min-block-size, so a side shorter than
-   --uktdd-body-min-height is rejected as unusable and the flipped side is
-   tried instead. (No max-content clamp against stretching past the natural
-   size: intrinsic keywords hit the same natural-size evaluation quirk when
-   set inside @position-try, which would reject the option outright. The
-   stretch can only surface when the author’s fallbacks skip the flipped
-   block placement entirely and the preferred side is under
-   --uktdd-body-min-height — vanishingly rare with the recipes this
-   package documents.) */
+/* The last-resort fill options appended after the fallback list. Each
+   sizes the element to one side’s block-axis space so the content scrolls.
+   block-size must be a definite length, not a max-block-size clamp on the
+   auto size: position-try evaluates an auto-sized box at its natural
+   (unclamped) size, so a clamp that would make it fit still reads as
+   overflowing and the option is never selected (the same quirk rejects
+   intrinsic keywords like max-content set inside @position-try). 100% is
+   the space on the attached side; subtracting the symmetric
+   --uktdd-body-gap margins keeps the margin box inside it. The base
+   min-block-size still applies, so a side shorter than
+   --uktdd-body-min-height is rejected and the other side’s fill is tried.
+
+   --uktdd-fill-bottom/-top must be unrejectable on the inline axis so
+   whichever block side can hold the element is always accepted — what
+   makes the pair a complete rescue within the five-option limit (see the
+   .uktdropdown-body rule). A bare block keyword spans all inline tiles, so
+   the containing block is viewport-wide and the element can’t overflow it
+   horizontally, and the explicit justify-self: anchor-center shifts the
+   trigger-centered element inward as needed to stay inside the viewport
+   (span-all’s default alignment centers without that shift, so near a
+   corner the option would overflow and be rejected) */
+@position-try --uktdd-fill-bottom {
+    position-area: block-end;
+    block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    justify-self: anchor-center;
+}
+
+@position-try --uktdd-fill-top {
+    position-area: block-start;
+    block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    justify-self: anchor-center;
+}
+
+/* The same-side fill (used by submenus, and available to authors composing
+   their own fallback lists, including tactic-flipped: `--uktdd-fill
+   flip-inline`). It sets no position-area, so it inherits the element’s
+   primary placement — or a tactic-transformed mirror of it — and only
+   sizes the element to that placement’s block-axis space */
 @position-try --uktdd-fill {
     block-size: calc(100% - var(--uktdd-body-gap) * 2);
 }

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -87,18 +87,23 @@
        the primary placement fits). The trailing fill options are the last
        resort when the body fits in none of the placements: each sizes the
        body to the block-axis space on one side of the trigger so the
-       content region scrolls. The limit at which engines may stop
-       evaluating position options can be as low as five (Chromium
-       evaluates five and silently ignores the rest). The default budget is
-       the three named author fallbacks plus these two fills: one per block
-       side, each unrejectable on the inline axis (span-all can’t overflow
-       horizontally, and anchor-center shifts the body as needed to keep it
-       inside the viewport). A fill can only be rejected when its side is
-       shorter than its min-block-size floor, and the fills cap that floor
-       at the worst-case larger side (see their @position-try rules), so at
-       least one of the pair always fits. Authors
-       overriding --uktdd-body-position-try-fallbacks must keep it to three
-       options so these fills stay within the limit */
+       content region scrolls. Engines may cap the position options list
+       at an implementation-defined length with a spec floor of five, and
+       the list includes the base position — only four fallbacks are
+       guaranteed. Chromium evaluates five fallbacks past the base and
+       silently ignores the rest; this default budget — the three named
+       author fallbacks plus these two fills — fills Chromium’s five, one
+       past the spec floor (an engine at the exact floor would not reach
+       --uktdd-fill-top; validated in Chromium only). Each fill pins one
+       block side, unrejectable on the inline axis (span-all can’t
+       overflow horizontally, and anchor-center shifts the body as needed
+       to keep it inside the viewport). A fill can only be rejected when
+       its side is shorter than its min-block-size floor, and the fills
+       cap that floor at the worst-case larger side (see their
+       @position-try rules), so at least one of the pair always fits.
+       Authors overriding --uktdd-body-position-try-fallbacks must keep it
+       to three options so the fills stay within Chromium’s budget — or
+       two to stay within the spec’s guaranteed floor */
     position-try-fallbacks:
         var(--uktdd-body-position-try-fallbacks), var(--uktdd-body-fill-fallbacks);
     min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));
@@ -218,11 +223,16 @@
         /* same strict-fit + fill-last-resort model as the body (see the
            .uktdropdown-body rule): a too-tall submenu sizes to its block-axis
            space and scrolls instead of clipping past the viewport edge. The
-           list is budgeted to the five-option evaluation limit like the
+           list is budgeted to Chromium’s five evaluated fallbacks like the
            body’s: the author fallback, a same-side fill, its opposite-side
            mirror (submenus open sideways, so the mirror flips inline), then
            the two block-side fills as the final rescue when neither side of
-           the parent item can hold the submenu column */
+           the parent item can hold the submenu column. Unlike the body’s
+           list, this one can’t drop below five fallbacks without losing
+           side coverage, so submenu rescue inherently relies on engines
+           evaluating one past the spec floor of four. Reusing
+           --uktdd-body-fill-fallbacks is deliberate: flipping the pair for
+           an upward-opening body flips its submenus’ final rescue too */
         position-try-fallbacks:
             var(--uktdd-submenu-position-try-fallbacks),
             --uktdd-fill,

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -18,8 +18,7 @@
     --uktdd-body-pad-top: 0.5em;
     --uktdd-body-min-width: min(50px, 100%);
     --uktdd-body-position-area: block-end span-inline-end;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-start, --uktdd-bottom-end, --uktdd-top-end;
+    --uktdd-body-position-try-fallbacks: --uktdd-top-start, --uktdd-bottom-end;
     /* the last-resort fill placements appended after the fallbacks above
        (see the .uktdropdown-body rule). Overridable so a dropdown that
        prefers opening upward can flip the pair’s order to keep the fill
@@ -89,21 +88,23 @@
        body to the block-axis space on one side of the trigger so the
        content region scrolls. Engines may cap the position options list
        at an implementation-defined length with a spec floor of five, and
-       the list includes the base position — only four fallbacks are
-       guaranteed. Chromium evaluates five fallbacks past the base and
-       silently ignores the rest; this default budget — the three named
-       author fallbacks plus these two fills — fills Chromium’s five, one
-       past the spec floor (an engine at the exact floor would not reach
-       --uktdd-fill-top; validated in Chromium only). Each fill pins one
-       block side, unrejectable on the inline axis (span-all can’t
-       overflow horizontally, and anchor-center shifts the body as needed
-       to keep it inside the viewport). A fill can only be rejected when
-       its side is shorter than its min-block-size floor, and the fills
-       cap that floor at the worst-case larger side (see their
-       @position-try rules), so at least one of the pair always fits.
-       Authors overriding --uktdd-body-position-try-fallbacks must keep it
-       to three options so the fills stay within Chromium’s budget — or
-       two to stay within the spec’s guaranteed floor */
+       that list includes the base position — so four fallbacks past it
+       are guaranteed on every conformant engine. This default budget —
+       two named author fallbacks plus these two fills — is exactly four,
+       within that floor with no reliance on any engine exceeding it. The
+       two author fallbacks are the single-axis flips of the primary (a
+       block flip and an inline flip); the both-axes diagonal is dropped
+       so the fills stay within the floor, so a trigger crammed into the
+       corner diagonal to the primary lands in a fill rather than a fourth
+       natural placement (re-tune the primary for edge-pinned triggers).
+       Each fill pins one block side, unrejectable on the inline axis
+       (span-all can’t overflow horizontally, and anchor-center shifts the
+       body as needed to keep it inside the viewport). A fill can only be
+       rejected when its side is shorter than its min-block-size floor,
+       and the fills cap that floor at the worst-case larger side (see
+       their @position-try rules), so at least one of the pair always
+       fits. Authors overriding --uktdd-body-position-try-fallbacks must
+       keep it to two options so the fills stay within the floor */
     position-try-fallbacks:
         var(--uktdd-body-position-try-fallbacks), var(--uktdd-body-fill-fallbacks);
     min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -36,6 +36,17 @@
     --uktdd-label-pad-right: 0.625em;
     --uktdd-submenu-position-area: inline-end span-block-end;
     --uktdd-submenu-position-try-fallbacks: --uktdd-submenu-inline-start;
+    /* the last-resort fills for a submenu too tall to open beside its parent
+       at natural size (see the [data-ukt-submenu] rule). Unlike the body’s
+       block-side fills, these keep the submenu beside the parent — macOS
+       never covers a parent menu with its submenu — filling the block axis
+       and scrolling: --uktdd-submenu-fill on the same side, its flip-inline
+       mirror on the other. Each anchor-centers on the block axis, so a
+       parent anywhere (including near the block-end edge, where the space
+       below it is too short) still gets the full viewport height beside it.
+       Overridable to flip the pair for a submenu that opens inline-start */
+    --uktdd-submenu-fill-fallbacks:
+        --uktdd-submenu-fill, --uktdd-submenu-fill flip-inline;
     /* like --uktdd-body-gap but on the inline axis, since submenus open to
        the side; auto-reverses when they flip to the opposite inline edge */
     --uktdd-submenu-gap: 0px;
@@ -222,23 +233,24 @@
         position-anchor: --uktdd-submenu-anchor;
         position-area: var(--uktdd-submenu-position-area);
         /* same strict-fit + fill-last-resort model as the body (see the
-           .uktdropdown-body rule): a too-tall submenu sizes to its block-axis
-           space and scrolls instead of clipping past the viewport edge. The
-           list is budgeted to Chromium’s five evaluated fallbacks like the
-           body’s: the author fallback, a same-side fill, its opposite-side
-           mirror (submenus open sideways, so the mirror flips inline), then
-           the two block-side fills as the final rescue when neither side of
-           the parent item can hold the submenu column. Unlike the body’s
-           list, this one can’t drop below five fallbacks without losing
-           side coverage, so submenu rescue inherently relies on engines
-           evaluating one past the spec floor of four. Reusing
-           --uktdd-body-fill-fallbacks is deliberate: flipping the pair for
-           an upward-opening body flips its submenus’ final rescue too */
+           .uktdropdown-body rule): a too-tall submenu sizes to fit and
+           scrolls instead of clipping past the viewport edge. But where the
+           body’s block-side fills cover the trigger as a last resort, a
+           submenu stays beside its parent — macOS never covers a parent
+           menu with its submenu. The list: the author fallback (the natural
+           opposite-side placement), then --uktdd-submenu-fill-fallbacks —
+           the full-height anchor-centered fills, one per inline side. Three
+           fallbacks past the base, within the spec’s five-option floor (the
+           block-cover pair is gone, so no engine reliance), and decoupled
+           from --uktdd-body-fill-fallbacks so a body’s upward flip no longer
+           reorders its submenus. The one case this drops versus covering the
+           parent — a submenu wider than the space on either side of its
+           parent — is out of scope for the narrow columns of a macOS-style
+           menu; a consumer who needs it can append the block-cover fills to
+           --uktdd-submenu-fill-fallbacks */
         position-try-fallbacks:
             var(--uktdd-submenu-position-try-fallbacks),
-            --uktdd-fill,
-            --uktdd-fill flip-inline,
-            var(--uktdd-body-fill-fallbacks);
+            var(--uktdd-submenu-fill-fallbacks);
         z-index: 2;
         margin-block: 0;
         margin-inline: var(--uktdd-submenu-gap);
@@ -386,6 +398,22 @@ div.uktdropdown-body {
    sizes the element to that placement’s block-axis space */
 @position-try --uktdd-fill {
     block-size: calc(100% - var(--uktdd-body-gap) * 2);
+}
+
+/* The submenu full-height fill (see --uktdd-submenu-fill-fallbacks): the
+   block-axis mirror of --uktdd-fill-bottom. A bare inline keyword spans all
+   block tiles, so the containing block is viewport-tall and the submenu
+   fills the full block axis on the inline-end side (beside the parent, never
+   over it), and align-self: anchor-center shifts it on the block axis to
+   stay on-screen — the rescue for a parent near the block-end edge, where
+   the top-aligned --uktdd-fill has too little room below it. Rejected only
+   on the inline axis (no room for the submenu’s width on that side), so the
+   flip-inline pair covers both sides. Compose `--uktdd-submenu-fill
+   flip-inline` for the opposite side */
+@position-try --uktdd-submenu-fill {
+    position-area: inline-end;
+    block-size: calc(100% - var(--uktdd-body-gap) * 2);
+    align-self: anchor-center;
 }
 
 /* The opt-in cover fill (in no default list): where the block-side fills


### PR DESCRIPTION
## Summary

Fixes #399 — a `Dropdown` body nearly as tall as the viewport could open off-screen at a block-axis viewport edge instead of flipping/scrolling, and consumers had to cap `--uktdd-body-max-height` to work around it.

**Root cause (empirically confirmed, and different from the issue's diagnosis):** it isn't a fallback-evaluation quirk in the fills — the CSS anchor positioning spec permits an implementation-defined limit on the length of position-options lists ("must be at least five"), and **Chromium evaluates exactly five options and silently ignores the rest**. The shipped list was 3 author fallbacks + 4 `--uktdd-fill` tactic variants = 7 options, so `--uktdd-fill flip-block` (6th) and `--uktdd-fill flip-block flip-inline` (7th) were unreachable dead code. That also explains why reordering the fills "fixed one edge but broke the other" (it moved a different option past the cliff) and why `position-try-order: most-height` had no effect.

## The fix

Replace the four appended tactic fills with two named options — `--uktdd-fill-bottom` and `--uktdd-fill-top` — bringing the default list to exactly five. Each fill pairs:

- a single-side `position-area` (`block-end` / `block-start`), which spans all inline tiles so the option can never be rejected for horizontal overflow, with
- an explicit `justify-self: anchor-center`, which centers the body over the trigger and shifts it inward as needed to stay on-screen. The explicitness is load-bearing: `span-all`'s *default* alignment centers the same way but skips the shift, so near a viewport corner the option would overflow and be rejected.

A fill can then only be rejected when its side is shorter than `--uktdd-body-min-height`, and the two block sides sum to the viewport, so at least one of the pair always fits — for every trigger position, including corners, with no height cap needed. The pair is appended via a new `--uktdd-body-fill-fallbacks` custom property so upward-opening dropdowns can flip its order to keep the last-resort fill on their preferred side.

Submenus get the same budget: author fallback, `--uktdd-fill`, `--uktdd-fill flip-inline`, then the two block-side fills (also exactly five).

**Also fixes a pre-existing submenu bug** surfaced while testing: the submenu rule's `--uktdd-body-gap: 0` override was unitless, making the fills' `calc(100% - var(--uktdd-body-gap) * 2)` block-size invalid (`<percentage> - <number>`), so every submenu fill option was evaluated at natural size and rejected — submenu fill fallbacks have never applied, and a too-tall submenu overflowed the viewport. Now `0px`.

## Behavior trade-off

In the fill placements the body spans the trigger (anchor-centered, shifted to fit) instead of keeping the primary placement's edge alignment. Fills only apply when the body fits nowhere at its natural size, so normal placement is unchanged. Consumer fallback lists must stay within the budget — at most 3 options in `--uktdd-body-position-try-fallbacks`, 1 in `--uktdd-submenu-position-try-fallbacks` — now documented in the README.

## Validation

Verified in headless Chromium 141.0.7390.37 (the version from the issue report) with a Playwright anchor-positioning harness using the real `Dropdown.css`:

- 90 body placements swept across bottom/top edges and left/right corners in a 1200×420 viewport, for the issue's end-aligned config, the default config, and a top-opening recipe (with flipped fill pair), with and without `--uktdd-body-gap` — all land fully on-screen; the issue's failing case now flips above and fills the roomy side
- short bodies confirm named fallbacks still govern natural-size placement
- submenu smoke tests: sideways placement and inline flip preserved; tall submenus now fill and scroll; near-bottom and corner cases stay on-screen
- the five-option limit itself confirmed with a micro-test (N failing dummy options before a fitting one: index 5 reached, index 6 never)

`bun run build`, dropdown tests (102 passed), and `bun run format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rR4n1tgs2TWm9CtSdGaqX

---
_Generated by [Claude Code](https://claude.ai/code/session_019rR4n1tgs2TWm9CtSdGaqX)_