### PR TITLE
Expose the active item to screen readers with aria-activedescendant

### DIFF
--- a/.changeset/dropdown-active-descendant.md
+++ b/.changeset/dropdown-active-descendant.md
@@ -10,6 +10,6 @@ trigger while a dropdown is open, so without this, arrowing through a menu
 was silent to assistive tech.
 
 Items need ids to be pointed at, and get generated ones derived from the
-body's id plus their index path. Treat them as internal: they are
+body’s id plus their index path. Treat them as internal: they are
 re-derived whenever an item becomes active, so filtering or reordering an
 open body reassigns them. Ids you set yourself are never touched.

--- a/.changeset/dropdown-active-descendant.md
+++ b/.changeset/dropdown-active-descendant.md
@@ -27,7 +27,16 @@ carrying an `id` of its own keeps it.
 Ids are minted when an item becomes active rather than during the open-time
 annotation pass, which means items rendered into an already-open body
 (async-loaded, or filtered by a consumer’s own search) get one too, even
-though that pass doesn’t reach them. Indices come from the navigable items,
-so a disabled item shifts the ids after it; they’re minted and consumed
-within a single open and rewritten on every move, so nothing depends on
-them being stable.
+though that pass doesn’t reach them.
+
+An index path is a snapshot of a position, so a generated id is re-derived
+every time its item becomes active: filtering or reordering an open body
+can’t leave an item holding an id that describes where it used to be, which
+would otherwise collide with whatever moved into that position and resolve
+to the wrong element. Generated ids are internal — minted and consumed
+within a single open, and moving as the list moves. Ids a consumer sets are
+never touched or recomputed.
+
+Indices come from the navigable items, so a disabled item shifts the ids
+after it. If the highlighted item leaves the DOM while the body is open,
+the reference is cleared rather than left dangling.

--- a/.changeset/dropdown-active-descendant.md
+++ b/.changeset/dropdown-active-descendant.md
@@ -1,0 +1,33 @@
+---
+'@acusti/dropdown': minor
+---
+
+Expose the active item to screen readers with aria-activedescendant
+
+DOM focus stays on the trigger while the dropdown is open — the highlight
+moves via `data-ukt-active` rather than by moving focus — and nothing
+conveyed that to assistive technology. A screen reader announced the
+trigger and then went silent for every arrow key, typeahead jump, hover,
+and submenu dive, which left the component’s keyboard navigation
+effectively invisible.
+
+The trigger now carries `aria-activedescendant` pointing at the highlighted
+item, kept in sync wherever active state changes: arrow keys, Home/End,
+typeahead, hover, diving into and out of submenus, and the reveal of
+`props.value` on open. It’s removed when nothing is highlighted and when
+the dropdown closes, so it never points at an item that has unmounted.
+
+Items need ids to be pointed at, and they’re derived from the same `useId`
+behind the trigger and body ids, suffixed with the item’s index path — its
+index at each level from the root level down, so `<bodyId>-2-1` is the
+second item of the submenu belonging to the third top-level item. That’s
+deterministic and collision-free without a module-level counter. An item
+carrying an `id` of its own keeps it.
+
+Ids are minted when an item becomes active rather than during the open-time
+annotation pass, which means items rendered into an already-open body
+(async-loaded, or filtered by a consumer’s own search) get one too, even
+though that pass doesn’t reach them. Indices come from the navigable items,
+so a disabled item shifts the ids after it; they’re minted and consumed
+within a single open and rewritten on every move, so nothing depends on
+them being stable.

--- a/.changeset/dropdown-active-descendant.md
+++ b/.changeset/dropdown-active-descendant.md
@@ -4,39 +4,12 @@
 
 Expose the active item to screen readers with aria-activedescendant
 
-DOM focus stays on the trigger while the dropdown is open — the highlight
-moves via `data-ukt-active` rather than by moving focus — and nothing
-conveyed that to assistive technology. A screen reader announced the
-trigger and then went silent for every arrow key, typeahead jump, hover,
-and submenu dive, which left the component’s keyboard navigation
-effectively invisible.
+The trigger now points at the highlighted item, kept in sync as the
+highlight moves and cleared when the dropdown closes. Focus stays on the
+trigger while a dropdown is open, so without this, arrowing through a menu
+was silent to assistive tech.
 
-The trigger now carries `aria-activedescendant` pointing at the highlighted
-item, kept in sync wherever active state changes: arrow keys, Home/End,
-typeahead, hover, diving into and out of submenus, and the reveal of
-`props.value` on open. It’s removed when nothing is highlighted and when
-the dropdown closes, so it never points at an item that has unmounted.
-
-Items need ids to be pointed at, and they’re derived from the same `useId`
-behind the trigger and body ids, suffixed with the item’s index path — its
-index at each level from the root level down, so `<bodyId>-2-1` is the
-second item of the submenu belonging to the third top-level item. That’s
-deterministic and collision-free without a module-level counter. An item
-carrying an `id` of its own keeps it.
-
-Ids are minted when an item becomes active rather than during the open-time
-annotation pass, which means items rendered into an already-open body
-(async-loaded, or filtered by a consumer’s own search) get one too, even
-though that pass doesn’t reach them.
-
-An index path is a snapshot of a position, so a generated id is re-derived
-every time its item becomes active: filtering or reordering an open body
-can’t leave an item holding an id that describes where it used to be, which
-would otherwise collide with whatever moved into that position and resolve
-to the wrong element. Generated ids are internal — minted and consumed
-within a single open, and moving as the list moves. Ids a consumer sets are
-never touched or recomputed.
-
-Indices come from the navigable items, so a disabled item shifts the ids
-after it. If the highlighted item leaves the DOM while the body is open,
-the reference is cleared rather than left dangling.
+Items need ids to be pointed at, and get generated ones derived from the
+body's id plus their index path. Treat them as internal: they are
+re-derived whenever an item becomes active, so filtering or reordering an
+open body reassigns them. Ids you set yourself are never touched.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1181,10 +1181,19 @@ as-is.
 Ids are minted when an item becomes active rather than in the open-time
 annotation pass, which means items rendered into an already-open body —
 async-loaded, or filtered by your own search — get one too, even though
