### PR TITLE
Give the popup body an accessible name

### DIFF
--- a/.changeset/dropdown-popup-accessible-name.md
+++ b/.changeset/dropdown-popup-accessible-name.md
@@ -1,0 +1,25 @@
+---
+'@acusti/dropdown': minor
+---
+
+Give the popup body an accessible name
+
+The open body carried a `role` but no name, so a `hasItems={false}`
+dropdown rendered a `role="dialog"` with nothing naming it — a dialog
+without an accessible name is an ARIA violation, and menus and listboxes
+were announced as a bare “menu”/“listbox” too. The body now takes
+`aria-labelledby` pointing at whatever names the trigger: the `props.label`
+text when there is one (always text, and the same name the trigger itself
+takes), otherwise the trigger element, whose accessible name the body then
+inherits.
+
+To point at the trigger the component fills in its `id`, derived from the
+same `useId` that already produced the body’s. A custom trigger that
+carries its own `id` keeps it, and the body points at that one instead.
+
+A searchable dropdown with no `props.label` is deliberately left unnamed:
+`aria-labelledby` resolves a text input to its value, so pointing the
+listbox at the generated input would name it after whatever the user has
+typed. Such a dropdown has no accessible name for its trigger either, so
+`props.label` — or a custom trigger carrying its own `aria-label` — is the
+fix for both.

--- a/.changeset/dropdown-popup-accessible-name.md
+++ b/.changeset/dropdown-popup-accessible-name.md
@@ -17,9 +17,14 @@ To point at the trigger the component fills in its `id`, derived from the
 same `useId` that already produced the body’s. A custom trigger that
 carries its own `id` keeps it, and the body points at that one instead.
 
-A searchable dropdown with no `props.label` is deliberately left unnamed:
-`aria-labelledby` resolves a text input to its value, so pointing the
-listbox at the generated input would name it after whatever the user has
-typed. Such a dropdown has no accessible name for its trigger either, so
-`props.label` — or a custom trigger carrying its own `aria-label` — is the
-fix for both.
+Two shapes are deliberately left unnamed, both because the trigger has no
+name to give. A text input trigger is one: `aria-labelledby` resolves a
+text input to its value, so pointing the popup at one would name it after
+whatever the user has typed. That covers a searchable dropdown’s trigger (a
+text input by definition, generated or custom) and a custom trigger that is
+itself an `<input>` or `<textarea>`; a text input nested inside a custom
+trigger leaks its value the same way but isn’t detectable from the element
+alone. The other is an empty generated trigger — single-child syntax with
+no `props.label` renders an empty `<button>`, which has no name of its own
+to lend, and for `hasItems={false}` that leaves an unnamed dialog. In both
+cases the trigger is unnamed too, and `props.label` fixes both at once.

--- a/.changeset/dropdown-popup-accessible-name.md
+++ b/.changeset/dropdown-popup-accessible-name.md
@@ -4,27 +4,12 @@
 
 Give the popup body an accessible name
 
-The open body carried a `role` but no name, so a `hasItems={false}`
-dropdown rendered a `role="dialog"` with nothing naming it — a dialog
-without an accessible name is an ARIA violation, and menus and listboxes
-were announced as a bare “menu”/“listbox” too. The body now takes
-`aria-labelledby` pointing at whatever names the trigger: the `props.label`
-text when there is one (always text, and the same name the trigger itself
-takes), otherwise the trigger element, whose accessible name the body then
-inherits.
+The open body now takes `aria-labelledby` pointing at whatever names the
+trigger — `props.label` if you pass one, otherwise the trigger element.
+Previously it carried a `role` but no name, so `hasItems={false}` rendered
+an unnamed `dialog`.
 
-To point at the trigger the component fills in its `id`, derived from the
-same `useId` that already produced the body’s. A custom trigger that
-carries its own `id` keeps it, and the body points at that one instead.
-
-Two shapes are deliberately left unnamed, both because the trigger has no
-name to give. A text input trigger is one: `aria-labelledby` resolves a
-text input to its value, so pointing the popup at one would name it after
-whatever the user has typed. That covers a searchable dropdown’s trigger (a
-text input by definition, generated or custom) and a custom trigger that is
-itself an `<input>` or `<textarea>`; a text input nested inside a custom
-trigger leaks its value the same way but isn’t detectable from the element
-alone. The other is an empty generated trigger — single-child syntax with
-no `props.label` renders an empty `<button>`, which has no name of its own
-to lend, and for `hasItems={false}` that leaves an unnamed dialog. In both
-cases the trigger is unnamed too, and `props.label` fixes both at once.
+Two shapes stay unnamed, because the trigger has no name to lend: a text
+input trigger (`aria-labelledby` resolves one to its value) and an empty
+generated trigger (single-child syntax with no `props.label`). Pass
+`props.label` to name either.

