### PR TITLE
Split --uktdd-body-position-try-fallbacks into two fixed slots

### DIFF
--- a/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
+++ b/.changeset/dropdown-fill-fallbacks-within-evaluation-limit.md
@@ -2,55 +2,47 @@
 '@acusti/dropdown': minor
 ---
 
-Keep the last-resort fill placements within the `position-try` evaluation
+Budget the last-resort fill placements to the `position-try` evaluation
 limit so a too-tall body flips and scrolls instead of opening off-screen
 (fixes #399)
 
-The CSS anchor positioning spec lets engines cap the position options list
-at an implementation-defined length with a floor of five — and the list
-includes the element’s base position, so only four fallbacks past it are
+A too-tall body falls back to last-resort fill placements, which have to
+fit within the `position-try` evaluation limit, or an engine silently drops
+one and the body opens toward a viewport edge instead of flipping and
+scrolling. The CSS anchor positioning spec lets engines cap the position
+options list at an implementation-defined length with a floor of five,
+including the element’s base position, so only four fallbacks past it are
 guaranteed. In practice Chromium is the tightest, evaluating six options
 (five fallbacks past the base) and silently ignoring the rest, while Safari
-and Firefox evaluate many more. The body’s previous list was three author
-fallbacks plus four `--uktdd-fill` tactic variants (seven fallbacks), so
-the block-flipped fills that rescue a near-viewport-height body at a
-block-axis viewport edge were never evaluated: the body opened toward the
-edge and ran off-screen, and consumers had to cap `--uktdd-body-max-height`
-to work around it.
+and Firefox evaluate many more.
 
-The four appended tactic fills are replaced by two new named options —
-`--uktdd-fill-bottom` and `--uktdd-fill-top` — and the default author
-fallback list drops from three options to two (the block flip and inline
-flip of the primary; the both-axes diagonal is dropped). The full list is
-now two author fallbacks plus the two fills — four fallbacks past the base
-position, exactly the spec’s guaranteed floor of five options, so no engine
-can silently drop a fill. The cost of dropping the diagonal is that a
-trigger crammed into the corner diagonal to the primary opening direction
-lands in a fill rather than a fourth natural placement, which for a
-corner-pinned trigger is a re-tune-the-primary case anyway. Each fill pairs
-a single-side `position-area` (`block-end`/`block-start`, spanning all
-inline tiles so it can never be rejected for horizontal overflow) with
+The default budget is two author fallbacks plus two named fill options,
+`--uktdd-fill-bottom` and `--uktdd-fill-top`, so no engine can silently
+drop a fill. The two author fallbacks are the single-axis flips of the
+primary (a block flip and an inline flip); the opposite diagonal flip is
+dropped to stay within the floor. The cost of dropping the diagonal is that
+a trigger crammed into the corner diagonal to the primary opening direction
+lands in a fill rather than a fourth natural placement. Each fill pairs a
+single-side `position-area` (`block-end`/`block-start`, spanning all inline
+tiles so it can never be rejected for horizontal overflow) with
 `justify-self: anchor-center`, which centers the body over the trigger and
 shifts it inward as needed to stay on-screen (the explicitness matters:
 `span-all`’s default alignment centers without that shift, so near a corner
 it would overflow and be rejected). A fill is only rejected when its side
-is shorter than the body’s min-block-size floor — what sends a cramped
-side’s fill to the roomier opposite side — and each fill caps that floor at
-the worst-case larger side (half the viewport minus the trigger, the most a
+is shorter than the body’s `min-block-size` floor, and each fill caps that
+floor at the larger side (roughly half the viewport, the most a
 block-centered trigger can guarantee), so at least one of the pair always
-fits — for every trigger position, including corners and a
-`--uktdd-body-min-height` above half the viewport, with no height cap
-needed. The pair is appended via the new `--uktdd-body-fill-fallbacks`
-custom property, so upward-opening dropdowns can flip its order to keep the
-last-resort fill on their preferred side. (Submenus have their own
-last-resort fills, `--uktdd-submenu-fill-fallbacks`, rather than reusing
-this pair — see the separate submenu changeset.)
+fits, no additional height cap needed. The pair is appended via the new
+`--uktdd-body-fill-fallbacks` custom property, so upward-opening dropdowns
+can flip its order to keep the last-resort fill on their preferred side.
+(Submenus have their own last-resort fills,
+`--uktdd-submenu-fill-fallbacks`, rather than reusing this pair — see the
+separate submenu changeset.)
 
-In the fill placements the body now spans the trigger (anchor-centered,
-shifted to fit) instead of keeping the primary placement’s edge alignment.
-Consumer fallback lists must stay within the budget: at most two options in
-`--uktdd-body-position-try-fallbacks` (matching the new floor-safe
-default), and a single option in `--uktdd-submenu-position-try-fallbacks`.
+In the fill placements the body spans the trigger instead of keeping the
+primary placement’s edge alignment. Consumer overrides stay within the
+budget: the two `--uktdd-body-position-try-fallback-1`/`-2` slots plus the
+two fills, and the single `--uktdd-submenu-position-try-fallback`.
 
 Also fixes the submenu rule’s `--uktdd-body-gap: 0` override: the unitless
 zero made the fill options’ `calc(100% - var(--uktdd-body-gap) * 2)`

--- a/.changeset/dropdown-prefer-authored-direction.md
+++ b/.changeset/dropdown-prefer-authored-direction.md
@@ -5,24 +5,21 @@
 Make the authored placement direction win whenever it fits, instead of
 letting `position-try-order: most-height` override it. The body (and each
 submenu) now uses its `--uktdd-body-position-area` primary placement — and
-then its `--uktdd-body-position-try-fallbacks` in order — accepting the
-first that fits at the box’s natural size, and only squeezing-and-scrolling
-as a last resort. Previously `position-try-order: most-height` re-sorted
-the candidates by available height, so a dropdown told to open above with
-ample room above could still open below merely because the viewport had
-more empty space there.
+then its author fallbacks in order — accepting the first that fits at the
+box’s natural size, and only squeezing-and-scrolling as a last resort.
+Previously `position-try-order: most-height` re-sorted the candidates by
+available height, so a dropdown told to open above with ample room above
+could still open below merely because the viewport had more empty space
+there.
 
 Removed `position-try-order: most-height` from `.uktdropdown-body` and
 dropped the `100%` term from its base `max-block-size` (a placement is now
 accepted only when the body fits it at natural size, so it no longer
 silently shrinks under the primary). When the body fits nowhere at natural
-size, four appended `--uktdd-fill` fallbacks size it to the available
-block-axis space and let `.uktdropdown-content` scroll, staying as close to
-the primary placement as possible: same side first, flipping inline
-alignment only to escape a horizontal-overflow rejection, and flipping to
-the opposite block side only when the preferred side is under
-`--uktdd-body-min-height`. Submenus gained a `min-block-size` so the same
-too-short-side rejection applies to them.
+size, it falls back to last-resort fill placements that size it to the
+available block-axis space and let `.uktdropdown-content` scroll rather
+than clipping past the viewport edge. Submenus gained a `min-block-size` so
+the same too-short-side rejection applies to them.
 
 **Migration:** if you relied on `most-height` to auto-open a dropdown
 toward whichever side had more room (for example the README’s centered-menu
@@ -30,6 +27,6 @@ recipe, which flipped `bottom span-all` to `top span-all` on the taller
 side), it now stays on its primary side while that side can hold the body
 and flips only when the body doesn’t fit there. Set
 `--uktdd-body-position-area` to the side you actually want as the default,
-and list the flipped side first in `--uktdd-body-position-try-fallbacks`.
-If you referenced `--uktdd-fill` as a custom `@position-try` name, rename
-yours — it’s now shipped by the package.
+and put the flipped side in `--uktdd-body-position-try-fallback-1`. If you
+referenced `--uktdd-fill` as a custom `@position-try` name, rename yours —
+it’s now shipped by the package.

--- a/.changeset/dropdown-rename-position-try-fallbacks.md
+++ b/.changeset/dropdown-rename-position-try-fallbacks.md
@@ -28,7 +28,7 @@ physical keyword on one axis with a logical one on the other — and read as
 `top`/`bottom` in the near-universal horizontal-tb writing mode.
 
 **Migration:** if you referenced any of the renamed `@position-try` block
-names in `--uktdd-body-position-try-fallbacks`, or set
+names in `--uktdd-body-position-try-fallback-1`/`-2`, or set
 `--uktdd-body-position-area`/`--uktdd-submenu-position-area` directly with
 `top`/`bottom`/`span-left`/`span-right`, update them:
 
@@ -37,14 +37,14 @@ names in `--uktdd-body-position-try-fallbacks`, or set
 .my-dropdown {
     --uktdd-body-position-area: bottom span-left;
     --uktdd-body-position-try-fallbacks:
-        --uktdd-top-right, --uktdd-bottom-left, --uktdd-top-left;
+        --uktdd-top-right, --uktdd-bottom-left;
 }
 
-/* after */
+/* after (the fallback list is now two fixed slots) */
 .my-dropdown {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start, --uktdd-top-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-start;
 }
 ```
 

--- a/.changeset/dropdown-split-fallback-slots.md
+++ b/.changeset/dropdown-split-fallback-slots.md
@@ -1,0 +1,30 @@
+---
+'@acusti/dropdown': major
+---
+
+Replace the `--uktdd-body-position-try-fallbacks` list with two fixed
+slots, `--uktdd-body-position-try-fallback-1` and
+`--uktdd-body-position-try-fallback-2`, and rename the submenu’s list to
+the singular `--uktdd-submenu-position-try-fallback`
+
+The author fallbacks sit between the primary placement and the appended
+fills, and the component’s budget is exactly two of them (two author
+fallbacks + two fills = four, plus the base = the spec’s guaranteed
+five-option floor). As a comma-separated list, that limit was only
+documented, and a third entry silently pushed a fill past the floor,
+letting a trigger near a viewport edge open off-screen. Splitting the list
+into two named slots makes the two-option budget structural: there is no
+third slot to overflow into. The submenu, which affords a single author
+fallback, likewise becomes a single named slot.
+
+Migration: set `--uktdd-body-position-try-fallback-1` and `-2` where you
+previously set the two entries of `--uktdd-body-position-try-fallbacks`
+(the direction-recipe table in the README lists the per-direction values),
+and `--uktdd-submenu-position-try-fallback` (singular) where you set the
+submenu list.
+
+Also adds a shipped no-op placement, `--uktdd-noop`, for a recipe with a
+single meaningful fallback (a centered menu, say): set slot 1 and leave
+slot 2 as `--uktdd-noop` so it doesn’t inherit the default’s flip. It
+applies no overrides, so it evaluates as the primary placement and is
+skipped.

--- a/.changeset/dropdown-submenu-fills-beside-parent.md
+++ b/.changeset/dropdown-submenu-fills-beside-parent.md
@@ -30,5 +30,5 @@ The one case this gives up versus covering the parent — a submenu wider
 than the space on either side of its parent — is out of scope for the
 narrow columns of a macOS-style menu; a consumer who needs it can append
 `--uktdd-fill-bottom, --uktdd-fill-top` to `--uktdd-submenu-fill-fallbacks`
-(keeping `--uktdd-submenu-position-try-fallbacks` to a single option to
-stay within the evaluation limit).
+(the single `--uktdd-submenu-position-try-fallback` slot leaves room for
+those two extra fills within the evaluation limit).

--- a/.changeset/nested-dropdown-submenus.md
+++ b/.changeset/nested-dropdown-submenus.md
@@ -25,7 +25,7 @@ named export combines sibling dropdowns into a macOS-style menu bar.
   properties); parent-item open state is carried by `aria-expanded`
 - Submenus reuse the anchor-positioning layout model (the expanded parent
   item is the anchor) with new `--uktdd-submenu-position-area`,
-  `--uktdd-submenu-position-try-fallbacks`, and `--uktdd-submenu-translate`
+  `--uktdd-submenu-position-try-fallback`, and `--uktdd-submenu-translate`
   custom properties; parent items render a macOS-style disclosure chevron
   (drawn in CSS, restylable via `[aria-haspopup='menu']::after`), and
   submenu bodies get an explicit text color via the new

--- a/packages/docs/stories/Dropdown.css
+++ b/packages/docs/stories/Dropdown.css
@@ -120,7 +120,8 @@
 .searchable-with-label,
 .searchable-and-allow-create {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-start;
 
     input,
     .uktdropdown-body {
@@ -130,7 +131,8 @@
 
 .css-value-input-trigger {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-start;
 
     .uktdropdown-body {
         /* a horizontal alignment nudge, not a trigger↔body gap; set as a raw
@@ -231,7 +233,10 @@
        trigger rather than clamping against the viewport’s left edge */
     align-self: center;
     --uktdd-body-position-area: bottom span-all;
-    --uktdd-body-position-try-fallbacks: --centered-menu-top;
+    /* one meaningful fallback (the flipped centered placement); slot 2 is
+       the no-op so it doesn’t inherit the default corner flip */
+    --uktdd-body-position-try-fallback-1: --centered-menu-top;
+    --uktdd-body-position-try-fallback-2: --uktdd-noop;
 
     .uktdropdown-body {
         inline-size: 200px;
@@ -288,7 +293,8 @@
 
 .too-tall {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks: --uktdd-top-end, --uktdd-bottom-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-start;
 }
 
 /* CoverFillRecipe: the cover fill trades trigger coverage for full
@@ -490,8 +496,8 @@
 
     .avatar-menu {
         --uktdd-body-position-area: block-end span-inline-start;
-        --uktdd-body-position-try-fallbacks:
-            --uktdd-top-end, --uktdd-top-start, --uktdd-bottom-end;
+        --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+        --uktdd-body-position-try-fallback-2: --uktdd-top-start;
 
         .avatar-profile,
         .avatar-edit {

--- a/packages/docs/stories/Dropdown.stories.tsx
+++ b/packages/docs/stories/Dropdown.stories.tsx
@@ -712,8 +712,8 @@ const DIRECTION_RECIPE_ROWS = [
             label: 'Bottom Start (default)',
             style: {
                 '--uktdd-body-position-area': 'block-end span-inline-end',
-                '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-top-start, --uktdd-bottom-end',
+                '--uktdd-body-position-try-fallback-1': '--uktdd-top-start',
+                '--uktdd-body-position-try-fallback-2': '--uktdd-bottom-end',
             },
         },
         {
@@ -721,8 +721,8 @@ const DIRECTION_RECIPE_ROWS = [
             label: 'Bottom End',
             style: {
                 '--uktdd-body-position-area': 'block-end span-inline-start',
-                '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-top-end, --uktdd-bottom-start',
+                '--uktdd-body-position-try-fallback-1': '--uktdd-top-end',
+                '--uktdd-body-position-try-fallback-2': '--uktdd-bottom-start',
             },
         },
     ],
@@ -733,8 +733,8 @@ const DIRECTION_RECIPE_ROWS = [
             style: {
                 '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
                 '--uktdd-body-position-area': 'block-start span-inline-end',
-                '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-bottom-start, --uktdd-top-end',
+                '--uktdd-body-position-try-fallback-1': '--uktdd-bottom-start',
+                '--uktdd-body-position-try-fallback-2': '--uktdd-top-end',
             },
         },
         {
@@ -743,8 +743,8 @@ const DIRECTION_RECIPE_ROWS = [
             style: {
                 '--uktdd-body-fill-fallbacks': '--uktdd-fill-top, --uktdd-fill-bottom',
                 '--uktdd-body-position-area': 'block-start span-inline-start',
-                '--uktdd-body-position-try-fallbacks':
-                    '--uktdd-bottom-end, --uktdd-top-start',
+                '--uktdd-body-position-try-fallback-1': '--uktdd-bottom-end',
+                '--uktdd-body-position-try-fallback-2': '--uktdd-top-start',
             },
         },
     ],
@@ -754,7 +754,7 @@ export const DirectionRecipes: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallbacks` (see the README’s “Changing the Default Direction” section for the full cheatsheet). Each dropdown carries its recipe on its `style` prop, so “Show code” below displays the exact variable pairs. Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The top-opening pair also flips `--uktdd-body-fill-fallbacks` so the last-resort fill prefers the upward side. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
+                story: 'The four `@position-try` recipes the component ships, each pairing `--uktdd-body-position-area` with its matching `--uktdd-body-position-try-fallback-1` and `-2` (see the README’s [“Changing the Default Direction”](https://github.com/acusti/uikit/tree/main/packages/dropdown#changing-the-default-direction) section for the full cheatsheet). Each dropdown carries its recipe on its `style` prop, so “Show code” below displays the exact variables. Each is named for the edge that stays flush with the trigger, not the direction the body extends toward: “start” keeps the body’s inline-start edge flush with the trigger’s, extending toward inline-end; “end” is the mirror image. The top-opening pair also flips `--uktdd-body-fill-fallbacks` so the last-resort fill prefers the upward side. Each recipe opens in its named direction whenever that side has room, independent of where the trigger sits; the bottom pair is placed near the top of the canvas and the top pair near the bottom only so each menu opens into empty space instead of overlapping the other row.',
             },
         },
     },