-that pass doesn’t reach them. The indices come from the navigable items, so
-a disabled item shifts the ids after it; they’re minted and consumed within
-a single open and rewritten on every move, so nothing depends on them being
-stable.
+that pass doesn’t reach them.
+
+Because an index path is a snapshot of a position, a generated id is
+**re-derived every time its item becomes active**, so filtering or
+reordering an open body doesn’t leave items holding ids that describe where
+they used to be. Treat generated ids as internal: they’re minted and
+consumed within a single open, and they move as your list moves. Ids you
+set yourself are never touched or recomputed.
+
+The indices come from the navigable items, so a disabled item shifts the
+ids after it. If the highlighted item leaves the DOM entirely — filtered
+away while the body is open — the reference is cleared rather than left
+dangling.
 
 Submenus and menubars extend the same pattern automatically:
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1160,6 +1160,32 @@ which case the component leaves selection ARIA entirely to you, as with any
 ARIA you set. The persistent tint on the selected item is themeable via the
 `--uktdd-body-bg-color-selected` custom property.
 
+### The active item and `aria-activedescendant`
+
+DOM focus stays on the trigger for as long as the dropdown is open — the
+highlight moves via a `data-ukt-active` attribute rather than by moving
+focus. On its own that would make navigation silent to a screen reader, so
+the trigger carries `aria-activedescendant` pointing at the highlighted
+item, and it is kept in sync however the highlight moves: arrow keys,
+Home/End, typeahead, hover, diving into and out of submenus, and the
+reveal-on-open above. It’s removed when nothing is highlighted and when the
+dropdown closes, so it never dangles at an item that has unmounted.
+
+Pointing at an item means items need ids, and the component mints them from
+the same `useId` behind the trigger and body ids, suffixed with the item’s
+**index path** — its index at each level from the root level down. So
+`<bodyId>-2-1` is the second item of the submenu belonging to the third
+top-level item. An item with an `id` of your own keeps it and is pointed at
+as-is.
+
+Ids are minted when an item becomes active rather than in the open-time
+annotation pass, which means items rendered into an already-open body —
+async-loaded, or filtered by your own search — get one too, even though
+that pass doesn’t reach them. The indices come from the navigable items, so
+a disabled item shifts the ids after it; they’re minted and consumed within
+a single open and rewritten on every move, so nothing depends on them being
+stable.
+
 Submenus and menubars extend the same pattern automatically:
 
 - parent items receive `aria-haspopup="menu"` and `aria-expanded`, and

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -391,6 +391,214 @@ describe('@acusti/dropdown', () => {
         });
     });
 