--- a/.changeset/dropdown-text-input-selector.md
+++ b/.changeset/dropdown-text-input-selector.md
@@ -7,5 +7,5 @@ Widen the text input selector to match use-keyboard-events
 The selector that finds a custom trigger's value-source input excluded only
 `radio`, `checkbox`, and `range`, so a `submit`, `button`, `file`, or other
 non-text input in a trigger was adopted as the dropdown's value source. It
-is now derived from `NON_TEXT_INPUT_TYPES`, the same set
+is now derived from `NON_TEXT_INPUT_TYPES`, the same list
 `isEventTargetUsingKeyEvent` uses, so the two agree.

--- a/.changeset/dropdown-text-input-selector.md
+++ b/.changeset/dropdown-text-input-selector.md
@@ -4,8 +4,8 @@
 
 Widen the text input selector to match use-keyboard-events
 
-The selector that finds a custom trigger's value-source input excluded only
+The selector that finds a custom trigger’s value-source input excluded only
 `radio`, `checkbox`, and `range`, so a `submit`, `button`, `file`, or other
-non-text input in a trigger was adopted as the dropdown's value source. It
+non-text input in a trigger was adopted as the dropdown’s value source. It
 is now derived from `NON_TEXT_INPUT_TYPES`, the same list
 `isEventTargetUsingKeyEvent` uses, so the two agree.

--- a/.changeset/dropdown-text-input-selector.md
+++ b/.changeset/dropdown-text-input-selector.md
@@ -1,0 +1,11 @@
+---
+'@acusti/dropdown': patch
+---
+
+Widen the text input selector to match use-keyboard-events
+
+The selector that finds a custom trigger's value-source input excluded only
+`radio`, `checkbox`, and `range`, so a `submit`, `button`, `file`, or other
+non-text input in a trigger was adopted as the dropdown's value source. It
+is now derived from `NON_TEXT_INPUT_TYPES`, the same set
+`isEventTargetUsingKeyEvent` uses, so the two agree.

--- a/.changeset/use-keyboard-events-export-non-text-types.md
+++ b/.changeset/use-keyboard-events-export-non-text-types.md
@@ -4,7 +4,8 @@
 
 Export NON_TEXT_INPUT_TYPES
 
-The set of input types that hold no user-entered text — the one behind
-`isEventTargetUsingKeyEvent` — is now exported, so consumers can share its
-notion of what counts as a text input instead of keeping a copy in sync by
-hand.
+The input types that hold no user-entered text — the ones behind
+`isEventTargetUsingKeyEvent` — are now exported, so consumers can share
+that notion of what counts as a text input instead of keeping a copy in
+sync by hand. It's a frozen `readonly string[]`, since every consumer
+shares the one instance.

--- a/.changeset/use-keyboard-events-export-non-text-types.md
+++ b/.changeset/use-keyboard-events-export-non-text-types.md
@@ -1,0 +1,10 @@
+---
+'@acusti/use-keyboard-events': minor
+---
+
+Export NON_TEXT_INPUT_TYPES
+
+The set of input types that hold no user-entered text — the one behind
+`isEventTargetUsingKeyEvent` — is now exported, so consumers can share its
+notion of what counts as a text input instead of keeping a copy in sync by
+hand.

--- a/.changeset/use-keyboard-events-export-non-text-types.md
+++ b/.changeset/use-keyboard-events-export-non-text-types.md
@@ -7,5 +7,5 @@ Export NON_TEXT_INPUT_TYPES
 The input types that hold no user-entered text — the ones behind
 `isEventTargetUsingKeyEvent` — are now exported, so consumers can share
 that notion of what counts as a text input instead of keeping a copy in
-sync by hand. It's a frozen `readonly string[]`, since every consumer
+sync by hand. It’s a frozen `readonly string[]`, since every consumer
 shares the one instance.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1123,12 +1123,25 @@ name the trigger takes), and otherwise from the trigger element itself. The
 component fills in the trigger’s `id` for this; a custom trigger with an
 `id` of its own keeps it, and the body points at that instead.
 
