### PR TITLE
Implement the documented Home/End keys

### DIFF
--- a/.changeset/dropdown-home-end-keys.md
+++ b/.changeset/dropdown-home-end-keys.md
@@ -1,0 +1,18 @@
+---
+'@acusti/dropdown': minor
+---
+
+Implement the documented Home/End keys
+
+The keyboard docs listed Home and End as “jump to first/last item in the
+current level”, but the key handler had no branch for either, so both were
+no-ops — the only way to reach a level’s ends was ⌥/⌘ + ↑/↓. Home and End
+now jump to the same targets those modifiers do, operating on the current
+level (the level of the deepest highlighted item) like every other
+navigation key, and reporting the item they land on to
+`props.onActiveItem`.
+
+Like ←/→, they stand down while a text input has focus — a searchable
+dropdown’s own input, or one inside a custom trigger — where Home/End are
+caret movement rather than menu navigation. The ⌥/⌘ + ↑/↓ shortcut, which
+was never documented, is now listed alongside them.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1081,7 +1081,8 @@ highlight into it.
 - **Escape**: Close the dropdown entirely — including any open submenus —
   and return focus to the trigger (macOS-style; use ← to back out one level
   at a time)
-- **Arrow Up/Down**: Navigate between items in the current level
+- **Arrow Up/Down**: Navigate between items in the current level; with ⌥ or
+  ⌘ held, jump to the first/last item of that level
 - **Arrow Right**: Open the highlighted parent item’s submenu (if not
   already disclosed) and highlight its first item; in a
   [`Menubar`](#menubar), if the highlighted item is a leaf, slide to the
@@ -1089,7 +1090,9 @@ highlight into it.
 - **Arrow Left**: Close the highlighted item’s level and return to its
   parent item; in a `Menubar` with the highlight at the top level of a
   menu, slide to the previous menu
-- **Home/End**: Jump to first/last item in the current level
+- **Home/End**: Jump to first/last item in the current level. Like ←/→,
+  they stand down while a text input has focus (a searchable dropdown’s own
+  input, or one inside a custom trigger), where they move the caret instead
 - **Type characters**: Jump to the best-matching item in the current level
 
 For accessibility, the component focuses on semantic HTML structure and

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -386,6 +386,107 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('Home/End keys', () => {
+        const renderMenu = (props: Partial<Props> = {}) =>
+            render(
+                <Dropdown {...props}>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                        <li data-ukt-value="two">Two</li>
+                        <li data-ukt-value="three">Three</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+        it('jumps to the last item on End and the first on Home', async () => {
+            const user = userEvent.setup();
+            renderMenu();
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{ArrowDown}');
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{End}');
+            expect(screen.getByText('Three').hasAttribute('data-ukt-active')).toBe(true);
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(false);
+
+            await user.keyboard('{Home}');
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+            expect(screen.getByText('Three').hasAttribute('data-ukt-active')).toBe(false);
+        });
+
+        it('reports the jumped-to item to props.onActiveItem', async () => {
+            const handleActiveItem = vi.fn();
+            const user = userEvent.setup();
+            renderMenu({ onActiveItem: handleActiveItem });
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+            await user.keyboard('{End}');
+
+            expect(handleActiveItem).toHaveBeenCalledTimes(1);
+            expect(handleActiveItem.mock.calls[0][0]).toMatchObject({
+                label: 'Three',
+                value: 'three',
+            });
+        });
+
+        it('operates on the current level, not the top level', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                                <li data-ukt-value="center">Center</li>
+                                <li data-ukt-value="right">Right</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            // dive into the submenu, then jump to its end
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}');
+            expect(screen.getByText('Left').hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{End}');
+            expect(screen.getByText('Right').hasAttribute('data-ukt-active')).toBe(true);
+            // the top level is untouched — Bold never becomes active
+            expect(screen.getByText('Bold').hasAttribute('data-ukt-active')).toBe(false);
+
+            await user.keyboard('{Home}');
+            expect(screen.getByText('Left').hasAttribute('data-ukt-active')).toBe(true);
+        });
+
+        it('leaves Home/End to the caret when a text input has focus', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                        <li data-ukt-value="two">Two</li>
+                        <li data-ukt-value="three">Three</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+            await user.keyboard('{ArrowDown}');
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+
+            await user.keyboard('{End}');
+
+            // still on One: End moved the caret, it didn’t jump to Three
+            expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
+            expect(screen.getByText('Three').hasAttribute('data-ukt-active')).toBe(false);
+        });
+    });
+
     it('triggers props.onClose and props.onOpen at the appropriate times', async () => {
         let closedCount = 0;
         const handleClose = () => closedCount++;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1088,6 +1088,22 @@ function RootDropdown({
                 syncSubmenuDisclosure();
                 return;
             }
+            // Home/End jump to the ends of the current level, the same targets
+            // as ⌥/⌘ + ↑/↓ above. Like ←/→ they stand down when a text input
+            // has focus (a searchable dropdown’s own input, or one inside a
+            // custom trigger), where they’re caret movement instead
+            if (!isTargetUsingKeyEvents && (key === 'Home' || key === 'End')) {
+                onEventHandled();
+                setActiveItem({
+                    dropdownElement,
+                    event,
+                    // Using a negative index counts back from the end
+                    index: key === 'Home' ? 0 : -1,
+                    onActiveItem: handleActiveItem,
+                });
+                syncSubmenuDisclosure();
+                return;
+            }
             // ←/→ dive into and surface out of submenus (and move between
             // menus in a menubar); leave them alone when a text input has focus
             if (!isTargetUsingKeyEvents) {


### PR DESCRIPTION
**PR 2 of 6** in the pre-v1-RC a11y stack. Base: #411 — review that first; this diff is only the second commit.

## The gap

`README.md` listed **Home/End** as "jump to first/last item in the current level", but `handleKeyDown` had no branch for either. Both were no-ops; the only way to reach a level's ends was the (undocumented) ⌥/⌘ + ↑/↓ shortcut. Verified before the fix:

```
active after ArrowDown: Apple
active after End:       Apple
active after Home:      Apple
```

APG lists Home/End for both the menu and listbox patterns, so implementing beat deleting the doc line.

## The fix

Home and End resolve to the same `setActiveItem` targets the modifiers use — `index: 0` and `index: -1` (which counts back from the end) — so they operate on the current level like every other navigation key and report the item they land on to `onActiveItem`.

They sit behind the same `!isTargetUsingKeyEvents` guard as the arrow keys that dive between levels: in a searchable dropdown, or one whose custom trigger holds a text input, Home/End are caret movement and menu navigation has no business intercepting them. (`isEventTargetUsingKeyEvent` returns `true` for a text `<input>`, so the guard is exactly the right lever.)

## Docs

The Home/End bullet gains the text-input caveat, and ⌥/⌘ + ↑/↓ is now documented alongside it, since two key combinations share those targets.

## Tests

Four new cases: both ends at the top level, `onActiveItem` reporting, current-level scoping inside a submenu, and the searchable-input stand-down. The first three fail against the pre-fix source; the fourth passes either way (Home/End were no-ops before) and guards against a future regression.

`bun run test` (113 passed), `lint`, `tsc`, and `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