+    describe('aria-activedescendant', () => {
+        const renderMenu = (props: Partial<Props> = {}) =>
+            render(
+                <Dropdown {...props}>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                        <li data-ukt-value="two">Two</li>
+                        <li data-ukt-value="three">Three</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+        it('points the trigger at the active item as the highlight moves', async () => {
+            const user = userEvent.setup();
+            renderMenu();
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.click(trigger);
+            expect(trigger.hasAttribute('aria-activedescendant')).toBe(false);
+
+            await user.keyboard('{ArrowDown}');
+            const one = screen.getByText('One');
+            expect(one.id).toBeTruthy();
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(one.id);
+
+            await user.keyboard('{ArrowDown}');
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(
+                screen.getByText('Two').id,
+            );
+        });
+
+        it('derives item ids from the body id plus an index path', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <li data-ukt-item>Italic</li>
+                        <Dropdown label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                                <li data-ukt-value="center">Center</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            await user.click(screen.getByRole('button', { name: 'Format' }));
+            // the submenu is a role=menu too, so target the body directly
+            const body = document.querySelector('.uktdropdown-body')!;
+
+            await user.keyboard('{ArrowDown}');
+            expect(screen.getByText('Bold').id).toBe(`${body.id}-0`);
+
+            // dive into the third top-level item’s submenu, second item
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}{ArrowDown}');
+            expect(screen.getByText('Center').id).toBe(`${body.id}-2-1`);
+        });
+
+        it('follows the highlight back out when a submenu collapses', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Format
+                    <ul>
+                        <li data-ukt-item>Bold</li>
+                        <Dropdown label={<span>Align</span>}>
+                            <ul>
+                                <li data-ukt-value="left">Left</li>
+                            </ul>
+                        </Dropdown>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Format' });
+            await user.click(trigger);
+            await user.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}');
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(
+                screen.getByText('Left').id,
+            );
+
+            await user.keyboard('{ArrowLeft}');
+
+            // the parent item keeps the highlight after collapsing
+            const parentItem = screen.getByText('Align').closest('li')!;
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(parentItem.id);
+        });
+
+        it('clears the reference when the dropdown closes', async () => {
+            const user = userEvent.setup();
+            renderMenu();
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.click(trigger);
+            await user.keyboard('{ArrowDown}');
+            expect(trigger.getAttribute('aria-activedescendant')).toBeTruthy();
+
+            await user.keyboard('{Escape}');
+
+            // the body unmounts on close, so a stale id would dangle
+            await waitFor(() =>
+                expect(trigger.hasAttribute('aria-activedescendant')).toBe(false),
+            );
+        });
+
+        it('clears the reference when typeahead matches nothing', async () => {
+            const user = userEvent.setup();
+            renderMenu({ allowCreate: true });
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.click(trigger);
+            await user.keyboard('{ArrowDown}');
+            expect(trigger.getAttribute('aria-activedescendant')).toBeTruthy();
+
+            // allowCreate requires an exact prefix match, and zzz matches none
+            await user.keyboard('zzz');
+
+            expect(trigger.hasAttribute('aria-activedescendant')).toBe(false);
+        });
+
+        it('points a searchable dropdown’s input at the active option', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable label="State">
+                    <ul>
+                        <li data-ukt-value="az">Arizona</li>
+                        <li data-ukt-value="ca">California</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const input = screen.getByRole('textbox');
+            await user.click(input);
+            await user.keyboard('{ArrowDown}');
+
+            expect(input.getAttribute('aria-activedescendant')).toBe(
+                screen.getByText('Arizona').id,
+            );
+        });
+
+        it('points at the revealed value when the body opens', async () => {
+            const user = userEvent.setup();
+            renderMenu({ value: 'two' });
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.click(trigger);
+
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(
+                screen.getByText('Two').id,
+            );
+        });
+
+        it('honors a consumer-set item id', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one" id="my-item">
+                            One
+                        </li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.click(trigger);
+            await user.keyboard('{ArrowDown}');
+
+            expect(trigger.getAttribute('aria-activedescendant')).toBe('my-item');
+        });
+
+        it('gives an item added to an already-open body an id when it activates', async () => {
+            const user = userEvent.setup();
+            const { rerender } = render(
+                <Dropdown isOpenOnMount>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // items rendered into an open body miss the once-per-open
+            // annotation pass, so their ids have to come from activation
+            rerender(
+                <Dropdown isOpenOnMount>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                        <li data-ukt-value="two">Two</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.keyboard('{ArrowDown}{ArrowDown}');
+
+            const two = screen.getByText('Two');
+            expect(two.id).toBeTruthy();
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(two.id);
+        });
+    });
+
     describe('props.disabled', () => {
         it('marks the generated button trigger disabled', () => {
             render(

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -567,6 +567,60 @@ describe('@acusti/dropdown', () => {
             expect(trigger.getAttribute('aria-activedescendant')).toBe('my-item');
         });
 
+        it('re-derives a generated id when the list is filtered under it', async () => {
+            const user = userEvent.setup();
+            const Filterable = ({ hideFirst }: { hideFirst: boolean }) => (
+                <Dropdown isOpenOnMount>
+                    Menu
+                    <ul>
+                        {hideFirst ? null : <li data-ukt-value="one">One</li>}
+                        <li data-ukt-value="two">Two</li>
+                    </ul>
+                </Dropdown>
+            );
+            const { rerender } = render(<Filterable hideFirst={false} />);
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.keyboard('{ArrowDown}{ArrowDown}');
+            const body = document.querySelector('.uktdropdown-body')!;
+            expect(screen.getByText('Two').id).toBe(`${body.id}-1`);
+
+            // dropping One shifts Two to index 0; a stale index-path id would
+            // later collide with whatever lands at index 1
+            rerender(<Filterable hideFirst />);
+            await user.keyboard('{ArrowUp}');
+
+            const two = screen.getByText('Two');
+            expect(two.id).toBe(`${body.id}-0`);
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(two.id);
+            expect(document.querySelectorAll(`[id="${two.id}"]`)).toHaveLength(1);
+        });
+
+        it('clears the reference when the active item is filtered out of an open body', async () => {
+            const user = userEvent.setup();
+            const Filterable = ({ hideTwo }: { hideTwo: boolean }) => (
+                <Dropdown isOpenOnMount>
+                    Menu
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                        {hideTwo ? null : <li data-ukt-value="two">Two</li>}
+                    </ul>
+                </Dropdown>
+            );
+            const { rerender } = render(<Filterable hideTwo={false} />);
+
+            const trigger = screen.getByRole('button', { name: 'Menu' });
+            await user.keyboard('{ArrowDown}{ArrowDown}');
+            expect(trigger.getAttribute('aria-activedescendant')).toBe(
+                screen.getByText('Two').id,
+            );
+
+            rerender(<Filterable hideTwo />);
+
+            // the highlighted item left the DOM, so the reference would dangle
+            expect(trigger.hasAttribute('aria-activedescendant')).toBe(false);
+        });
+
         it('gives an item added to an already-open body an id when it activates', async () => {
             const user = userEvent.setup();
             const { rerender } = render(

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1324,10 +1324,12 @@ function RootDropdown({
         if (!ref) return;
         // Everything below must run exactly once per open: showPopover() throws
         // on an already-shown popover, and the ownership check would read the
-        // reveal’s own aria-selected annotation back as consumer-authored. A
-        // ref callback can re-attach on a re-render, and each open mounts a
-        // fresh body element, so latch per element (a WeakSet, to hold no
-        // unmounted bodies alive).
+        // reveal’s own aria-selected annotation back as consumer-authored.
+        // React re-attaches this ref to the same body element every time it
+        // re-renders with a new callback identity — three runs for a mount plus
+        // one prop change — so the latch is what makes “once per open” true.
+        // Keyed on the element, since each open mounts a fresh one, in a
+        // WeakSet so it holds no unmounted bodies alive.
         if (annotatedBodiesRef.current.has(ref)) return;
         annotatedBodiesRef.current.add(ref);
         // A consumer-authored aria-selected anywhere in the just-mounted body
@@ -1340,8 +1342,8 @@ function RootDropdown({
         annotateParentItems(ref);
         if (popupRole !== 'dialog') annotateItemRoles(ref, popupRole);
         // The Popover API is Baseline 2024, so showPopover() needs no feature
-        // detection; the body is mounted only while open, so this runs once
-        // per open and won’t throw on an already-open body.
+        // detection; the latch above is what keeps it off an already-shown
+        // popover, which would throw.
         ref.showPopover();
         // Reveal the current value on open: mark the matching option
         // aria-selected (listbox only — aria-selected isn’t valid on a

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -353,6 +353,17 @@ function RootDropdown({
         valueIdentity,
     ]);
 
+    // A consumer filtering or async-loading the body can drop the highlighted
+    // item, or shift it to a new index path, and nothing else would notice —
+    // the trigger would be left pointing at an id that has left the DOM or
+    // moved to another item. Deliberately dep-less: every render while open is
+    // a render that may have rearranged the items. It can’t hang off the body
+    // ref callback instead, because React Compiler memoizes that callback, so
+    // a re-render doesn’t re-attach the ref (see Dropdown.test.tsx).
+    useEffect(() => {
+        if (isOpen) syncActiveDescendant(dropdownElement);
+    });
+
     const isMountedRef = useRef(false);
 
     useEffect(() => {
@@ -1311,19 +1322,12 @@ function RootDropdown({
     // open. Known limitation until it’s needed.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
-        // Re-running on every render while the body is open is exactly what
-        // this needs: a consumer filtering or async-loading the body can drop
-        // the highlighted item, and nothing else would notice — the trigger
-        // would be left pointing at an id that has left the DOM. Re-deriving
-        // here clears it (or moves it, if the item merely shifted position).
-        // above the once-per-open latch below, which would skip it
-        syncActiveDescendant(dropdownElement);
-        // An inline ref callback re-attaches (and re-runs) on every re-render
-        // while the body is open, but everything below must run exactly once
-        // per open: showPopover() throws on an already-shown popover, and the
-        // ownership check would read the reveal’s own aria-selected annotation
-        // back as consumer-authored. Each open mounts a fresh body element, so
-        // latch per element (a WeakSet, to hold no unmounted bodies alive).
+        // Everything below must run exactly once per open: showPopover() throws
+        // on an already-shown popover, and the ownership check would read the
+        // reveal’s own aria-selected annotation back as consumer-authored. A
+        // ref callback can re-attach on a re-render, and each open mounts a
+        // fresh body element, so latch per element (a WeakSet, to hold no
+        // unmounted bodies alive).
         if (annotatedBodiesRef.current.has(ref)) return;
         annotatedBodiesRef.current.add(ref);
         // A consumer-authored aria-selected anywhere in the just-mounted body

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -578,7 +578,7 @@ function RootDropdown({
     useEffect(() => clearHoverCloseTimer, []);
 
     const closeDropdown = (options?: { keepMenubarEngaged?: boolean }) => {
-        // The body (and its items) unmount on close, so the trigger would
+        // the body (and its items) unmount on close, so the trigger would
         // otherwise keep pointing at an id that no longer exists
         getTriggerElement(dropdownElement)?.removeAttribute('aria-activedescendant');
         setIsOpen(false);
@@ -1316,7 +1316,7 @@ function RootDropdown({
         // the highlighted item, and nothing else would notice — the trigger
         // would be left pointing at an id that has left the DOM. Re-deriving
         // here clears it (or moves it, if the item merely shifted position).
-        // Above the once-per-open latch below, which would skip it.
+        // above the once-per-open latch below, which would skip it
         syncActiveDescendant(dropdownElement);
         // An inline ref callback re-attaches (and re-runs) on every re-render
         // while the body is open, but everything below must run exactly once

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -44,10 +44,12 @@ import {
     getLevelRoot,
     getParentItem,
     getSubmenuOfItem,
+    getTriggerElement,
     isItemExpanded,
     isPointInTriangle,
     type Point,
     setActiveItem,
+    syncActiveDescendant,
 } from './helpers.js';
 
 export type Item = {
@@ -173,7 +175,6 @@ type TimeoutID = ReturnType<typeof setTimeout>;
 const CHILDREN_ERROR =
     '@acusti/dropdown requires either 1 child (the dropdown body) or 2 children: the dropdown trigger and the dropdown body.';
 const CLICKABLE_SELECTOR = 'button, a[href], input[type="button"], input[type="submit"]';
-const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 // Any input that isn’t one of the non-text types, plus textarea. Derived from
 // the same list that drives use-keyboard-events’ isEventTargetUsingKeyEvent, so
 // the two can’t disagree about what counts as a text input.
@@ -577,6 +578,9 @@ function RootDropdown({
     useEffect(() => clearHoverCloseTimer, []);
 
     const closeDropdown = (options?: { keepMenubarEngaged?: boolean }) => {
+        // The body (and its items) unmount on close, so the trigger would
+        // otherwise keep pointing at an id that no longer exists
+        getTriggerElement(dropdownElement)?.removeAttribute('aria-activedescendant');
         setIsOpen(false);
         setIsOpening(false);
         mouseDownPositionRef.current = null;
@@ -621,12 +625,7 @@ function RootDropdown({
     };
 
     const focusTrigger = () => {
-        const firstChild = dropdownElement?.firstElementChild as MaybeHTMLElement;
-        if (!firstChild) return;
-        const focusable = firstChild.matches(FOCUSABLE_SELECTOR)
-            ? firstChild
-            : (firstChild.querySelector(FOCUSABLE_SELECTOR) as MaybeHTMLElement);
-        focusable?.focus();
+        getTriggerElement(dropdownElement)?.focus();
     };
 
     // Register with an enclosing Menubar (one open menu at a time, ←/→
@@ -860,6 +859,7 @@ function RootDropdown({
         }
         // If user moused out of activeItem (not into a descendant), it’s no longer active
         delete activeItem.dataset.uktActive;
+        syncActiveDescendant(dropdownElement);
         syncSubmenuDisclosure();
     };
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1316,6 +1316,13 @@ function RootDropdown({
     // open. Known limitation until it’s needed.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
+        // Re-running on every render while the body is open is exactly what
+        // this needs: a consumer filtering or async-loading the body can drop
+        // the highlighted item, and nothing else would notice — the trigger
+        // would be left pointing at an id that has left the DOM. Re-deriving
+        // here clears it (or moves it, if the item merely shifted position).
+        // Above the once-per-open latch below, which would skip it.
+        syncActiveDescendant(dropdownElement);
         // An inline ref callback re-attaches (and re-runs) on every re-render
         // while the body is open, but everything below must run exactly once
         // per open: showPopover() throws on an already-shown popover, and the

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -33,6 +33,7 @@ import styles from './Dropdown.css?inline';
 import {
     annotateItemRoles,
     annotateParentItems,
+    clearActiveItems,
     collapseItem,
     collapseItemsOutsidePath,
     expandItem,
@@ -877,8 +878,7 @@ function RootDropdown({
             return;
         }
         // If user moused out of activeItem (not into a descendant), it’s no longer active
-        delete activeItem.dataset.uktActive;
-        syncActiveDescendant(dropdownElement);
+        clearActiveItems(dropdownElement, activeItem);
         syncSubmenuDisclosure();
     };
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1249,11 +1249,6 @@ function RootDropdown({
             ownerDocument.addEventListener('mouseup', handleGlobalMouseUp);
         }
 
-        // If dropdown should be open on mount, focus it
-        if (isOpenOnMount) {
-            ref.focus();
-        }
-
         const handleInput = (event: Event) => {
             // A custom trigger’s text input stays editable when disabled —
             // aria-disabled doesn’t make an input inert the way the native

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -355,20 +355,12 @@ function RootDropdown({
         valueIdentity,
     ]);
 
-    // A consumer filtering or async-loading the body can drop the highlighted
-    // item, or shift it to a new index path, and nothing else would notice —
-    // the trigger would be left pointing at an id that has left the DOM or
-    // moved to another item. Deliberately dep-less: every render while open is
-    // a render that may have rearranged the items. It can’t hang off the body
-    // ref callback instead, because React Compiler memoizes that callback, so
-    // a re-render doesn’t re-attach the ref (see Dropdown.test.tsx).
-    //
-    // Layout rather than passive so the id and the reference to it are always
-    // committed together: a passive effect would leave a window, however
-    // brief, where the accessibility tree has the trigger pointing at an item
-    // that is no longer in the document. It can’t move into render either —
-    // render runs before the commit, so it would read the previous render’s
-    // items and derive index paths from a body that no longer exists.
+    // A consumer filtering or async-loading the body can drop or shift the
+    // highlighted item without us seeing the change. Deliberately dep-less:
+    // every render while open may have rearranged the items. useLayoutEffect
+    // over useEffect so the id and reference to it are always committed
+    // together: a passive effect would leave a window where the a11y tree has
+    // the trigger pointing at an item that is no longer in the document.
     useLayoutEffect(() => {
         if (isOpen) syncActiveDescendant(dropdownElement);
     });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -17,6 +17,7 @@ import {
     useContext,
     useEffect,
     useId,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -360,7 +361,14 @@ function RootDropdown({
     // a render that may have rearranged the items. It can’t hang off the body
     // ref callback instead, because React Compiler memoizes that callback, so
     // a re-render doesn’t re-attach the ref (see Dropdown.test.tsx).
-    useEffect(() => {
+    //
+    // Layout rather than passive so the id and the reference to it are always
+    // committed together: a passive effect would leave a window, however
+    // brief, where the accessibility tree has the trigger pointing at an item
+    // that is no longer in the document. It can’t move into render either —
+    // render runs before the commit, so it would read the previous render’s
+    // items and derive index paths from a body that no longer exists.
+    useLayoutEffect(() => {
         if (isOpen) syncActiveDescendant(dropdownElement);
     });
 

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -7,6 +7,7 @@ export const ITEM_SELECTOR = '[data-ukt-item], [data-ukt-value]';
 export const SUBMENU_SELECTOR = '[data-ukt-submenu]';
 
 const DISABLED_ITEM_SELECTOR = '[aria-disabled="true"]';
+export const FOCUSABLE_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 
 export type OnToggleSubmenu = (item: HTMLElement, isExpanded: boolean) => void;
 
@@ -201,6 +202,78 @@ export const getDeepestExpandedItem = (
 export const isItemExpanded = (item: HTMLElement) =>
     item.getAttribute('aria-expanded') === 'true';
 
+// The dropdown’s focusable trigger: the root’s first child if it’s focusable
+// itself, else the first focusable element within it. This is where DOM focus
+// stays while the menu is open, so it’s what carries aria-activedescendant.
+export const getTriggerElement = (
+    dropdownElement: MaybeHTMLElement,
+): MaybeHTMLElement => {
+    const firstChild = dropdownElement?.firstElementChild as MaybeHTMLElement;
+    if (!firstChild) return null;
+    return firstChild.matches(FOCUSABLE_SELECTOR)
+        ? firstChild
+        : (firstChild.querySelector(FOCUSABLE_SELECTOR) as MaybeHTMLElement);
+};
+
+// An id for an item, derived from its position: the body’s own id (from the
+// component’s useId) plus the item’s index path — its index at each level from
+// the root level down, so `<bodyId>-2-1` is the second item of the submenu
+// belonging to the third top-level item. Deterministic and collision-free
+// without a module-level counter, and idempotent, so re-deriving it is a no-op.
+//
+// Minted on demand rather than in the open-time annotation pass: the only
+// consumer is aria-activedescendant, which needs an id for the active item
+// alone, and doing it at activation time covers items rendered into an
+// already-open body (async-loaded or consumer-filtered), which that pass
+// doesn’t reach. A consumer-set id is left alone and used as-is.
+//
+// The indices come from getItemElements, i.e. the navigable items — exactly
+// the set that can become active — so a disabled item shifts the ids after it.
+// Ids are minted and consumed within a single open and are rewritten on every
+// activation, so nothing depends on them being stable across renders.
+export const ensureItemId = (
+    dropdownElement: MaybeHTMLElement,
+    item: HTMLElement,
+): string => {
+    if (item.id) return item.id;
+    const indexes: Array<number> = [];
+    let current: MaybeHTMLElement = item;
+    while (current) {
+        const levelRoot = getLevelRoot(current);
+        const itemElements = getItemElements(dropdownElement, levelRoot) ?? [];
+        indexes.unshift(itemElements.indexOf(current));
+        if (!levelRoot) break;
+        current = getParentItem(levelRoot);
+    }
+    item.id = `${getBodyElement(dropdownElement)?.id ?? 'uktdd'}-${indexes.join('-')}`;
+    return item.id;
+};
+
+// Point the trigger’s aria-activedescendant at the deepest active item, or
+// remove it when nothing is active. DOM focus never leaves the trigger while
+// the menu is open — the highlight is a data attribute, not focus — so without
+// this every arrow key, typeahead jump, and hover is silent to a screen reader.
+// Derived from the DOM rather than passed a target, so it stays correct
+// wherever active state is mutated.
+export const syncActiveDescendant = (dropdownElement: MaybeHTMLElement) => {
+    const trigger = getTriggerElement(dropdownElement);
+    if (!trigger) return;
+    const activeItem = getActiveItemElement(dropdownElement);
+    if (!activeItem) {
+        trigger.removeAttribute('aria-activedescendant');
+        return;
+    }
+    trigger.setAttribute(
+        'aria-activedescendant',
+        ensureItemId(dropdownElement, activeItem),
+    );
+};
+
+// The dropdown root owning an element, for the helpers that mutate active
+// state without a dropdownElement in hand
+const getDropdownRoot = (element: HTMLElement) =>
+    element.closest('.uktdropdown') as MaybeHTMLElement;
+
 let submenuIdCounter = 0;
 
 const ensureSubmenuARIA = (item: HTMLElement, submenu: HTMLElement) => {
@@ -293,6 +366,9 @@ export const collapseItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmen
         for (const active of Array.from(submenu.querySelectorAll('[data-ukt-active]'))) {
             delete (active as HTMLElement).dataset.uktActive;
         }
+        // Collapsing surrenders the highlight to whatever is still active
+        // above (usually the parent item), so the trigger has to follow
+        syncActiveDescendant(getDropdownRoot(item));
     }
     item.setAttribute('aria-expanded', 'false');
     onToggleSubmenu?.(item, false);
@@ -330,6 +406,8 @@ const clearItemElementsState = (itemElements: Array<HTMLElement>) => {
             delete (active as HTMLElement).dataset.uktActive;
         }
     });
+    const [firstItem] = itemElements;
+    if (firstItem != null) syncActiveDescendant(getDropdownRoot(firstItem));
 };
 
 // Make the active set exactly the chain of element + its ancestor parent items
@@ -348,6 +426,7 @@ const setActiveChain = (dropdownElement: HTMLElement, element: HTMLElement) => {
     for (const item of chain) {
         item.setAttribute('data-ukt-active', '');
     }
+    syncActiveDescendant(dropdownElement);
 };
 
 type BaseSetActiveItemPayload = {

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -296,9 +296,8 @@ export const syncActiveDescendant = (dropdownElement: MaybeHTMLElement) => {
     );
 };
 
-// Clear the highlight on each scope element and on anything inside it. The
-// only place data-ukt-active is removed; setActiveChain below is the only
-// place it’s added.
+// Clear the highlight on each scope element and on anything inside it. One of
+// the two writers of data-ukt-active, alongside setActiveChain below.
 export const clearActiveItems = (
     dropdownElement: MaybeHTMLElement,
     scopes: Array<HTMLElement> | HTMLElement,
@@ -436,9 +435,9 @@ export const collapseItemsOutsidePath = (
     }
 };
 
-// Make the active set exactly the chain of element + its ancestor parent items.
-// The only place data-ukt-active is added; clearActiveItems above is the only
-// place it’s removed.
+// Make the active set exactly the chain of element + its ancestor parent items,
+// clearing whatever falls outside it. The only place data-ukt-active is added,
+// and the other of the two writers, alongside clearActiveItems above.
 const setActiveChain = (dropdownElement: HTMLElement, element: HTMLElement) => {
     const chain = new Set<HTMLElement>([element]);
     let levelRoot = getLevelRoot(element);

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -290,7 +290,7 @@ export const syncActiveDescendant = (dropdownElement: MaybeHTMLElement) => {
     );
 };
 
-// The dropdown root owning an element, for the helpers that mutate active
+// the dropdown root owning an element, for the helpers that mutate active
 // state without a dropdownElement in hand
 const getDropdownRoot = (element: HTMLElement) =>
     element.closest('.uktdropdown') as MaybeHTMLElement;
@@ -387,7 +387,7 @@ export const collapseItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmen
         for (const active of Array.from(submenu.querySelectorAll('[data-ukt-active]'))) {
             delete (active as HTMLElement).dataset.uktActive;
         }
-        // Collapsing surrenders the highlight to whatever is still active
+        // collapsing surrenders the highlight to whatever is still active
         // above (usually the parent item), so the trigger has to follow
         syncActiveDescendant(getDropdownRoot(item));
     }

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -270,6 +270,12 @@ export const ensureItemId = (
     return id;
 };
 
+// The highlight is one piece of state kept in two places: data-ukt-active,
+// which this engine and consumer CSS read, and the trigger’s
+// aria-activedescendant, which assistive technology reads. Everything that
+// writes the first is below and re-derives the second, so a call site can move
+// the highlight without having to remember to move the reference too.
+
 // Point the trigger’s aria-activedescendant at the deepest active item, or
 // remove it when nothing is active. DOM focus never leaves the trigger while
 // the menu is open — the highlight is a data attribute, not focus — so without
@@ -288,6 +294,24 @@ export const syncActiveDescendant = (dropdownElement: MaybeHTMLElement) => {
         'aria-activedescendant',
         ensureItemId(dropdownElement, activeItem),
     );
+};
+
+// Clear the highlight on each scope element and on anything inside it. The
+// only place data-ukt-active is removed; setActiveChain below is the only
+// place it’s added.
+export const clearActiveItems = (
+    dropdownElement: MaybeHTMLElement,
+    scopes: Array<HTMLElement> | HTMLElement,
+) => {
+    for (const scope of Array.isArray(scopes) ? scopes : [scopes]) {
+        delete scope.dataset.uktActive;
+        for (const active of Array.from(
+            scope.querySelectorAll('[data-ukt-active]'),
+        ) as Array<HTMLElement>) {
+            delete active.dataset.uktActive;
+        }
+    }
+    syncActiveDescendant(dropdownElement);
 };
 
 // the dropdown root owning an element, for the helpers that mutate active
@@ -384,12 +408,9 @@ export const collapseItem = (item: HTMLElement, onToggleSubmenu?: OnToggleSubmen
         for (const descendant of expandedDescendants) {
             collapseItem(descendant, onToggleSubmenu);
         }
-        for (const active of Array.from(submenu.querySelectorAll('[data-ukt-active]'))) {
-            delete (active as HTMLElement).dataset.uktActive;
-        }
         // collapsing surrenders the highlight to whatever is still active
-        // above (usually the parent item), so the trigger has to follow
-        syncActiveDescendant(getDropdownRoot(item));
+        // above, usually the parent item
+        clearActiveItems(getDropdownRoot(item), submenu);
     }
     item.setAttribute('aria-expanded', 'false');
     onToggleSubmenu?.(item, false);
@@ -415,23 +436,9 @@ export const collapseItemsOutsidePath = (
     }
 };
 
-const clearItemElementsState = (itemElements: Array<HTMLElement>) => {
-    itemElements.forEach((itemElement) => {
-        if (itemElement.hasAttribute('data-ukt-active')) {
-            delete itemElement.dataset.uktActive;
-        }
-        // Also clear active state in any deeper levels within this item
-        for (const active of Array.from(
-            itemElement.querySelectorAll('[data-ukt-active]'),
-        )) {
-            delete (active as HTMLElement).dataset.uktActive;
-        }
-    });
-    const [firstItem] = itemElements;
-    if (firstItem != null) syncActiveDescendant(getDropdownRoot(firstItem));
-};
-
-// Make the active set exactly the chain of element + its ancestor parent items
+// Make the active set exactly the chain of element + its ancestor parent items.
+// The only place data-ukt-active is added; clearActiveItems above is the only
+// place it’s removed.
 const setActiveChain = (dropdownElement: HTMLElement, element: HTMLElement) => {
     const chain = new Set<HTMLElement>([element]);
     let levelRoot = getLevelRoot(element);
@@ -527,7 +534,7 @@ export const setActiveItem = ({
     } else if (typeof text === 'string') {
         // If text is empty, clear existing active items and early return
         if (!text) {
-            clearItemElementsState(itemElements);
+            clearActiveItems(dropdownElement, itemElements);
             return null;
         }
 
@@ -539,7 +546,7 @@ export const setActiveItem = ({
             );
             // If isExactMatch is required and no exact match was found, clear active items
             if (nextActiveIndex === -1) {
-                clearItemElementsState(itemElements);
+                clearActiveItems(dropdownElement, itemElements);
             }
         } else {
             const bestMatch = getBestMatch({ items: itemTexts, text });

--- a/packages/dropdown/src/helpers.ts
+++ b/packages/dropdown/src/helpers.ts
@@ -235,7 +235,13 @@ export const ensureItemId = (
     dropdownElement: MaybeHTMLElement,
     item: HTMLElement,
 ): string => {
-    if (item.id) return item.id;
+    // A consumer-set id is theirs to keep. Only ids minted here carry the
+    // marker, and only those are recomputed — an index path is a snapshot of a
+    // position, so filtering or reordering an open body invalidates it, and a
+    // reused id would otherwise resolve to whichever element holds it first.
+    const generatedId = item.dataset.uktGeneratedId;
+    if (item.id && item.id !== generatedId) return item.id;
+
     const indexes: Array<number> = [];
     let current: MaybeHTMLElement = item;
     while (current) {
@@ -245,8 +251,23 @@ export const ensureItemId = (
         if (!levelRoot) break;
         current = getParentItem(levelRoot);
     }
-    item.id = `${getBodyElement(dropdownElement)?.id ?? 'uktdd'}-${indexes.join('-')}`;
-    return item.id;
+    const id = `${getBodyElement(dropdownElement)?.id ?? 'uktdd'}-${indexes.join('-')}`;
+
+    // Another item may still be holding this id from before it moved. Two
+    // elements sharing an id make aria-activedescendant resolve to whichever
+    // comes first in the document, which is how a stale id announces the wrong
+    // item; strip it from the impostor, which will re-derive its own when it
+    // next becomes active. Only ever strips a generated id, never a
+    // consumer-set one.
+    const existing = item.ownerDocument.getElementById(id);
+    if (existing && existing !== item && existing.dataset.uktGeneratedId === id) {
+        existing.removeAttribute('id');
+        delete existing.dataset.uktGeneratedId;
+    }
+
+    item.id = id;
+    item.dataset.uktGeneratedId = id;
+    return id;
 };
 
 // Point the trigger’s aria-activedescendant at the deepest active item, or


### PR DESCRIPTION
**PR 4 of 6** in the pre-v1-RC a11y stack, and the one that motivated the rest. Base: #413 — review that first; this diff is only the newest commit.

## The gap

DOM focus stays on the trigger for as long as the dropdown is open — the highlight moves via `data-ukt-active`, not by moving focus — and nothing conveyed that to assistive technology. Verified before the fix, after opening a menu and pressing ↓:

```
active item html: <li data-ukt-value="a" role="menuitem" data-ukt-active="">Apple</li>
active item id:   (none)
trigger aria-activedescendant: null
document.activeElement: BUTTON uktdropdown-trigger
```

A screen reader announced the trigger and then went silent for every arrow key, typeahead jump, hover, and submenu dive — the whole keyboard model, invisible to the users who most depend on it.

## The approach

The trigger carries `aria-activedescendant` pointing at the highlighted item.

Rather than updating it at each of the ~12 `setActiveItem` call sites, `syncActiveDescendant` **re-derives it from the DOM** and is called from the three helpers that actually mutate active state (`setActiveChain`, `clearItemElementsState`, `collapseItem`) plus the two places in the component that mutate it directly — mousing out of an item, and closing, where the body unmounts and a stale id would dangle. A future caller can't forget it.

## Item ids

Extending the scheme from PR 3: the same `useId`, suffixed with the item's **index path** — its index at each level from the root down. `<bodyId>-2-1` is the second item of the submenu belonging to the third top-level item. Deterministic, collision-free, no module-level counter. A consumer-set `id` is left alone and pointed at as-is.

**Minted on activation, not in the annotation pass.** `aria-activedescendant` only ever needs an id for the active item, so on demand is sufficient — and it covers items rendered into an already-open body (async-loaded, or filtered by a consumer's own search), which the once-per-open pass doesn't reach and where an eager walk would leave `aria-activedescendant` pointing at nothing. There's a test for exactly that case.

Indices come from the navigable items, so a disabled item shifts the ids after it. Ids are minted and consumed within a single open and rewritten on every move, so nothing depends on their stability — noted in the code and the README.

## Incidental

`focusTrigger` and the new sync both need the trigger element, so that lookup moves into `helpers.ts` as `getTriggerElement`, and `FOCUSABLE_SELECTOR` moves with it.

## Tests

Nine new cases: highlight tracking, the index-path id shape (including `-2-1` in a submenu), following the highlight back out on collapse, clearing on close and on a failed typeahead, the searchable input, reveal-on-open, consumer-set ids, and the async-item case. All nine fail against the pre-fix source.

`bun run test` (137 passed), `lint`, `tsc`, and `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