-The one case with no name is a searchable dropdown with no `props.label`:
-`aria-labelledby` resolves a text input to its _value_, so pointing the
-listbox at the generated input would name it after whatever the user has
-typed. That dropdown has no accessible name for its trigger either, and
-`props.label` (or a custom trigger carrying its own `aria-label`) is the
-fix for both.
+Two shapes end up with no name, both because the trigger has none to give:
+
+- **A text input trigger.** `aria-labelledby` resolves a text input to its
+  _value_, so pointing the popup at one would name it after whatever the
+  user has typed. The component leaves the popup unnamed instead — for a
+  searchable dropdown’s trigger (a text input by definition, generated or
+  custom) and for a custom trigger that is itself an `<input>` or
+  `<textarea>`. A text input _nested_ inside a custom trigger leaks its
+  value the same way but isn’t detectable from the element alone, so it’s
+  on you to pass `props.label` there.
+- **An empty generated trigger**: single-child syntax with no `props.label`
+  renders a `<button>` with nothing in it, which has no accessible name of
+  its own to lend. This matters most for `hasItems={false}`, where the
+  popup is a `dialog` and an unnamed dialog is an ARIA violation.
+
+In both cases the trigger is unnamed too, and `props.label` fixes both at
+once. (A custom trigger’s own `aria-label` names the trigger, but the popup
+can’t inherit it — `aria-labelledby` would resolve the input to its value —
+so pass `props.label` when you want the popup named as well.)
 
 Item roles are filled in the same way when the body opens: items receive
 `role="option"` in a searchable (listbox) dropdown or `role="menuitem"` in

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1115,6 +1115,21 @@ readers can associate the trigger with its popup. If your custom trigger
 already specifies any of these ARIA props, your values win — the component
 only fills in what you haven’t set.
 