@@ -842,7 +842,8 @@ export const FillsWhenTooTall: Story = {
 const COVER_FILL_STYLE = {
     '--uktdd-body-fill-fallbacks':
         '--uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top',
-    '--uktdd-body-position-try-fallbacks': '--uktdd-top-start, --uktdd-bottom-end',
+    '--uktdd-body-position-try-fallback-1': '--uktdd-top-start',
+    '--uktdd-body-position-try-fallback-2': '--uktdd-bottom-end',
 } as const;
 
 export const CoverFillRecipe: Story = {

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -524,7 +524,9 @@ Placement is best customized in CSS instead of props. The component exposes
 CSS custom properties for the most common low-level placement controls:
 
 - `--uktdd-body-position-area`
-- `--uktdd-body-position-try-fallbacks`
+- `--uktdd-body-position-try-fallback-1` and
+  `--uktdd-body-position-try-fallback-2` (the two author fallbacks, tried
+  in order after the primary placement)
 - `--uktdd-body-fill-fallbacks` (the last-resort fill placements, tried
   when the body fits nowhere at its natural size)
 - `--uktdd-body-gap` (space between the trigger and the body)
@@ -538,8 +540,8 @@ Example:
 ```css
 .settings-dropdown {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-bottom-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-start;
     --uktdd-body-gap: 8px;
 }
 
@@ -553,15 +555,17 @@ placement and sizing control when a product surface needs it.
 
 ### Changing the Default Direction
 
-`--uktdd-body-position-area` and `--uktdd-body-position-try-fallbacks`
-always change together. `--uktdd-body-position-area` is the primary
-placement, used whenever it fits in the viewport — that’s what actually
-determines the direction a dropdown opens by default. The fallbacks list is
-only consulted when the primary placement doesn’t fit, so overriding it
-alone changes nothing in the common case where the primary already fits.
-Overriding the primary alone works, but leaves behind a fallback cascade
-tuned for the old primary — in a cramped viewport, the dropdown can fall
-back toward the direction you just moved away from.
+`--uktdd-body-position-area` and its two fallback slots
+(`--uktdd-body-position-try-fallback-1`,
+`--uktdd-body-position-try-fallback-2`) always change together.
+`--uktdd-body-position-area` is the primary placement, used whenever it
+fits in the viewport — that’s what actually determines the direction a
+dropdown opens by default. The fallback slots are tried in order only when
+the primary placement doesn’t fit. Set all three together to ensure the
+menu behaves the way you want it to in all possible contexts. If the new
+direction has only one meaningful fallback (a centered menu, say), put it
+in slot 1 and set slot 2 to the shipped no-op `--uktdd-noop` so it doesn’t
+inherit that flip.
 
 The four `@position-try` blocks the component ships (`--uktdd-top-start`,
 `--uktdd-top-end`, `--uktdd-bottom-start`, `--uktdd-bottom-end`) are named
@@ -576,15 +580,18 @@ physical keyword on one axis with a logical one on the other — though
 `block-start`/`block-end` read as `top`/`bottom` in the near-universal
 horizontal-tb writing mode.
 
-Pick the row matching the direction you want, and set both variables to its
-pair:
+Pick the row matching the direction you want, and set the three CSS custom
+properties to the corresponding values:
 
-| Direction                           | `--uktdd-body-position-area`    | `--uktdd-body-position-try-fallbacks`   |
-| ----------------------------------- | ------------------------------- | --------------------------------------- |
-| Bottom, start-aligned (the default) | `block-end span-inline-end`     | `--uktdd-top-start, --uktdd-bottom-end` |
-| Bottom, end-aligned                 | `block-end span-inline-start`   | `--uktdd-top-end, --uktdd-bottom-start` |
-| Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start, --uktdd-top-end` |
-| Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end, --uktdd-top-start` |
+| Direction                           | `--uktdd-body-position-area`    | `…try-fallback-1`      | `…try-fallback-2`      |
+| ----------------------------------- | ------------------------------- | ---------------------- | ---------------------- |
+| Bottom, start-aligned (the default) | `block-end span-inline-end`     | `--uktdd-top-start`    | `--uktdd-bottom-end`   |
+| Bottom, end-aligned                 | `block-end span-inline-start`   | `--uktdd-top-end`      | `--uktdd-bottom-start` |
+| Top, start-aligned                  | `block-start span-inline-end`   | `--uktdd-bottom-start` | `--uktdd-top-end`      |
+| Top, end-aligned                    | `block-start span-inline-start` | `--uktdd-bottom-end`   | `--uktdd-top-start`    |
+
+(The `…try-fallback-N` columns are `--uktdd-body-position-try-fallback-1`
+and `-2`.)
 
 The two Top rows should also flip the last-resort fill pair to match:
 `--uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom`.
@@ -595,8 +602,8 @@ trigger pinned to the bottom of the viewport, near the inline-end edge):
 ```css
 .bottom-toolbar-dropdown {
     --uktdd-body-position-area: block-start span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-bottom-end, --uktdd-top-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-bottom-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-top-start;
     --uktdd-body-fill-fallbacks: --uktdd-fill-top, --uktdd-fill-bottom;
 }
 ```
@@ -639,22 +646,20 @@ trigger can guarantee — so a min-height above half the viewport (honored in
 full by the named placements) can’t reject both fills: the body fills the
 roomier side and scrolls rather than overflowing.
 
-Keep `--uktdd-body-position-try-fallbacks` to at most two options. The spec
-lets engines cap the position options list at an implementation-defined
-length with a floor of five — and that list includes the element’s base
-position, so only four fallbacks past it are guaranteed. The component
-appends the two fill placements after your list, so two author fallbacks
-plus the two fills is exactly four — within the floor on every conformant
-engine. A third author fallback (six options) still works on every current
-engine but leans past the spec floor onto their real limits (Chromium
-evaluates exactly six; Safari and Firefox more); a fourth pushes a fill
-past even Chromium, so a trigger near a viewport edge can open off-screen
-instead of flipping and scrolling. The default’s two fallbacks are the
-single-axis flips of the primary (a block flip and an inline flip); it
-drops the both-axes diagonal to stay within the floor, so a trigger crammed
-into the corner diagonal to the primary opening direction lands in a fill
-rather than a natural placement — re-tune the primary (per the recipes
-above) for triggers pinned to a viewport corner.
+There are exactly two author fallback slots by design. The
+[CSS spec](https://drafts.csswg.org/css-anchor-position-1/#fallback-apply)
+requires implementations to support at least five position options,
+including the element’s base position, and `@acusti/dropdown` appends two
+last-resort placements to the end, so that leaves two fallbacks that you
+can specify, hence why they are exposed as two separate custom properties.
+The two default slots are the single-axis flips of the primary (a block
+flip and an inline flip); the mirror opposite diagonal is intentionally not
+a slot, so that a trigger crammed into the corner diagonal to the primary
+opening direction lands in a fill rather than a natural placement. See the
+[recipes above](#changing-the-default-direction) for different common
+placement scenarios. For a recipe with a single meaningful fallback (a
+centered menu, say), set slot 1 and leave slot 2 as the shipped no-op
+`--uktdd-noop`, so it doesn’t inherit the default’s flip.
 
 ### Trading Trigger Coverage for a Full-Height Menu
 
@@ -669,8 +674,8 @@ rather than one side of it.
 
 ```css
 .tall-menu {
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-start, --uktdd-bottom-end;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-start;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-end;
     --uktdd-body-fill-fallbacks:
         --uktdd-fill-cover, --uktdd-fill-bottom, --uktdd-fill-top;
 }
@@ -710,8 +715,8 @@ the menu size itself from its contents.
 ```css
 .avatar-menu {
     --uktdd-body-position-area: block-end span-inline-start;
-    --uktdd-body-position-try-fallbacks:
-        --uktdd-top-end, --uktdd-top-start;
+    --uktdd-body-position-try-fallback-1: --uktdd-top-end;
+    --uktdd-body-position-try-fallback-2: --uktdd-top-start;
 }
 ```
 
@@ -732,13 +737,17 @@ the trigger always overflows it — and `position-try` refuses to select a
 fallback that overflows, so a `bottom center` → `top center` setup never
 flips. `span-all` centers over the trigger identically but spans the full
 width, so it flips cleanly and clamps to the viewport near an edge. The
-menu opens below by default and flips above only when it doesn’t fit below;
-list the flipped fallback so that flip is available:
+menu opens below by default and flips above only when it doesn’t fit below.
+It has one meaningful fallback (the flipped centered placement), so set it
+in slot 1 and leave slot 2 as the no-op — otherwise slot 2 keeps the
+default’s corner flip and the menu can land off-center in a cramped
+viewport:
 
 ```css
 .centered-menu {
     --uktdd-body-position-area: bottom span-all;
-    --uktdd-body-position-try-fallbacks: --centered-menu-top;
+    --uktdd-body-position-try-fallback-1: --centered-menu-top;
+    --uktdd-body-position-try-fallback-2: --uktdd-noop;
 }
 
 /* define the flipped fallback in your own CSS */
@@ -859,11 +868,8 @@ it flush to the parent item’s edge across browsers. Placement custom
 properties follow the established naming scheme:
 
 - `--uktdd-submenu-position-area` (default: `inline-end span-block-end`)
-- `--uktdd-submenu-position-try-fallbacks` (default:
-  `--uktdd-submenu-inline-start`; keep it to a single option — the
-  component appends two last-resort fills after it, and the spec guarantees
-  only four evaluated fallbacks, so a second author fallback would push a
-  fill out of reach)
+- `--uktdd-submenu-position-try-fallback` (default:
+  `--uktdd-submenu-inline-start`; a single slot, not a list)
 - `--uktdd-submenu-fill-fallbacks` (the last-resort fills for a submenu too
   tall to open beside its parent at natural size; default
   `--uktdd-submenu-fill, --uktdd-submenu-fill flip-inline` — a full-height
@@ -871,13 +877,10 @@ properties follow the established naming scheme:
   submenu fills the viewport height beside the parent and scrolls rather
   than covering the parent menu, the way macOS never covers a parent with
   its submenu. Flip the pair for a submenu that opens `inline-start` by
-  default. A submenu wider than the space on either side of its parent —
-  out of scope for a macOS-style menu’s narrow columns — is the one case
-  this gives up versus covering the parent; append
+  default. A submenu wider than the space on either side of its parent is
+  the one case this default doesn’t handle; append
   `--uktdd-fill-bottom, --uktdd-fill-top` here to restore the
-  parent-covering rescue if you need it, keeping
-  `--uktdd-submenu-position-try-fallbacks` empty to stay within the
-  evaluation limit)
+  parent-covering rescue if you need it)
 - `--uktdd-submenu-gap` (space between the parent item and the submenu;
   applied as a symmetric `margin-inline`, the inline-axis counterpart to
   `--uktdd-body-gap`, so it auto-reverses when the submenu flips to the

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -18,7 +18,14 @@
     --uktdd-body-pad-top: 0.5em;
     --uktdd-body-min-width: min(50px, 100%);
     --uktdd-body-position-area: block-end span-inline-end;
-    --uktdd-body-position-try-fallbacks: --uktdd-top-start, --uktdd-bottom-end;
+    /* The two author fallbacks, tried in order after the primary placement
+       and before the fills. The defaults are the primary’s single-axis
+       flips: slot 1 the block flip, slot 2 the inline flip. Change direction
+       by resetting --uktdd-body-position-area and both slots together (see
+       the recipes in the README). The primary sets the direction, the
+       slots are its flips */
+    --uktdd-body-position-try-fallback-1: --uktdd-top-start;
+    --uktdd-body-position-try-fallback-2: --uktdd-bottom-end;
     /* the last-resort fill placements appended after the fallbacks above
        (see the .uktdropdown-body rule). Overridable so a dropdown that
        prefers opening upward can flip the pair’s order to keep the fill
@@ -35,7 +42,8 @@
     --uktdd-body-color-path: currentColor;
     --uktdd-label-pad-right: 0.625em;
     --uktdd-submenu-position-area: inline-end span-block-end;
-    --uktdd-submenu-position-try-fallbacks: --uktdd-submenu-inline-start;
+    /* the submenu’s only author fallback (the natural opposite placement) */
+    --uktdd-submenu-position-try-fallback: --uktdd-submenu-inline-start;
     /* the last-resort fills for a submenu too tall to open beside its parent
        at natural size (see the [data-ukt-submenu] rule). Unlike the body’s
        block-side fills, these keep the submenu beside the parent — macOS
@@ -114,10 +122,10 @@
        rejected when its side is shorter than its min-block-size floor,
        and the fills cap that floor at the worst-case larger side (see
        their @position-try rules), so at least one of the pair always
-       fits. Authors overriding --uktdd-body-position-try-fallbacks must
-       keep it to two options so the fills stay within the floor */
+       fits */
     position-try-fallbacks:
-        var(--uktdd-body-position-try-fallbacks), var(--uktdd-body-fill-fallbacks);
+        var(--uktdd-body-position-try-fallback-1),
+        var(--uktdd-body-position-try-fallback-2), var(--uktdd-body-fill-fallbacks);
     min-block-size: min(var(--uktdd-body-min-height), var(--uktdd-body-max-height));
     /* no 100% clamp: a placement is only accepted when the body’s natural
        size fits it, so squeezing is reserved for the --uktdd-fill options */
@@ -232,24 +240,20 @@
         position: fixed;
         position-anchor: --uktdd-submenu-anchor;
         position-area: var(--uktdd-submenu-position-area);
-        /* same strict-fit + fill-last-resort model as the body (see the
-           .uktdropdown-body rule): a too-tall submenu sizes to fit and
-           scrolls instead of clipping past the viewport edge. But where the
-           body’s block-side fills cover the trigger as a last resort, a
-           submenu stays beside its parent — macOS never covers a parent
-           menu with its submenu. The list: the author fallback (the natural
-           opposite-side placement), then --uktdd-submenu-fill-fallbacks —
-           the full-height anchor-centered fills, one per inline side. Three
-           fallbacks past the base, within the spec’s five-option floor (the
-           block-cover pair is gone, so no engine reliance), and decoupled
-           from --uktdd-body-fill-fallbacks so a body’s upward flip no longer
-           reorders its submenus. The one case this drops versus covering the
-           parent — a submenu wider than the space on either side of its
-           parent — is out of scope for the narrow columns of a macOS-style
-           menu; a consumer who needs it can append the block-cover fills to
+        /* like the body’s fill model, but a too-tall submenu stays beside
+           its parent so that it can’t cover its parent menu.
+           The list is the author fallback (the natural opposite placement),
+           then --uktdd-submenu-fill-fallbacks: full-height anchor-centered
+           fills, one per inline side. These fills are rejected only on the
+           inline axis, so — unlike the body pair, whose two sides sum to the
+           viewport — there’s no at-least-one-always-fits guarantee: a submenu
+           too tall to open beside its parent and too wide for either side
+           reverts to its (overflowing) primary. Normal submenus won’t hit
+           that, but for extra wide menus, append the block-cover fills
+           (--uktdd-fill-bottom, --uktdd-fill-top) to
            --uktdd-submenu-fill-fallbacks */
         position-try-fallbacks:
-            var(--uktdd-submenu-position-try-fallbacks),
+            var(--uktdd-submenu-position-try-fallback),
             var(--uktdd-submenu-fill-fallbacks);
         z-index: 2;
         margin-block: 0;
@@ -315,6 +319,15 @@ div.uktdropdown-body {
         var(--uktdd-body-pad-bottom) var(--uktdd-body-pad-left);
 }
 
+/* An empty option for a fallback slot a recipe doesn’t use — e.g. a
+   centered menu (bottom/top span-all) has one meaningful author fallback,
+   so it sets --uktdd-body-position-try-fallback-1 and leaves slot 2 as
+   --uktdd-noop, which applies no overrides and evaluates identically to the
+   primary placement, meaning it’s rejected in turn and skipped without
+   breaking the declaration the way an empty var() would. */
+@position-try --uktdd-noop {
+}
+
 /* Named for the aligned edge (start/end), not the direction the body
    extends toward — e.g. top-start opens above the trigger with their
    inline-start edges flush, and the body can extend past the trigger’s
@@ -344,31 +357,24 @@ div.uktdropdown-body {
     position-area: inline-start span-block-end;
 }
 
-/* The last-resort fill options appended after the fallback list. Each
-   sizes the element to one side’s block-axis space so the content scrolls.
-   block-size must be a definite length, not a max-block-size clamp on the
-   auto size: position-try evaluates an auto-sized box at its natural
-   (unclamped) size, so a clamp that would make it fit still reads as
-   overflowing and the option is never selected (the same quirk rejects
-   intrinsic keywords like max-content set inside @position-try). 100% is
-   the space on the attached side; subtracting the symmetric
-   --uktdd-body-gap margins keeps the margin box inside it. min-block-size
-   still applies, so a side shorter than --uktdd-body-min-height is
-   rejected and the other side’s fill is tried — but capped at the
-   worst-case larger side, (100dvb - anchor)/2 (an anchor centered on the
-   block axis splits the rest of the viewport evenly), so a min above
-   ~half the viewport can no longer reject both sides and strand the body
-   at the overflowing primary placement.
+/* The last-resort fills, each sizing the element to one block side’s space
+   so the content scrolls. block-size must be a definite length:
+   position-try evaluates an auto-sized box at its natural (unclamped) size,
+   so a max-block-size clamp that would make it fit still reads as
+   overflowing and is never selected (same quirk that rejects max-content
+   here). 100% is the attached side’s space, less the symmetric
+   --uktdd-body-gap margins.
 
-   --uktdd-fill-bottom/-top must be unrejectable on the inline axis so
-   whichever block side can hold the element is always accepted — what
-   makes the pair a complete rescue within the five-option limit (see the
-   .uktdropdown-body rule). A bare block keyword spans all inline tiles, so
-   the containing block is viewport-wide and the element can’t overflow it
-   horizontally, and the explicit justify-self: anchor-center shifts the
-   trigger-centered element inward as needed to stay inside the viewport
-   (span-all’s default alignment centers without that shift, so near a
-   corner the option would overflow and be rejected) */
+   min-block-size still applies (a side shorter than --uktdd-body-min-height
+   is rejected and the other tried), but is capped at the worst-case larger
+   side, so a min above ~half the viewport can’t reject both sides and
+   strand the body at the overflowing primary.
+
+   The pair must be unrejectable on the inline axis so whichever block side
+   fits can be accepted. A bare block keyword spans all inline tiles
+   (viewport-wide containing block, no horizontal overflow), and justify-self:
+   anchor-center shifts the trigger-centered element inward to stay on-screen
+   (span-all’s default alignment wouldn’t, so a corner would overflow) */
 @position-try --uktdd-fill-bottom {
     position-area: block-end;
     block-size: calc(100% - var(--uktdd-body-gap) * 2);


### PR DESCRIPTION
Stacked on #403.

## Why

The body's author fallbacks sit between the primary placement and the appended fills, and the budget is exactly **two** (2 author fallbacks + 2 fills = 4 past the base = the spec's guaranteed five-option floor). As a comma-separated `--uktdd-body-position-try-fallbacks` list, that limit was only *documented* — a third entry silently pushed a fill past the floor and let a trigger near a viewport edge open off-screen (the #399-class bug this stack exists to prevent).

## What

- **Two fixed slots** — `--uktdd-body-position-try-fallback-1` and `--uktdd-body-position-try-fallback-2` — replace the list, so the two-option budget is *structural*: there's no third slot to overflow into.
- The submenu, which affords a single author fallback, becomes the singular `--uktdd-submenu-position-try-fallback`.
- **New shipped no-op `--uktdd-noop`** for a recipe with one meaningful fallback (a centered menu): set slot 1, leave slot 2 as `--uktdd-noop` so it doesn't inherit the default's corner flip. It's an empty `@position-try` that evaluates as the primary placement — already rejected by the time it's reached — so it's skipped.

Propagated through the direction-recipe table, all examples, the story fixtures/recipe rows, and the comments. Also fixes a lingering three-option list in the FixedHeader avatar-menu fixture (missed in the earlier diagonal-drop pass).

## Migration

Set `--uktdd-body-position-try-fallback-1` / `-2` where you set the two entries of the old list (the README recipe table lists per-direction values), and `--uktdd-submenu-position-try-fallback` (singular) for the submenu. Breaking rename, acceptable at `1.0.0-alpha.6`.

## Verification

Centered-menu story verified in Storybook (Chromium): the split composition `var(--fallback-1), var(--fallback-2), var(fills)` parses and places centered-below correctly, and the `--uktdd-noop` slot-2 doesn't drag it into a corner. Dropdown tests (102), tsc, lint, format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)