### PR TITLE
Derive dropdown body tints from its themed colors (not the system colors)

### DIFF
--- a/.changeset/dropdown-derive-tints-from-themed-colors.md
+++ b/.changeset/dropdown-derive-tints-from-themed-colors.md
@@ -1,0 +1,22 @@
+---
+'@acusti/dropdown': patch
+---
+
+Derive the body’s layered tints from its own themed colors instead of from
+the system colors directly, so overriding the surface carries them with it.
+`--uktdd-body-bg-color-selected` and `--uktdd-body-border-color` now
+`color-mix()` against `currentColor` rather than `CanvasText`, and
+`--uktdd-body-bg-color-path` — which has to mix the body’s foreground into
+its background, and so can’t use `currentColor` for both halves — moves its
+default out of `:root` and onto the `[data-ukt-active]` path rule as a
+`var()` fallback. A `var()` inside a custom property is substituted where
+that property is declared, so the previous `:root` defaults resolved
+against the ambient color scheme before a consumer’s override on the body
+could reach them: a dropdown themed with `--uktdd-body-color` and
+`--uktdd-body-bg-color` alone still got a light-mode hairline, selected
+tint, and path step, which on a dark-surfaced menu meant a black border it
+couldn’t show and a near-white path step. All three remain plain custom
+properties that override the derived default when set directly, and all
+three compute to their previous values while `--uktdd-body-color` and
+`--uktdd-body-bg-color` are at their defaults, so a dropdown that themes
+nothing renders identically.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -190,20 +190,33 @@ is the one you want.
 ## Color Scheme
 
 The default colors are drawn from CSS system colors (`Canvas`,
-`CanvasText`, `Highlight`, `HighlightText`) and `color-mix()` blends
-against `CanvasText`, rather than fixed light-mode values, so the dropdown
-looks native in whichever color scheme is in effect.
-`--uktdd-body-box-shadow` is the exception — a fixed `rgba(0, 0, 0, 0.25)`
-rather than a scheme-aware mix, since mixing in `CanvasText` turns it into
-a diffuse white glow in dark mode instead of a shadow. `color-scheme` (set
-via `--uktdd-color-scheme`, default `inherit`) is left to inherit from the
-host page rather than forced to `light dark`: the popover is page content,
-not OS chrome, so it matches whatever scheme the page itself has opted into
-— light, if the page hasn’t adopted dark mode — rather than following the
-OS/browser preference regardless of the page. Set `--uktdd-color-scheme` to
-`light dark` (or `light`/`dark`) to follow the user’s preference
-irrespective of the host page instead. Override any of the
-`--uktdd-body-bg-color*` / `--uktdd-body-color*` /
+`CanvasText`, `Highlight`, `HighlightText`) rather than fixed light-mode
+values, so the dropdown looks native in whichever color scheme is in
+effect.
+
+The tints layered over the body — `--uktdd-body-bg-color-selected`,
+`--uktdd-body-border-color`, and `--uktdd-body-bg-color-path` — are
+`color-mix()` blends that derive from the body’s own foreground and
+background rather than from `CanvasText`/`Canvas` directly, so theming the
+surface carries them with it: set `--uktdd-body-color` and
+`--uktdd-body-bg-color` and the selected tint, hairline border, and
+active-path step all re-derive from the pair you set. That matters because
+a `var()` inside a custom property is substituted where that property is
+declared, so a `:root` default blended against `CanvasText` would freeze to
+the ambient color scheme before a consumer’s override could reach it — a
+dark menu on a light page would keep a black hairline it can’t show. Each
+one is still a plain custom property, so setting it directly overrides the
+derived default outright. `--uktdd-body-box-shadow` is the exception — a
+fixed `rgba(0, 0, 0, 0.25)` rather than a scheme-aware mix, since mixing in
+`CanvasText` turns it into a diffuse white glow in dark mode instead of a
+shadow. `color-scheme` (set via `--uktdd-color-scheme`, default `inherit`)
+is left to inherit from the host page rather than forced to `light dark`:
+the popover is page content, not OS chrome, so it matches whatever scheme
+the page itself has opted into — light, if the page hasn’t adopted dark
+mode — rather than following the OS/browser preference regardless of the
+page. Set `--uktdd-color-scheme` to `light dark` (or `light`/`dark`) to
+follow the user’s preference irrespective of the host page instead.
+Override any of the `--uktdd-body-bg-color*` / `--uktdd-body-color*` /
 `--uktdd-body-box-shadow` custom properties to theme it further.
 `--uktdd-menubar-trigger-bg-color-active` blends against `currentColor`
 instead, so it stays visible against a menubar trigger that the consumer