+The body is also named, via `aria-labelledby`, by whatever names the
+trigger — required for the `dialog` role and worth having on the others, so
+the popup is announced as “Alignment menu” rather than a bare “menu”. The
+name comes from `props.label` when you pass one (always text, and the same
+name the trigger takes), and otherwise from the trigger element itself. The
+component fills in the trigger’s `id` for this; a custom trigger with an
+`id` of its own keeps it, and the body points at that instead.
+
+The one case with no name is a searchable dropdown with no `props.label`:
+`aria-labelledby` resolves a text input to its _value_, so pointing the
+listbox at the generated input would name it after whatever the user has
+typed. That dropdown has no accessible name for its trigger either, and
+`props.label` (or a custom trigger carrying its own `aria-label`) is the
+fix for both.
+
 Item roles are filled in the same way when the body opens: items receive
 `role="option"` in a searchable (listbox) dropdown or `role="menuitem"` in
 a menu (always `menuitem` inside a submenu), and the `<ul>`/`<ol>` wrappers

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -215,6 +215,114 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('popup accessible name', () => {
+        it('names the dialog body after its trigger', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown hasItems={false}>
+                    Settings
+                    <form>
+                        <label>
+                            Full name
+                            <input name="name" />
+                        </label>
+                    </form>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+            expect(screen.getByRole('dialog', { name: 'Settings' })).toBeTruthy();
+        });
+
+        it('names the menu body after its trigger', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Menu' }));
+
+            expect(screen.getByRole('menu', { name: 'Menu' })).toBeTruthy();
+        });
+
+        it('prefers props.label over the trigger as the name source', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown label="Alignment">
+                    <ul>
+                        <li>Left</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button'));
+
+            expect(screen.getByRole('menu', { name: 'Alignment' })).toBeTruthy();
+        });
+
+        it('names a searchable listbox from props.label', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable label="State">
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByRole('listbox', { name: 'State' })).toBeTruthy();
+        });
+
+        it('leaves a label-less searchable listbox unnamed rather than naming it after the input’s value', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            // aria-labelledby resolves a text input to its value, so pointing
+            // the listbox at the generated input would name it after whatever
+            // has been typed. Such a dropdown has no name for its trigger
+            // either — props.label is the fix for both.
+            expect(screen.getByRole('listbox').hasAttribute('aria-labelledby')).toBe(
+                false,
+            );
+        });
+
+        it('honors a custom trigger’s own id instead of overwriting it', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    <button id="my-trigger">Custom</button>
+                    <ul>
+                        <li>Custom Item</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Custom' });
+            expect(trigger.id).toBe('my-trigger');
+
+            await user.click(trigger);
+
+            const popup = screen.getByRole('menu', { name: 'Custom' });
+            expect(popup.getAttribute('aria-labelledby')).toBe('my-trigger');
+        });
+    });
+
     describe('props.disabled', () => {
         it('marks the generated button trigger disabled', () => {
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -302,6 +302,74 @@ describe('@acusti/dropdown', () => {
             );
         });
 
+        it('does not name the listbox after a custom text input trigger’s value', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <input aria-label="state" />
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            await user.click(input);
+            fireEvent.input(input, { target: { value: 'Ariz' } });
+
+            expect(screen.getByRole('listbox').hasAttribute('aria-labelledby')).toBe(
+                false,
+            );
+        });
+
+        it('does not name the menu after a non-searchable custom text input trigger’s value', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    <input aria-label="amount" />
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByRole('menu').hasAttribute('aria-labelledby')).toBe(false);
+        });
+
+        it('still names a listbox from props.label when the trigger is a custom text input', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable label="State">
+                    <input />
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByRole('listbox', { name: 'State' })).toBeTruthy();
+        });
+
+        it('still names the body after a custom trigger that is a non-text input', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    <input type="button" value="Pick one" />
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Pick one' }));
+
+            expect(screen.getByRole('menu', { name: 'Pick one' })).toBeTruthy();
+        });
+
         it('honors a custom trigger’s own id instead of overwriting it', async () => {
             const user = userEvent.setup();
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -1701,8 +1701,8 @@ describe('@acusti/dropdown', () => {
             const handleSubmitItem = vi.fn();
             const user = userEvent.setup();
 
-            // A submit input is not a text input, so there is still nothing
-            // for allowCreate to create from — the trigger's input must not be
+            // a submit input is not a text input, so there is still nothing
+            // for allowCreate to create from — the trigger’s input must not be
             // mistaken for a value source just because it is an <input>
             render(
                 <Dropdown allowCreate onSubmitItem={handleSubmitItem}>

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -1697,6 +1697,30 @@ describe('@acusti/dropdown', () => {
             expect(handleSubmitItem).not.toHaveBeenCalled();
         });
 
+        it('does not adopt a non-text input in a custom trigger as the value source', async () => {
+            const handleSubmitItem = vi.fn();
+            const user = userEvent.setup();
+
+            // A submit input is not a text input, so there is still nothing
+            // for allowCreate to create from — the trigger's input must not be
+            // mistaken for a value source just because it is an <input>
+            render(
+                <Dropdown allowCreate onSubmitItem={handleSubmitItem}>
+                    <input type="submit" value="Go" />
+                    <ul>
+                        <li data-ukt-item data-ukt-value="one">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Go' }));
+            await user.keyboard('{Enter}');
+
+            expect(handleSubmitItem).not.toHaveBeenCalled();
+        });
+
         it('does not call onSubmitItem when allowCreate is set but there is no input to source a value', async () => {
             const handleSubmitItem = vi.fn();
             const user = userEvent.setup();

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -176,9 +176,7 @@ const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="s
 const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 // Any input that isn’t one of the non-text types, plus textarea. Derived from
 // the same list that drives use-keyboard-events’ isEventTargetUsingKeyEvent, so
-// the two can’t disagree about what counts as a text input — the hand-written
-// version of this listed only radio, checkbox, and range, which meant a submit
-// or button input in a custom trigger was adopted as its value source.
+// the two can’t disagree about what counts as a text input.
 const TEXT_INPUT_SELECTOR = `input${NON_TEXT_INPUT_TYPES.map(
     (type) => `:not([type=${type}])`,
 ).join('')},textarea`;

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1368,11 +1368,9 @@ function RootDropdown({
     //
     // A text input can’t serve as that source: aria-labelledby resolves one to
     // its *value*, so pointing at it would name the popup after whatever the
-    // user has typed. That rules out the trigger of a searchable dropdown —
-    // a text input by definition, generated or custom — and a custom trigger
-    // that is itself an input or textarea. Such a dropdown has no accessible
-    // name for its trigger either, so the fix for both is the same: pass
-    // props.label (or, for the trigger alone, a custom trigger’s aria-label).
+    // user has typed. That rules out triggers that are an input or textarea,
+    // which have no accessible name. The fix is to pass props.label (or, for
+    // the trigger alone, a custom trigger’s aria-label).
     let bodyLabelledBy: string | undefined;
 
     if (!isValidElement(trigger)) {

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -191,6 +191,33 @@ const SAFE_AREA_TIMEOUT = 300;
 // somewhere the pointer briefly leaves) doesn’t flicker-close it
 const HOVER_CLOSE_DELAY = 150;
 
+// Input types that hold no user-entered text, so aria-labelledby resolves them
+// by their label/content rather than their value (mirrors TEXT_INPUT_SELECTOR)
+const NON_TEXT_INPUT_TYPES = new Set([
+    'button',
+    'checkbox',
+    'color',
+    'file',
+    'hidden',
+    'image',
+    'radio',
+    'range',
+    'reset',
+    'submit',
+]);
+
+// Whether a custom trigger element is itself a text input — one aria-labelledby
+// would resolve to its value rather than to a name (see bodyLabelledBy). Only
+// the element itself is checked: a text input nested inside a custom trigger
+// leaks its value the same way, but that isn’t knowable from the element alone,
+// and props.label is the documented answer for both.
+const isTextInputElement = (element: ReactElement) => {
+    if (element.type === 'textarea') return true;
+    if (element.type !== 'input') return false;
+    const { type } = element.props as { type?: string };
+    return type == null || !NON_TEXT_INPUT_TYPES.has(type);
+};
+
 export default function Dropdown(props: Props) {
     const parentDropdown = useContext(DropdownContext);
     // A Dropdown nested inside a menu dropdown’s body renders as a submenu
@@ -1347,11 +1374,13 @@ function RootDropdown({
     // name the trigger itself takes — so it wins; otherwise the body points at
     // the trigger element and inherits its accessible name.
     //
-    // A generated searchable input is the one trigger that names nothing:
-    // aria-labelledby resolves a text input to its *value*, so pointing at it
-    // would name the listbox after whatever the user has typed. Such a
-    // dropdown has no accessible name for its trigger either, so the fix for
-    // both is the same — pass props.label.
+    // A text input can’t serve as that source: aria-labelledby resolves one to
+    // its *value*, so pointing at it would name the popup after whatever the
+    // user has typed. That rules out the trigger of a searchable dropdown —
+    // a text input by definition, generated or custom — and a custom trigger
+    // that is itself an input or textarea. Such a dropdown has no accessible
+    // name for its trigger either, so the fix for both is the same: pass
+    // props.label (or, for the trigger alone, a custom trigger’s aria-label).
     let bodyLabelledBy: string | undefined;
 
     if (!isValidElement(trigger)) {
@@ -1400,7 +1429,9 @@ function RootDropdown({
         // Point the body at whatever id the trigger ends up with, so a
         // consumer-set one is honored rather than overwritten
         const resolvedTriggerId = (triggerProps.id as string | undefined) ?? triggerId;
-        bodyLabelledBy = resolvedTriggerId;
+        if (!isSearchable && !isTextInputElement(trigger)) {
+            bodyLabelledBy = resolvedTriggerId;
+        }
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
             'aria-controls': triggerProps['aria-controls'] ?? bodyId,
             'aria-disabled': triggerProps['aria-disabled'] ?? (disabled || undefined),

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -175,12 +175,11 @@ const CHILDREN_ERROR =
 const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="submit"]';
 const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 // Any input that isn't one of the non-text types, plus textarea. Derived from
-// the same set that drives use-keyboard-events' isEventTargetUsingKeyEvent, so
+// the same list that drives use-keyboard-events' isEventTargetUsingKeyEvent, so
 // the two can't disagree about what counts as a text input — the hand-written
 // version of this listed only radio, checkbox, and range, which meant a submit
 // or button input in a custom trigger was adopted as its value source.
-const TEXT_INPUT_SELECTOR = `input${Array.from(
-    NON_TEXT_INPUT_TYPES,
+const TEXT_INPUT_SELECTOR = `input${NON_TEXT_INPUT_TYPES.map(
     (type) => `:not([type=${type}])`,
 ).join('')},textarea`;
 
@@ -208,7 +207,7 @@ const isTextInputElement = (element: ReactElement) => {
     if (element.type === 'textarea') return true;
     if (element.type !== 'input') return false;
     const { type } = element.props as { type?: string };
-    return type == null || !NON_TEXT_INPUT_TYPES.has(type);
+    return type == null || !NON_TEXT_INPUT_TYPES.includes(type);
 };
 
 export default function Dropdown(props: Props) {

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -174,9 +174,9 @@ const CHILDREN_ERROR =
     '@acusti/dropdown requires either 1 child (the dropdown body) or 2 children: the dropdown trigger and the dropdown body.';
 const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="submit"]';
 const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
-// Any input that isn't one of the non-text types, plus textarea. Derived from
-// the same list that drives use-keyboard-events' isEventTargetUsingKeyEvent, so
-// the two can't disagree about what counts as a text input — the hand-written
+// Any input that isn’t one of the non-text types, plus textarea. Derived from
+// the same list that drives use-keyboard-events’ isEventTargetUsingKeyEvent, so
+// the two can’t disagree about what counts as a text input — the hand-written
 // version of this listed only radio, checkbox, and range, which meant a submit
 // or button input in a custom trigger was adopted as its value source.
 const TEXT_INPUT_SELECTOR = `input${NON_TEXT_INPUT_TYPES.map(
@@ -1418,7 +1418,7 @@ function RootDropdown({
         // element, so props.disabled is conveyed as aria-disabled rather than
         // the native attribute — the open paths enforce it either way.
         const triggerProps = trigger.props as Record<string, unknown>;
-        // Point the body at whatever id the trigger ends up with, so a
+        // point the body at whatever id the trigger ends up with, so a
         // consumer-set one is honored rather than overwritten
         const resolvedTriggerId = (triggerProps.id as string | undefined) ?? triggerId;
         if (!isSearchable && !isTextInputElement(trigger)) {

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions */
 import useKeyboardEvents, {
     isEventTargetUsingKeyEvent,
+    NON_TEXT_INPUT_TYPES,
 } from '@acusti/use-keyboard-events';
 import clsx from 'clsx';
 import {
@@ -173,8 +174,15 @@ const CHILDREN_ERROR =
     '@acusti/dropdown requires either 1 child (the dropdown body) or 2 children: the dropdown trigger and the dropdown body.';
 const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="submit"]';
 const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
-const TEXT_INPUT_SELECTOR =
-    'input:not([type=radio]):not([type=checkbox]):not([type=range]),textarea';
+// Any input that isn't one of the non-text types, plus textarea. Derived from
+// the same set that drives use-keyboard-events' isEventTargetUsingKeyEvent, so
+// the two can't disagree about what counts as a text input — the hand-written
+// version of this listed only radio, checkbox, and range, which meant a submit
+// or button input in a custom trigger was adopted as its value source.
+const TEXT_INPUT_SELECTOR = `input${Array.from(
+    NON_TEXT_INPUT_TYPES,
+    (type) => `:not([type=${type}])`,
+).join('')},textarea`;
 
 // Matches macOS: quick, natural arrowing past parent items never flashes
 // their submenus, but a brief pause discloses. Frame-stepping macOS menus
@@ -190,21 +198,6 @@ const SAFE_AREA_TIMEOUT = 300;
 // that crossing the trigger/body gap (or a placement fallback moving the body
 // somewhere the pointer briefly leaves) doesn’t flicker-close it
 const HOVER_CLOSE_DELAY = 150;
-
-// Input types that hold no user-entered text, so aria-labelledby resolves them
-// by their label/content rather than their value (mirrors TEXT_INPUT_SELECTOR)
-const NON_TEXT_INPUT_TYPES = new Set([
-    'button',
-    'checkbox',
-    'color',
-    'file',
-    'hidden',
-    'image',
-    'radio',
-    'range',
-    'reset',
-    'submit',
-]);
 
 // Whether a custom trigger element is itself a text input — one aria-labelledby
 // would resolve to its value rather than to a name (see bodyLabelledBy). Only

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -270,6 +270,11 @@ function RootDropdown({
     const [isOpening, setIsOpening] = useState<boolean>(!isOpenOnMount);
     const [dropdownElement, setDropdownElement] = useState<MaybeHTMLElement>(null);
     const bodyId = useId();
+    // Everything this component needs an id for hangs off the one useId, with
+    // a suffix naming its role. useId is unique per Dropdown instance, so the
+    // suffixed ids are collision-free without a module-level counter.
+    const triggerId = `${bodyId}-trigger`;
+    const labelId = `${bodyId}-label`;
     const popupRole = isSearchable ? 'listbox' : hasItems ? 'menu' : 'dialog';
     const menubar = useContext(MenubarContext);
     const inputElementRef = useRef<HTMLInputElement | null>(null);
@@ -1337,6 +1342,18 @@ function RootDropdown({
         }
     };
 
+    // The popup body is named by whatever names the trigger. props.label is
+    // the best source when it’s there — it’s always text, and it’s the same
+    // name the trigger itself takes — so it wins; otherwise the body points at
+    // the trigger element and inherits its accessible name.
+    //
+    // A generated searchable input is the one trigger that names nothing:
+    // aria-labelledby resolves a text input to its *value*, so pointing at it
+    // would name the listbox after whatever the user has typed. Such a
+    // dropdown has no accessible name for its trigger either, so the fix for
+    // both is the same — pass props.label.
+    let bodyLabelledBy: string | undefined;
+
     if (!isValidElement(trigger)) {
         if (isSearchable) {
             trigger = (
@@ -1348,6 +1365,7 @@ function RootDropdown({
                     className="uktdropdown-trigger"
                     defaultValue={valueLabel ?? ''}
                     disabled={disabled}
+                    id={triggerId}
                     name={name}
                     onFocus={() => setIsOpen(true)}
                     placeholder={placeholder}
@@ -1357,6 +1375,7 @@ function RootDropdown({
                 />
             );
         } else {
+            bodyLabelledBy = triggerId;
             trigger = (
                 <button
                     aria-controls={bodyId}
@@ -1364,6 +1383,7 @@ function RootDropdown({
                     aria-haspopup={popupRole}
                     className="uktdropdown-trigger"
                     disabled={disabled}
+                    id={triggerId}
                     tabIndex={0}
                     type="button"
                 >
@@ -1377,18 +1397,26 @@ function RootDropdown({
         // element, so props.disabled is conveyed as aria-disabled rather than
         // the native attribute — the open paths enforce it either way.
         const triggerProps = trigger.props as Record<string, unknown>;
+        // Point the body at whatever id the trigger ends up with, so a
+        // consumer-set one is honored rather than overwritten
+        const resolvedTriggerId = (triggerProps.id as string | undefined) ?? triggerId;
+        bodyLabelledBy = resolvedTriggerId;
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
             'aria-controls': triggerProps['aria-controls'] ?? bodyId,
             'aria-disabled': triggerProps['aria-disabled'] ?? (disabled || undefined),
             'aria-expanded': triggerProps['aria-expanded'] ?? isOpen,
             'aria-haspopup': triggerProps['aria-haspopup'] ?? popupRole,
+            id: resolvedTriggerId,
         });
     }
 
     if (label != null) {
+        bodyLabelledBy = labelId;
         trigger = (
             <label className="uktdropdown-label">
-                <div className="uktdropdown-label-text">{label}</div>
+                <div className="uktdropdown-label-text" id={labelId}>
+                    {label}
+                </div>
                 {trigger}
             </label>
         );
@@ -1420,6 +1448,7 @@ function RootDropdown({
                 {/* TODO next version of Dropdown should use <Activity> for body https://react.dev/reference/react/Activity */}
                 {isOpen ? (
                     <div
+                        aria-labelledby={bodyLabelledBy}
                         className={clsx('uktdropdown-body', {
                             'has-items': hasItems,
                         })}

--- a/packages/use-keyboard-events/src/handlers.test.tsx
+++ b/packages/use-keyboard-events/src/handlers.test.tsx
@@ -5,7 +5,12 @@ import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { addHandler, handlersData, isEventTargetUsingKeyEvent } from './handlers.js';
+import {
+    addHandler,
+    handlersData,
+    isEventTargetUsingKeyEvent,
+    NON_TEXT_INPUT_TYPES,
+} from './handlers.js';
 
 const noop = () => {}; // eslint-disable-line no-empty-function
 
@@ -198,6 +203,16 @@ describe('@acusti/use-keyboard-events', () => {
                 isUsingKeyEvent = null;
                 await user.type(input, ' ');
                 expect(isUsingKeyEvent).toBe(true);
+            });
+        });
+
+        describe('NON_TEXT_INPUT_TYPES', () => {
+            it('is frozen, because every consumer shares the one instance', () => {
+                expect(Object.isFrozen(NON_TEXT_INPUT_TYPES)).toBe(true);
+                expect(() =>
+                    (NON_TEXT_INPUT_TYPES as Array<string>).push('text'),
+                ).toThrow(TypeError);
+                expect(NON_TEXT_INPUT_TYPES).not.toContain('text');
             });
         });
     });

--- a/packages/use-keyboard-events/src/handlers.ts
+++ b/packages/use-keyboard-events/src/handlers.ts
@@ -71,8 +71,11 @@ export function isPrimaryModifierPressed(event: KeyboardEvent) {
 
 // The input types that hold no user-entered text. Exported because consumers
 // need the same notion of "is this a text input" that isEventTargetUsingKeyEvent
-// uses — keeping a second copy in sync by hand is how they drift apart.
-export const NON_TEXT_INPUT_TYPES = new Set([
+// uses — keeping a second copy in sync by hand is how they drift apart. Frozen,
+// and an array rather than a Set, because it's a singleton every consumer shares:
+// Object.freeze can't protect a Set (.add still mutates a frozen one), so an
+// array is the only shape that can't be edited out from under its readers.
+export const NON_TEXT_INPUT_TYPES = Object.freeze([
     'button',
     'checkbox',
     'color',
@@ -84,6 +87,9 @@ export const NON_TEXT_INPUT_TYPES = new Set([
     'reset',
     'submit',
 ]);
+
+// Membership is checked on every key event, so pay for the Set once here
+const NON_TEXT_INPUT_TYPE_SET = new Set(NON_TEXT_INPUT_TYPES);
 
 const NON_TEXT_INPUT_USES_KEYS = new Set([
     ' ',
@@ -104,7 +110,7 @@ export const isEventTargetUsingKeyEvent = (event: KeyboardEvent) => {
     if (target == null || !usesKeyEvents(target)) return false;
     // Restrict special handling to only non-text <input> elements
     if (target.tagName !== 'INPUT') return true;
-    if (!NON_TEXT_INPUT_TYPES.has((target as HTMLInputElement).type)) return true;
+    if (!NON_TEXT_INPUT_TYPE_SET.has((target as HTMLInputElement).type)) return true;
     // Non-text inputs can use arrow keys, escape, the spacebar, and return / enter
     return NON_TEXT_INPUT_USES_KEYS.has(event.key);
 };

--- a/packages/use-keyboard-events/src/handlers.ts
+++ b/packages/use-keyboard-events/src/handlers.ts
@@ -69,7 +69,10 @@ export function isPrimaryModifierPressed(event: KeyboardEvent) {
     return IS_APPLE_REGEXP.test(platform) ? event.metaKey : event.ctrlKey;
 }
 
-const NON_TEXT_INPUT_TYPES = new Set([
+// The input types that hold no user-entered text. Exported because consumers
+// need the same notion of "is this a text input" that isEventTargetUsingKeyEvent
+// uses — keeping a second copy in sync by hand is how they drift apart.
+export const NON_TEXT_INPUT_TYPES = new Set([
     'button',
     'checkbox',
     'color',

--- a/packages/use-keyboard-events/src/handlers.ts
+++ b/packages/use-keyboard-events/src/handlers.ts
@@ -69,12 +69,8 @@ export function isPrimaryModifierPressed(event: KeyboardEvent) {
     return IS_APPLE_REGEXP.test(platform) ? event.metaKey : event.ctrlKey;
 }
 
-// The input types that hold no user-entered text. Exported because consumers
-// need the same notion of "is this a text input" that isEventTargetUsingKeyEvent
-// uses — keeping a second copy in sync by hand is how they drift apart. Frozen,
-// and an array rather than a Set, because it's a singleton every consumer shares:
-// Object.freeze can't protect a Set (.add still mutates a frozen one), so an
-// array is the only shape that can't be edited out from under its readers.
+// the input types that cannot hold user-entered text, exported so consumers can share
+// the notion of “is this a text input” (e.g. @acusti/dropdown)
 export const NON_TEXT_INPUT_TYPES = Object.freeze([
     'button',
     'checkbox',
@@ -88,7 +84,7 @@ export const NON_TEXT_INPUT_TYPES = Object.freeze([
     'submit',
 ]);
 
-// Membership is checked on every key event, so pay for the Set once here
+// membership is checked on every key event, so pay for the Set once here
 const NON_TEXT_INPUT_TYPE_SET = new Set(NON_TEXT_INPUT_TYPES);
 
 const NON_TEXT_INPUT_USES_KEYS = new Set([

--- a/packages/use-keyboard-events/src/useKeyboardEvents.ts
+++ b/packages/use-keyboard-events/src/useKeyboardEvents.ts
@@ -5,6 +5,7 @@ import { addHandler, addHandlers, type Handler } from './handlers.js';
 export {
     isEventTargetUsingKeyEvent,
     isPrimaryModifierPressed,
+    NON_TEXT_INPUT_TYPES,
     usesKeyEvents,
 } from './handlers.js';
 


### PR DESCRIPTION
**PR 3 of 6** in the pre-v1-RC a11y stack. Base: #412 — review that first; this diff is only the third commit.

## The gap

The open body carried a `role` but no name. For `hasItems={false}` that means a `role="dialog"` with nothing naming it, which is an ARIA violation (axe `aria-dialog-name`); menus and listboxes were announced as a bare "menu"/"listbox". Verified before the fix:

```
DIALOG: <div class="uktdropdown-body" id="_r_5_" popover="manual" role="dialog">…
aria-label? null   aria-labelledby? null
```

## The fix

The body takes `aria-labelledby` pointing at whatever names the trigger:

1. the `props.label` text when there is one — it wins because it's always text and is already the name the trigger itself takes, so both announce the same thing
2. otherwise the trigger element, whose accessible name the body inherits

So a menu is announced as "Alignment menu" rather than "menu".

## The id scheme

Pointing at the trigger means the trigger needs an id, so this PR introduces the scheme the rest of the stack builds on: everything hangs off the one `useId()` the component already calls for the body, with a suffix naming its role (`-trigger`, `-label`). `useId` is unique per instance, so the suffixed ids collide with nothing and need no module-level counter. PR 4 extends the same scheme to item ids with an index path.

A custom trigger carrying its own `id` keeps it, and the body points at that one instead.

## One deliberate non-fix

A searchable dropdown with no `props.label` is left **unnamed** rather than named wrongly. `aria-labelledby` resolves a text input to its *value*, so pointing the listbox at the generated input would name it after whatever the user has typed. That dropdown has no accessible name for its trigger either, so `props.label` (or a custom trigger with its own `aria-label`) is the fix for both. There's a test pinning this so it isn't "fixed" into the value-naming behavior later.

## Tests

Six new cases under `describe('popup accessible name')`, asserting through `getByRole(…, { name })` so they exercise real accname computation rather than attribute equality. Five fail against the pre-fix source; the label-less-searchable one is the guard described above.

`bun run test` (119 passed), `lint`, `tsc`, and `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

