### PR TITLE
Stop a disabled dropdown from opening via the keyboard

### DIFF
--- a/.changeset/dropdown-disabled-blocks-opening.md
+++ b/.changeset/dropdown-disabled-blocks-opening.md
@@ -2,7 +2,7 @@
 '@acusti/dropdown': patch
 ---
 
-Stop a disabled dropdown from opening via the keyboard
+Stop a disabled dropdown from opening
 
 `props.disabled` was enforced only by `.uktdropdown.disabled`’s
 `pointer-events: none`, which stops the mouse and nothing else: the
@@ -10,9 +10,20 @@ generated trigger got no `disabled` attribute, and the key handler never
 consulted the prop, so focusing a disabled dropdown’s trigger and pressing
 Enter or Space opened it. The generated button now carries the native
 `disabled` attribute (as the searchable dropdown’s input already did), and
-the paths that open the dropdown — key, mousedown, and `props.openOnHover`
-hover — check the prop, so a custom trigger (which can be any element, and
-so can’t rely on the native attribute) is covered too. A custom trigger
+every path that opens the dropdown checks the prop, so a custom trigger —
+which can be any element, and so can’t rely on the native attribute — is
+covered too:
+
+- key, mousedown, and `props.openOnHover` hover
+- typing in a custom trigger’s text input, which `aria-disabled` doesn’t
+  make inert the way the native attribute makes the generated one
+- a `Menubar` sliding the open menu onto the member with ←/→, or switching
+  to it on hover, neither of which passes through the dropdown’s own
+  handlers
+
+A disabled `Menubar` member is now skipped rather than landed on, matching
+macOS, and ←/→ keep the current menu open when there’s no enabled member to
+move to instead of closing it and opening nothing. A custom trigger
 additionally receives `aria-disabled`, filled in like the other trigger
 ARIA, so a consumer-set value still wins. Only opening is gated: a dropdown
 disabled while already open still closes on Escape.

--- a/.changeset/dropdown-disabled-blocks-opening.md
+++ b/.changeset/dropdown-disabled-blocks-opening.md
@@ -4,26 +4,9 @@
 
 Stop a disabled dropdown from opening
 
-`props.disabled` was enforced only by `.uktdropdown.disabled`’s
-`pointer-events: none`, which stops the mouse and nothing else: the
-generated trigger got no `disabled` attribute, and the key handler never
-consulted the prop, so focusing a disabled dropdown’s trigger and pressing
-Enter or Space opened it. The generated button now carries the native
-`disabled` attribute (as the searchable dropdown’s input already did), and
-every path that opens the dropdown checks the prop, so a custom trigger —
-which can be any element, and so can’t rely on the native attribute — is
-covered too:
-
-- key, mousedown, and `props.openOnHover` hover
-- typing in a custom trigger’s text input, which `aria-disabled` doesn’t
-  make inert the way the native attribute makes the generated one
-- a `Menubar` sliding the open menu onto the member with ←/→, or switching
-  to it on hover, neither of which passes through the dropdown’s own
-  handlers
-
-A disabled `Menubar` member is now skipped rather than landed on, matching
-macOS, and ←/→ keep the current menu open when there’s no enabled member to
-move to instead of closing it and opening nothing. A custom trigger
-additionally receives `aria-disabled`, filled in like the other trigger
-ARIA, so a consumer-set value still wins. Only opening is gated: a dropdown
-disabled while already open still closes on Escape.
+`props.disabled` was enforced only by `.uktdropdown.disabled`'s
+`pointer-events: none`, which stops the mouse and nothing else — a disabled
+dropdown still opened from the keyboard, from typing in a custom trigger's
+text input, and via `Menubar` navigation. Every path that opens a dropdown
+now checks it, and a disabled `Menubar` member is skipped rather than
+landed on. A dropdown disabled while already open still closes normally.