--- a/packages/dropdown/src/Dropdown.css
+++ b/packages/dropdown/src/Dropdown.css
@@ -18,8 +18,11 @@
     --uktdd-body-bg-color-hover: Highlight;
     --uktdd-body-color-hover: HighlightText;
     /* the persistent tint on the item matching props.value (the current
-       selection), shown even after the active/hover highlight moves off it */
-    --uktdd-body-bg-color-selected: color-mix(in oklab, CanvasText 6%, transparent);
+       selection), shown even after the active/hover highlight moves off it.
+       Mixed against currentColor rather than CanvasText so that it tracks
+       authored --uktdd-body-color values (CanvasText tracks color-scheme,
+       while currentColor is the element’s own `color`) */
+    --uktdd-body-bg-color-selected: color-mix(in oklab, currentColor 6%, transparent);
     /* shared by the body & submenu (see their box-shadow declarations below).
        A fixed black rather than a CanvasText-based mix: CanvasText is
        near-white in dark mode, so mixing it in turns this into a diffuse
@@ -31,8 +34,10 @@
        shadow can’t on a dark Canvas (a shadow alone is nearly invisible
        against a dark background, unlike on a light one). Unlike the
        shadow, a crisp 1px line has no blur radius to turn into a glow, so
-       color-mix against CanvasText is safe here in both schemes */
-    --uktdd-body-border-color: color-mix(in oklab, CanvasText 15%, transparent);
+       a color-mix is safe here in both schemes. Mixed against currentColor
+       for the same reason as --uktdd-body-bg-color-selected above (to track an
+       authored --uktdd-body-color instead of just color-scheme) */
+    --uktdd-body-border-color: color-mix(in oklab, currentColor 15%, transparent);
     --uktdd-body-buffer: 10px;
     --uktdd-body-max-height: calc(100dvh - var(--uktdd-body-buffer));
     --uktdd-body-max-width: calc(100dvw - var(--uktdd-body-buffer));
@@ -63,11 +68,9 @@
        submenus */
     --uktdd-body-gap: 0px;
     --uktdd-body-color: CanvasText;
-    /* the muted highlight for an ancestor item on the active path (see the
-       [data-ukt-active] rules below); mixed against Canvas instead of a
-       fixed light gray so it reads as a gray step off the body background
-       in both a light and a dark Canvas */
-    --uktdd-body-bg-color-path: color-mix(in oklab, CanvasText 12%, Canvas);
+    /* --uktdd-body-bg-color-path isn’t defaulted here — see the
+       [data-ukt-active] path rule below; set this property directly to
+       override it */
     --uktdd-body-color-path: currentColor;
     --uktdd-label-pad-right: 0.625em;
     --uktdd-submenu-position-area: inline-end span-block-end;
@@ -205,7 +208,17 @@
        even when the pointer is over a separator or disabled submenu item */
     [data-ukt-active]:has([data-ukt-submenu] [data-ukt-active]),
     [data-ukt-active]:has([data-ukt-submenu]:hover) {
-        background-color: var(--uktdd-body-bg-color-path);
+        /* --uktdd-body-bg-color-path has no :root default: it mixes the
+           body’s foreground into its background, and a background has no
+           use-time keyword like currentColor to carry that resolution
+           down. So the fallback lives here, in the var() itself, where a
+           consumer’s --uktdd-body-color/-bg-color override is in scope —
+           not frozen to :root’s defaults. Matches a CanvasText/Canvas mix
+           at those defaults */
+        background-color: var(
+            --uktdd-body-bg-color-path,
+            color-mix(in oklab, var(--uktdd-body-color) 12%, var(--uktdd-body-bg-color))
+        );
         color: var(--uktdd-body-color-path);
     }
 


### PR DESCRIPTION
`--uktdd-body-bg-color-selected`, `--uktdd-body-border-color`, and
`--uktdd-body-bg-color-path` are tints layered over the body, so they should
follow the body's own foreground and background. They were `color-mix()` blends
against `CanvasText`/`Canvas` declared at `:root`, which meant they didn't.

## Why the `:root` defaults couldn't follow a theme

A `var()` inside a custom property is substituted **where that property is
declared**, and the already-substituted value is what inherits. So
`--uktdd-body-border-color`'s value resolved on `:root` — against `:root`'s
`--uktdd-body-color`, i.e. `CanvasText` — and inherited down to
`.uktdropdown-body` already frozen. A consumer's override on the body arrived
too late to affect it.

This is not obvious, and it's worth stating explicitly because the intuitive fix
doesn't work: pointing the `:root` mixes at `var(--uktdd-body-color)` instead of
`CanvasText` changes nothing. I verified that in Chromium before writing this —
the themed and unthemed variants come out byte-identical.

What does work is a value that resolves at *use* time rather than at declaration
time:

- **`currentColor`** for the two foreground-derived tints. It's a keyword, not a
  `var()`, so it survives into the using rule and resolves against that
  element's own `color` — which `.uktdropdown-body` and `[data-ukt-submenu]`
  both set to `var(--uktdd-body-color)`. This is the same technique
  `--uktdd-menubar-trigger-bg-color-active` already uses, for the same reason.
- **A `var()` fallback at the point of use** for `--uktdd-body-bg-color-path`,
  which mixes the foreground *into the background* and so needs both halves.
  CSS has no `currentBackgroundColor`, so its default moves out of `:root` and
  onto the `[data-ukt-active]` path rule, where both halves resolve against the
  consumer's values. The property itself still overrides it when set.

## What it fixes

A dropdown themed with `--uktdd-body-color` and `--uktdd-body-bg-color` alone
kept light-mode tints. On a dark-surfaced menu that meant a black hairline it
couldn't show and a near-white active-path step.

## Verification

Measured computed styles in Chromium against the compiled stylesheet, on real
body markup, comparing the published `1.0.0-beta.0` CSS to this branch:

| scenario | | border | selected | path |
|---|---|---|---|---|
| **defaults** | beta.0 | `oklab(0 0 0 / .15)` | `oklab(0 0 0 / .06)` | `oklab(0.880)` |
| | this PR | `oklab(0 0 0 / .15)` | `oklab(0 0 0 / .06)` | `oklab(0.880)` |
| **themed light** (fg+bg only) | beta.0 | `oklab(0 0 0 / .15)` | `oklab(0 0 0 / .06)` | `oklab(0.880)` |
| | this PR | `oklab(0.2 0 0 / .15)` | `oklab(0.2 0 0 / .06)` | `oklab(0.904)` |
| **inverted dark** (fg+bg only) | beta.0 | `oklab(0 0 0 / .15)` | `oklab(0 0 0 / .06)` | `oklab(0.880)` |
| | this PR | `oklab(0.970 / .15)` | `oklab(0.970 / .06)` | `oklab(0.323)` |
| **explicit knobs** | beta.0 | `rebeccapurple` | `gold` | `teal` |
| | this PR | `rebeccapurple` | `gold` | `teal` |

- Row 1: unchanged, so a dropdown that themes nothing renders identically.
- Rows 2–3: beta.0 ignores the theme; this branch tracks it. Note beta.0's black
  hairline on a `#1e1e1e` menu.
- Row 4: setting the properties directly still wins, unchanged.

`bun run build` clean, 102 dropdown tests pass, `format:check` clean.

## Notes

- Patch release, backward compatible — defaults are unchanged.
- The `--uktdd-body-box-shadow` fixed black is untouched; the reasoning for it
  (a `CanvasText` mix becomes a glow in dark mode) still holds, and the hairline
  border is what carries separation on a dark surface.
- `--uktdd-body-bg-color-hover`/`-color-hover` are deliberately left on
  `Highlight`/`HighlightText`. Those are the native-menu accent, not a tint over
  the surface, and a consumer replacing them is opting out of native feel.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