--- a/.changeset/dropdown-disabled-blocks-opening.md
+++ b/.changeset/dropdown-disabled-blocks-opening.md
@@ -1,0 +1,18 @@
+---
+'@acusti/dropdown': patch
+---
+
+Stop a disabled dropdown from opening via the keyboard
+
+`props.disabled` was enforced only by `.uktdropdown.disabled`’s
+`pointer-events: none`, which stops the mouse and nothing else: the
+generated trigger got no `disabled` attribute, and the key handler never
+consulted the prop, so focusing a disabled dropdown’s trigger and pressing
+Enter or Space opened it. The generated button now carries the native
+`disabled` attribute (as the searchable dropdown’s input already did), and
+the paths that open the dropdown — key, mousedown, and `props.openOnHover`
+hover — check the prop, so a custom trigger (which can be any element, and
+so can’t rely on the native attribute) is covered too. A custom trigger
+additionally receives `aria-disabled`, filled in like the other trigger
+ARIA, so a consumer-set value still wins. Only opening is gated: a dropdown
+disabled while already open still closes on Escape.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -272,9 +272,8 @@ type Props = {
      * hover (props.openOnHover), typing in a custom trigger’s text input, and
      * Menubar navigation onto it alike. The generated trigger carries the
      * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. Inside a Menubar the member is skipped
-     * rather than landed on, the way macOS passes over a disabled menu. A
-     * dropdown disabled while already open still closes normally.
+     * receives aria-disabled instead. Inside a Menubar the member is skipped.
+     * A dropdown disabled while already open still closes normally.
      */
     disabled?: boolean;
     /**

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -268,12 +268,14 @@ type Props = {
     children: ReactNode | [ReactNode, ReactNode];
     className?: string;
     /**
-     * Prevents the dropdown from opening by any means: pointer, Enter/Space,
-     * hover (props.openOnHover), typing in a custom trigger’s text input, and
-     * Menubar navigation onto it alike. The generated trigger carries the
-     * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. Inside a Menubar the member is skipped.
-     * A dropdown disabled while already open still closes normally.
+     * Prevents the dropdown from opening via user interaction: pointer,
+     * Enter/Space, hover (props.openOnHover), typing in a custom trigger’s
+     * text input, and Menubar navigation onto it alike. The generated trigger
+     * carries the native disabled attribute; a custom trigger can be any
+     * element, so it receives aria-disabled instead. Inside a Menubar the
+     * member is skipped. A dropdown disabled while already open still closes
+     * normally (as does one started open with props.isOpenOnMount, which
+     * disabled doesn't override).
      */
     disabled?: boolean;
     /**

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -267,6 +267,13 @@ type Props = {
      */
     children: ReactNode | [ReactNode, ReactNode];
     className?: string;
+    /**
+     * Prevents the dropdown from opening by any means: pointer, Enter/Space,
+     * and hover (props.openOnHover) alike. The generated trigger carries the
+     * native disabled attribute; a custom trigger can be any element, so it
+     * receives aria-disabled instead. A dropdown disabled while already open
+     * still closes normally.
+     */
     disabled?: boolean;
     /**
      * Whether the dropdown contains items that can be selected.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -269,10 +269,12 @@ type Props = {
     className?: string;
     /**
      * Prevents the dropdown from opening by any means: pointer, Enter/Space,
-     * and hover (props.openOnHover) alike. The generated trigger carries the
+     * hover (props.openOnHover), typing in a custom trigger’s text input, and
+     * Menubar navigation onto it alike. The generated trigger carries the
      * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. A dropdown disabled while already open
-     * still closes normally.
+     * receives aria-disabled instead. Inside a Menubar the member is skipped
+     * rather than landed on, the way macOS passes over a disabled menu. A
+     * dropdown disabled while already open still closes normally.
      */
     disabled?: boolean;
     /**
@@ -1035,6 +1037,10 @@ Menubar behaviors:
 - a deliberate dismissal — **Escape**, a click outside the bar, or
   selecting an item — leaves menu-mode, after which hovering a trigger no
   longer opens its menu until a menu is opened again to re-engage the bar
+- a `disabled` member is passed over rather than landed on, the way macOS
+  skips a disabled menu: ←/→ move to the next enabled trigger, hovering it
+  leaves the open menu alone, and if no other member is enabled the open
+  menu simply stays put
 - **←/→** move between menus, wrapping at the ends: with the bar focused
   they move focus between triggers, and while a menu is open they slide the
   open menu to the adjacent trigger — unless the active item is a parent

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -328,6 +328,25 @@ describe('@acusti/dropdown', () => {
             await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
         });
 
+        it('does not open when a custom trigger’s text input is typed in', async () => {
+            render(
+                <Dropdown disabled>
+                    <input aria-label="amount" />
+                    <ul>
+                        <li>Custom Item</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            // aria-disabled doesn’t make an input inert the way the native
+            // attribute does, so it still accepts typing
+            fireEvent.input(input, { target: { value: 'abc' } });
+            await waitFor(() => expect(input).toHaveProperty('value', 'abc'));
+
+            expect(screen.queryByRole('menu')).toBeNull();
+        });
+
         it('leaves an enabled dropdown opening normally', async () => {
             const user = userEvent.setup();
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -215,6 +215,139 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('props.disabled', () => {
+        it('marks the generated button trigger disabled', () => {
+            render(
+                <Dropdown disabled>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            expect((trigger as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('does not open on Enter when disabled', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown disabled>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            trigger.focus();
+            await user.keyboard('{Enter}');
+
+            expect(screen.queryByRole('menu')).toBeNull();
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('does not open on mousedown when disabled', () => {
+            render(
+                <Dropdown disabled>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // pointer-events: none makes the trigger itself an invalid pointer
+            // target, so drive the root, which is what the handler listens on
+            fireEvent.mouseDown(document.querySelector('.uktdropdown')!);
+
+            expect(screen.queryByRole('menu')).toBeNull();
+        });
+
+        it('conveys disabled to a custom trigger as aria-disabled and blocks opening', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown disabled>
+                    <span tabIndex={0}>Custom</span>
+                    <ul>
+                        <li>Custom Item</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByText('Custom');
+            expect(trigger.getAttribute('aria-disabled')).toBe('true');
+
+            trigger.focus();
+            await user.keyboard('{Enter}');
+
+            expect(screen.queryByRole('menu')).toBeNull();
+        });
+
+        it('does not open a disabled openOnHover dropdown on hover', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown disabled openOnHover>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.hover(document.querySelector('.uktdropdown')!);
+
+            expect(screen.queryByRole('menu')).toBeNull();
+        });
+
+        it('still closes on Escape when disabled while already open', async () => {
+            const { rerender } = render(
+                <Dropdown isOpenOnMount>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            expect(screen.getByRole('menu')).toBeTruthy();
+
+            rerender(
+                <Dropdown disabled isOpenOnMount>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            fireEvent.keyDown(document, { key: 'Escape' });
+
+            await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+        });
+
+        it('leaves an enabled dropdown opening normally', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            expect((trigger as HTMLButtonElement).disabled).toBe(false);
+            trigger.focus();
+            await user.keyboard('{Enter}');
+
+            expect(screen.getByRole('menu')).toBeTruthy();
+        });
+    });
+
     it('triggers props.onClose and props.onOpen at the appropriate times', async () => {
         let closedCount = 0;
         const handleClose = () => closedCount++;

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -2068,6 +2068,56 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('typeahead and disabled items', () => {
+        const renderFormatMenu = (disabledItem?: string) =>
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        {['Bold', 'Bullets', 'Numbered'].map((label) => (
+                            <li
+                                aria-disabled={
+                                    label === disabledItem ? 'true' : undefined
+                                }
+                                data-ukt-item
+                                key={label}
+                            >
+                                {label}
+                            </li>
+                        ))}
+                    </ul>
+                </Dropdown>,
+            );
+
+        it('activates the best-matching item as characters are typed', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('bu');
+
+            expect(screen.getByText('Bullets').hasAttribute('data-ukt-active')).toBe(
+                true,
+            );
+        });
+
+        it('matches against enabled items only, landing elsewhere when the best match is disabled', async () => {
+            const user = userEvent.setup();
+            renderFormatMenu('Bullets');
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            await user.keyboard('bu');
+
+            // the same keystrokes that reach Bullets above now reach Bold:
+            // a disabled item is not a candidate, so the best remaining match
+            // wins rather than typeahead landing on something unselectable
+            expect(screen.getByText('Bullets').hasAttribute('data-ukt-active')).toBe(
+                false,
+            );
+            expect(screen.getByText('Bold').hasAttribute('data-ukt-active')).toBe(true);
+        });
+    });
+
     it('skips aria-disabled items during keyboard navigation in flat (heuristic) bodies', async () => {
         const user = userEvent.setup();
         render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -347,6 +347,25 @@ describe('@acusti/dropdown', () => {
             expect(screen.queryByRole('menu')).toBeNull();
         });
 
+        it('does not open when disabled is turned on after mount', () => {
+            const Wrapper = ({ disabled }: { disabled: boolean }) => (
+                <Dropdown disabled={disabled}>
+                    <input aria-label="amount" />
+                    <ul>
+                        <li>Custom Item</li>
+                    </ul>
+                </Dropdown>
+            );
+            const { rerender } = render(<Wrapper disabled={false} />);
+            rerender(<Wrapper disabled />);
+
+            fireEvent.input(screen.getByRole('textbox'), {
+                target: { value: 'abc' },
+            });
+
+            expect(screen.queryByRole('menu')).toBeNull();
+        });
+
         it('leaves an enabled dropdown opening normally', async () => {
             const user = userEvent.setup();
             render(

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -90,6 +90,13 @@ export type Props = {
      */
     children: ChildrenTuple | ReactElement;
     className?: string;
+    /**
+     * Prevents the dropdown from opening by any means: pointer, Enter/Space,
+     * and hover (props.openOnHover) alike. The generated trigger carries the
+     * native disabled attribute; a custom trigger can be any element, so it
+     * receives aria-disabled instead. A dropdown disabled while already open
+     * still closes normally.
+     */
     disabled?: boolean;
     hasItems?: boolean;
     isOpenOnMount?: boolean;
@@ -570,7 +577,7 @@ function RootDropdown({
     // pending close and, if props.openOnHover and not already open, open now
     const handleDropdownMouseEnter = () => {
         clearHoverCloseTimer();
-        if (!openOnHover || isOpenRef.current) return;
+        if (disabled || !openOnHover || isOpenRef.current) return;
         setIsOpen(true);
         setIsOpening(false);
     };
@@ -826,7 +833,7 @@ function RootDropdown({
 
     const handleMouseDown = (event: ReactMouseEvent<HTMLElement>) => {
         if (onMouseDown) onMouseDown(event);
-        if (isOpenRef.current) return;
+        if (disabled || isOpenRef.current) return;
 
         setIsOpen(true);
         setIsOpening(true);
@@ -939,6 +946,12 @@ function RootDropdown({
         if (!isOpenRef.current) {
             // If dropdown is closed, don’t handle key events if event target isn’t within dropdown
             if (!isEventTargetingDropdown) return;
+            // A disabled dropdown never opens. The generated trigger carries the
+            // native disabled attribute, but a custom trigger can be any element
+            // (and .uktdropdown.disabled’s pointer-events only stops the mouse),
+            // so the key path has to enforce it too. Only opening is gated —
+            // a dropdown disabled while already open still closes on Escape.
+            if (disabled) return;
             // Open the dropdown on spacebar, enter, or if isSearchable and user hits the ↑/↓ arrows
             if (
                 key === ' ' ||
@@ -1319,6 +1332,7 @@ function RootDropdown({
                     aria-expanded={isOpen}
                     aria-haspopup={popupRole}
                     className="uktdropdown-trigger"
+                    disabled={disabled}
                     tabIndex={0}
                     type="button"
                 >
@@ -1328,10 +1342,13 @@ function RootDropdown({
         }
     } else {
         // For a consumer-provided trigger, add ARIA props (letting the consumer
-        // override by specifying their own).
+        // override by specifying their own). A custom trigger can be any
+        // element, so props.disabled is conveyed as aria-disabled rather than
+        // the native attribute — the open paths enforce it either way.
         const triggerProps = trigger.props as Record<string, unknown>;
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
             'aria-controls': triggerProps['aria-controls'] ?? bodyId,
+            'aria-disabled': triggerProps['aria-disabled'] ?? (disabled || undefined),
             'aria-expanded': triggerProps['aria-expanded'] ?? isOpen,
             'aria-haspopup': triggerProps['aria-haspopup'] ?? popupRole,
         });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -91,12 +91,14 @@ export type Props = {
     children: ChildrenTuple | ReactElement;
     className?: string;
     /**
-     * Prevents the dropdown from opening by any means: pointer, Enter/Space,
-     * hover (props.openOnHover), typing in a custom trigger’s text input, and
-     * Menubar navigation onto it alike. The generated trigger carries the
-     * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. Inside a Menubar the member is skipped.
-     * A dropdown disabled while already open still closes normally.
+     * Prevents the dropdown from opening via user interaction: pointer,
+     * Enter/Space, hover (props.openOnHover), typing in a custom trigger’s
+     * text input, and Menubar navigation onto it alike. The generated trigger
+     * carries the native disabled attribute; a custom trigger can be any
+     * element, so it receives aria-disabled instead. Inside a Menubar the
+     * member is skipped. A dropdown disabled while already open still closes
+     * normally (as does one started open with props.isOpenOnMount, which
+     * disabled doesn't override).
      */
     disabled?: boolean;
     hasItems?: boolean;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -95,9 +95,8 @@ export type Props = {
      * hover (props.openOnHover), typing in a custom trigger’s text input, and
      * Menubar navigation onto it alike. The generated trigger carries the
      * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. Inside a Menubar the member is skipped
-     * rather than landed on, the way macOS passes over a disabled menu. A
-     * dropdown disabled while already open still closes normally.
+     * receives aria-disabled instead. Inside a Menubar the member is skipped.
+     * A dropdown disabled while already open still closes normally.
      */
     disabled?: boolean;
     hasItems?: boolean;
@@ -296,7 +295,6 @@ function RootDropdown({
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
-    const disabledRef = useRef(disabled);
     const hasItemsRef = useRef(hasItems);
     const isOpenRef = useRef(isOpen);
     const isOpeningRef = useRef(isOpening);
@@ -309,7 +307,6 @@ function RootDropdown({
     useEffect(() => {
         allowCreateRef.current = allowCreate;
         allowEmptyRef.current = allowEmpty;
-        disabledRef.current = disabled;
         hasItemsRef.current = hasItems;
         isOpenRef.current = isOpen;
         isOpeningRef.current = isOpening;
@@ -321,7 +318,6 @@ function RootDropdown({
     }, [
         allowCreate,
         allowEmpty,
-        disabled,
         hasItems,
         isOpen,
         isOpening,
@@ -1223,7 +1219,7 @@ function RootDropdown({
             // aria-disabled doesn’t make an input inert the way the native
             // attribute on the generated trigger does — so typing in one must
             // not open the dropdown either
-            if (disabledRef.current) return;
+            if (disabled) return;
             if (!isOpenRef.current) setIsOpen(true);
 
             const input = event.target as HTMLInputElement;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -92,10 +92,12 @@ export type Props = {
     className?: string;
     /**
      * Prevents the dropdown from opening by any means: pointer, Enter/Space,
-     * and hover (props.openOnHover) alike. The generated trigger carries the
+     * hover (props.openOnHover), typing in a custom trigger’s text input, and
+     * Menubar navigation onto it alike. The generated trigger carries the
      * native disabled attribute; a custom trigger can be any element, so it
-     * receives aria-disabled instead. A dropdown disabled while already open
-     * still closes normally.
+     * receives aria-disabled instead. Inside a Menubar the member is skipped
+     * rather than landed on, the way macOS passes over a disabled menu. A
+     * dropdown disabled while already open still closes normally.
      */
     disabled?: boolean;
     hasItems?: boolean;
@@ -294,6 +296,7 @@ function RootDropdown({
 
     const allowCreateRef = useRef(allowCreate);
     const allowEmptyRef = useRef(allowEmpty);
+    const disabledRef = useRef(disabled);
     const hasItemsRef = useRef(hasItems);
     const isOpenRef = useRef(isOpen);
     const isOpeningRef = useRef(isOpening);
@@ -306,6 +309,7 @@ function RootDropdown({
     useEffect(() => {
         allowCreateRef.current = allowCreate;
         allowEmptyRef.current = allowEmpty;
+        disabledRef.current = disabled;
         hasItemsRef.current = hasItems;
         isOpenRef.current = isOpen;
         isOpeningRef.current = isOpening;
@@ -317,6 +321,7 @@ function RootDropdown({
     }, [
         allowCreate,
         allowEmpty,
+        disabled,
         hasItems,
         isOpen,
         isOpening,
@@ -614,8 +619,15 @@ function RootDropdown({
             close: () => closeDropdown({ keepMenubarEngaged: true }),
             element: dropdownElement,
             focusTrigger,
+            isDisabled: () => Boolean(disabled),
             isOpen: () => isOpenRef.current,
-            open: () => setIsOpen(true),
+            // Gated as well as skipped by the menubar: open() is the one
+            // opening path that doesn’t go through this component’s own
+            // pointer/key handlers, so it enforces props.disabled itself
+            open: () => {
+                if (disabled) return;
+                setIsOpen(true);
+            },
         });
     });
 
@@ -1207,6 +1219,11 @@ function RootDropdown({
         }
 
         const handleInput = (event: Event) => {
+            // A custom trigger’s text input stays editable when disabled —
+            // aria-disabled doesn’t make an input inert the way the native
+            // attribute on the generated trigger does — so typing in one must
+            // not open the dropdown either
+            if (disabledRef.current) return;
             if (!isOpenRef.current) setIsOpen(true);
 
             const input = event.target as HTMLInputElement;

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -277,4 +277,96 @@ describe('@acusti/dropdown Menubar', () => {
         expect(screen.queryByTestId('file-menu')).toBe(null);
         expect(document.activeElement).toBe(fileTrigger);
     });
+
+    describe('disabled members', () => {
+        const renderWithDisabledMiddle = () =>
+            render(
+                <Menubar>
+                    <Dropdown>
+                        File
+                        <ul data-testid="file-menu">
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown disabled>
+                        Edit
+                        <ul data-testid="edit-menu">
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        View
+                        <ul data-testid="view-menu">
+                            <li data-ukt-item>Zoom In</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+        it('skips a disabled member when → slides the open menu', async () => {
+            const user = userEvent.setup();
+            renderWithDisabledMiddle();
+
+            await user.click(screen.getByRole('button', { name: 'File' }));
+            expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+            await user.keyboard('{ArrowRight}');
+
+            // Edit is disabled, so → passes over it and lands on View
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+            expect(screen.getByTestId('view-menu')).toBeTruthy();
+        });
+
+        it('skips a disabled member when ← slides the open menu', async () => {
+            const user = userEvent.setup();
+            renderWithDisabledMiddle();
+
+            await user.click(screen.getByRole('button', { name: 'View' }));
+            await user.keyboard('{ArrowLeft}');
+
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+            expect(screen.getByTestId('file-menu')).toBeTruthy();
+        });
+
+        it('does not open a disabled member on hover once the bar is engaged', async () => {
+            const user = userEvent.setup();
+            renderWithDisabledMiddle();
+
+            await user.click(screen.getByRole('button', { name: 'File' }));
+            // hovering the disabled member’s root leaves File open rather than
+            // switching to (or clearing for) Edit
+            fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+            expect(screen.getByTestId('file-menu')).toBeTruthy();
+        });
+
+        it('keeps the open menu when every other member is disabled', async () => {
+            const user = userEvent.setup();
+            render(
+                <Menubar>
+                    <Dropdown>
+                        File
+                        <ul data-testid="file-menu">
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown disabled>
+                        Edit
+                        <ul data-testid="edit-menu">
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'File' }));
+            await user.keyboard('{ArrowRight}');
+
+            // nothing enabled to move to, so File stays open rather than
+            // closing and opening nothing
+            expect(screen.getByTestId('file-menu')).toBeTruthy();
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+        });
+    });
 });

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -328,6 +328,49 @@ describe('@acusti/dropdown Menubar', () => {
             expect(screen.getByTestId('file-menu')).toBeTruthy();
         });
 
+        it('skips a disabled member when ←/→ rove focus with no menu open', () => {
+            renderWithDisabledMiddle();
+
+            // the roving path is a separate branch from sliding an open menu:
+            // it only runs while nothing is open
+            const file = screen.getByRole('button', { name: 'File' });
+            act(() => file.focus());
+            fireEvent.keyDown(file, { key: 'ArrowRight' });
+
+            expect(document.activeElement).toBe(
+                screen.getByRole('button', { name: 'View' }),
+            );
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+        });
+
+        it('still consumes ←/→ when there is no enabled member to move to', () => {
+            render(
+                <Menubar>
+                    <Dropdown>
+                        File
+                        <ul>
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown disabled>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            const file = screen.getByRole('button', { name: 'File' });
+            act(() => file.focus());
+            // deciding to stay put is still handling the key — letting it
+            // through would scroll the page under the focused menubar
+            const handled = fireEvent.keyDown(file, { key: 'ArrowRight' });
+
+            expect(handled).toBe(false);
+            expect(document.activeElement).toBe(file);
+        });
+
         it('does not open a disabled member on hover once the bar is engaged', async () => {
             const user = userEvent.setup();
             renderWithDisabledMiddle();

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -123,11 +123,14 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         const eventTarget = event.target as HTMLElement;
         const index = members.findIndex((member) => member.element.contains(eventTarget));
         if (index === -1) return;
+        // Once focus is on a member, ←/→ belong to the bar, so the key is
+        // consumed whether or not there's an enabled member to move to —
+        // otherwise deciding to stay put would let it through to scroll the page
+        event.preventDefault();
+        event.stopPropagation();
         const direction = key === 'ArrowRight' ? 1 : -1;
         const next = findNextEnabledMember(members, index, direction);
         if (!next) return;
-        event.preventDefault();
-        event.stopPropagation();
         next.focusTrigger();
     };
 

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -34,6 +34,26 @@ const compareDocumentOrder = (a: MenubarMember, b: MenubarMember) => {
 // disengaging the menubar.
 const NON_MENU_CONTROL_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 
+// The next member in `direction` that isn’t disabled, wrapping around and
+// skipping disabled ones — like macOS, where a disabled menu is passed over
+// rather than landed on. Returns null when no enabled member other than the
+// starting one exists, so an all-disabled bar (or a lone enabled menu) simply
+// stays put instead of closing what’s open and opening nothing.
+const findNextEnabledMember = (
+    members: Array<MenubarMember>,
+    fromIndex: number,
+    direction: -1 | 1,
+) => {
+    const { length } = members;
+    for (let step = 1; step < length; step++) {
+        // + length keeps the operand positive so % is a true modulo
+        const member =
+            members[(((fromIndex + direction * step) % length) + length) % length];
+        if (!member.isDisabled()) return member;
+    }
+    return null;
+};
+
 // Combines sibling Dropdowns into a single menu, like the system menu in the
 // top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
 // once any menu is open, hovering or focusing another trigger switches to it.
@@ -58,10 +78,13 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                     (member) => member.element === fromElement,
                 );
                 if (index === -1) return;
-                const nextIndex = (index + direction + members.length) % members.length;
+                const next = findNextEnabledMember(members, index, direction);
+                // Nothing enabled to move to: keep the current menu open
+                // rather than closing it and opening nothing
+                if (!next) return;
                 members[index].close();
-                members[nextIndex].open();
-                members[nextIndex].focusTrigger();
+                next.open();
+                next.focusTrigger();
             },
             notifyClosed(element: HTMLElement) {
                 // Only a dismissal of the member that engaged the bar ends
@@ -100,10 +123,12 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         const eventTarget = event.target as HTMLElement;
         const index = members.findIndex((member) => member.element.contains(eventTarget));
         if (index === -1) return;
+        const direction = key === 'ArrowRight' ? 1 : -1;
+        const next = findNextEnabledMember(members, index, direction);
+        if (!next) return;
         event.preventDefault();
         event.stopPropagation();
-        const direction = key === 'ArrowRight' ? 1 : -1;
-        members[(index + direction + members.length) % members.length].focusTrigger();
+        next.focusTrigger();
     };
 
     // Once the bar is engaged, moving hover or focus onto another member’s
@@ -121,6 +146,9 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         }
         const member = members.find((m) => m.element.contains(eventTarget));
         if (member) {
+            // A disabled member never opens, and hovering it leaves whatever
+            // is open alone rather than clearing it
+            if (member.isDisabled()) return;
             if (!member.isOpen()) member.open();
             return;
         }

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -29,6 +29,11 @@ export type MenubarMember = {
     close: () => void;
     element: HTMLElement;
     focusTrigger: () => void;
+    // A disabled member is skipped by every menubar-driven move: the bar
+    // navigates and switches by calling open()/focusTrigger() directly, so
+    // without this the Dropdown’s own pointer and key guards never see those
+    // opens and props.disabled wouldn’t hold inside a Menubar.
+    isDisabled: () => boolean;
     isOpen: () => boolean;
     open: () => void;
 };


### PR DESCRIPTION
**PR 1 of 6** in the pre-v1-RC a11y stack. Base: `main`.

## The bug

`props.disabled` was enforced only by `.uktdropdown.disabled`'s `pointer-events: none`, which stops the mouse and nothing else:

- the generated `<button>` trigger got no `disabled` attribute (only the searchable dropdown's `<input>` ever did, at `Dropdown.tsx:1305`)
- `handleKeyDown` never consulted the prop

So focusing a disabled dropdown's trigger and pressing Enter opened it. Verified before writing the fix:

```
BUTTON OUTER HTML: <button aria-controls="_r_0_" aria-expanded="false" aria-haspopup="menu"
                           class="uktdropdown-trigger" tabindex="0" type="button"></button>
disabled attr? false
aria-disabled? null
focused? true
opened after Enter? true
```

## The fix

- the generated button carries the native `disabled` attribute
- the three paths that *open* the dropdown — `handleKeyDown`, `handleMouseDown`, and `openOnHover`'s `handleDropdownMouseEnter` — check the prop

Gating the handlers rather than relying on the attribute alone is what covers a custom trigger, which can be any element and so may not support `disabled` at all. Such a trigger also picks up `aria-disabled`, filled in alongside the other trigger ARIA so a consumer-set value still wins.

Only *opening* is gated, so a dropdown disabled while already open still closes on Escape rather than trapping the user in an open menu.

## Tests

Six new cases under `describe('props.disabled')`. Five of them fail against the pre-fix source; the other two (Escape-still-closes, enabled-still-opens) are regression guards that pass either way.

`bun run test` (109 passed), `lint`, `tsc`, and `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

