### PR TITLE
Declare the searchable trigger a combobox

### DIFF
--- a/.changeset/dropdown-combobox-role.md
+++ b/.changeset/dropdown-combobox-role.md
@@ -1,0 +1,17 @@
+---
+'@acusti/dropdown': minor
+---
+
+Declare the searchable trigger a combobox
+
+A searchable dropdown’s trigger now declares `role="combobox"` and
+`aria-autocomplete="list"`. Without the role it was exposed as a `textbox`,
+which doesn’t support the `aria-expanded` it was already carrying, so the
+open/closed state never reached assistive tech. A custom trigger gets the
+same treatment when it _is_ a single-line text input; a wrapper around one
+and a `<textarea>` are left alone.
+
+**Upgrading:** this changes the trigger’s exposed role, so anything
+selecting it by role needs `combobox` for searchable dropdowns —
+`getByRole('textbox')` in tests, `[role]` selectors in CSS or queries.
+Non-searchable triggers are unaffected.

--- a/.changeset/dropdown-combobox-role.md
+++ b/.changeset/dropdown-combobox-role.md
@@ -9,9 +9,11 @@ A searchable dropdown’s trigger now declares `role="combobox"` and
 which doesn’t support the `aria-expanded` it was already carrying, so the
 open/closed state never reached assistive tech. A custom trigger gets the
 same treatment when it _is_ a single-line text input; a wrapper around one
-and a `<textarea>` are left alone.
+is left alone. A trigger that stays a `textbox` — a `<textarea>`, or a text
+input in a non-searchable dropdown — no longer carries `aria-expanded`,
+which `textbox` doesn’t support either; give it a `role` to get it back.
 
 **Upgrading:** this changes the trigger’s exposed role, so anything
 selecting it by role needs `combobox` for searchable dropdowns —
-`getByRole('textbox')` in tests, `[role]` selectors in CSS or queries.
-Non-searchable triggers are unaffected.
+`getByRole('textbox')` in tests, `[role]` selectors in CSS or queries. The
+role of a non-searchable trigger is unchanged.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1100,16 +1100,19 @@ keyboard navigation. It works best when you use appropriate HTML elements
 in your dropdown content (like `<ul>` and `<li>` for lists, `<button>`
 elements for actions, etc.).
 
+The ARIA it adds is a best effort from what it can control: it annotates
+the DOM it renders and the shapes it recognizes, but never overwrites a
+value you pass. So when you provide a completely custom trigger, it is
+possible to end up with ARIA that doesn’t hold together. The safest thing
+if you go full custom is to take over the ARIA as well.
+
 ### ARIA attributes
 
 The trigger automatically receives `aria-haspopup`, `aria-expanded`, and
-`aria-controls` pointing to the open body. The exception is a custom
-trigger that is a text input or `<textarea>` and ends up with no `role`: it
-gets no `aria-expanded`, which `textbox` doesn’t support. A single-line
-`<input>` gets one back from `isSearchable`, which makes it a `combobox`
-(see below); a `<textarea>` — never a combobox, since that role is for
-single-line inputs — needs a `role` of its own. The popup role is chosen
-based on the dropdown’s mode:
+`aria-controls` pointing to the open body. The component does its best to
+also apply the correct roles and attributes with custom triggers, but if
+you are customizing in that way, consider also providing the appropriate
+ARIA. The popup role is chosen based on the dropdown’s mode:
 
 - `aria-haspopup="listbox"` when `isSearchable` is true (combobox pattern —
   see below)
@@ -1169,25 +1172,16 @@ ARIA you set. The persistent tint on the selected item is themeable via the
 ### The searchable trigger is a combobox
 
 A searchable dropdown’s trigger declares `role="combobox"` together with
-`aria-autocomplete="list"`. The role is what makes the rest of the pattern
-legal: ARIA 1.2 doesn’t include `aria-expanded` among the states a
-`textbox` supports, so a bare `<input>` carrying it — which is what this
-was before — is exposed without the disclosure state a combobox needs.
-`aria-autocomplete="list"` describes what typing actually does here:
+`aria-autocomplete="list"`, which describes what typing actually does here:
 suggestions appear in the popup, and nothing is completed inline in the
 input.
 
 For a custom trigger, the role is filled in only when the trigger element
-**is** a single-line text input. A trigger that merely wraps an input is
-left alone — `role="combobox"` on a wrapper is the deprecated ARIA 1.1
-shape, and it would misdescribe the wrapper — and a `<textarea>` is
-excluded for the same reason, since a combobox is single-line. (A textarea
-trigger still counts as a text input for naming, so it can’t name the popup
-either.) As always, a `role` or `aria-autocomplete` you set yourself wins.
-
-Note that this changes the trigger’s exposed role, so anything selecting it
-by role — `getByRole('textbox')` in tests, or a `[role]` selector — needs
-`combobox` for searchable dropdowns. Non-searchable triggers are unchanged.
+is a single-line text input. A trigger that merely wraps an input is left
+alone. Same with a `<textarea>`, since a combobox is single-line. (A
+textarea trigger still counts as a text input for naming, so it can’t name
+the popup either.) As always, a `role` or `aria-autocomplete` you set
+yourself wins.
 
 ### The active item and `aria-activedescendant`
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1106,7 +1106,8 @@ The trigger automatically receives `aria-haspopup`, `aria-expanded`, and
 `aria-controls` pointing to the open body. The popup role is chosen based
 on the dropdown’s mode:
 
-- `aria-haspopup="listbox"` when `isSearchable` is true (combobox pattern)
+- `aria-haspopup="listbox"` when `isSearchable` is true (combobox pattern —
+  see below)
 - `aria-haspopup="menu"` when `hasItems` is true (the default)
 - `aria-haspopup="dialog"` when `hasItems={false}` (interactive content)
 
@@ -1159,6 +1160,27 @@ on a `menuitem`) — unless you author `aria-selected` on items yourself, in
 which case the component leaves selection ARIA entirely to you, as with any
 ARIA you set. The persistent tint on the selected item is themeable via the
 `--uktdd-body-bg-color-selected` custom property.
+
+### The searchable trigger is a combobox
+
+A searchable dropdown’s trigger declares `role="combobox"` together with
+`aria-autocomplete="list"`. The role is what makes the rest of the pattern
+legal: ARIA 1.2 doesn’t include `aria-expanded` among the states a
+`textbox` supports, so a bare `<input>` carrying it — which is what this
+was before — is exposed without the disclosure state a combobox needs.
+`aria-autocomplete="list"` describes what typing actually does here:
+suggestions appear in the popup, and nothing is completed inline in the
+input.
+
+For a custom trigger, the role is filled in only when the trigger element
+**is** the text input. A trigger that merely wraps an input is left alone —
+`role="combobox"` on a wrapper is the deprecated ARIA 1.1 shape, and it
+would misdescribe the wrapper. As always, a `role` or `aria-autocomplete`
+you set yourself wins.
+
+Note that this changes the trigger’s exposed role, so anything selecting it
+by role — `getByRole('textbox')` in tests, or a `[role]` selector — needs
+`combobox` for searchable dropdowns. Non-searchable triggers are unchanged.
 
 ### The active item and `aria-activedescendant`
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1173,10 +1173,12 @@ suggestions appear in the popup, and nothing is completed inline in the
 input.
 
 For a custom trigger, the role is filled in only when the trigger element
-**is** the text input. A trigger that merely wraps an input is left alone —
-`role="combobox"` on a wrapper is the deprecated ARIA 1.1 shape, and it
-would misdescribe the wrapper. As always, a `role` or `aria-autocomplete`
-you set yourself wins.
+**is** a single-line text input. A trigger that merely wraps an input is
+left alone — `role="combobox"` on a wrapper is the deprecated ARIA 1.1
+shape, and it would misdescribe the wrapper — and a `<textarea>` is
+excluded for the same reason, since a combobox is single-line. (A textarea
+trigger still counts as a text input for naming, so it can’t name the popup
+either.) As always, a `role` or `aria-autocomplete` you set yourself wins.
 
 Note that this changes the trigger’s exposed role, so anything selecting it
 by role — `getByRole('textbox')` in tests, or a `[role]` selector — needs

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1103,8 +1103,13 @@ elements for actions, etc.).
 ### ARIA attributes
 
 The trigger automatically receives `aria-haspopup`, `aria-expanded`, and
-`aria-controls` pointing to the open body. The popup role is chosen based
-on the dropdown’s mode:
+`aria-controls` pointing to the open body. The exception is a custom
+trigger that is a text input or `<textarea>` and ends up with no `role`: it
+gets no `aria-expanded`, which `textbox` doesn’t support. A single-line
+`<input>` gets one back from `isSearchable`, which makes it a `combobox`
+(see below); a `<textarea>` — never a combobox, since that role is for
+single-line inputs — needs a `role` of its own. The popup role is chosen
+based on the dropdown’s mode:
 
 - `aria-haspopup="listbox"` when `isSearchable` is true (combobox pattern —
   see below)

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -208,6 +208,10 @@ describe('@acusti/dropdown', () => {
             expect(screen.queryByRole('combobox')).toBeNull();
             const trigger = screen.getByRole('textbox', { name: 'notes' });
             expect(trigger.hasAttribute('aria-autocomplete')).toBe(false);
+            // aria-expanded isn’t supported on textbox either
+            expect(trigger.hasAttribute('aria-expanded')).toBe(false);
+            // aria-haspopup is, so it stays
+            expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
 
             await user.click(trigger);
 
@@ -442,6 +446,50 @@ describe('@acusti/dropdown', () => {
             await user.click(screen.getByRole('textbox'));
 
             expect(screen.getByRole('menu').hasAttribute('aria-labelledby')).toBe(false);
+        });
+
+        it('leaves aria-expanded off a trigger whose role can’t take it', () => {
+            const { rerender } = render(
+                <Dropdown>
+                    <input aria-label="amount" />
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // not searchable, so this stays a textbox rather than a combobox
+            expect(screen.getByRole('textbox').hasAttribute('aria-expanded')).toBe(false);
+
+            rerender(
+                <Dropdown>
+                    <button type="button">Pick</button>
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+                'false',
+            );
+        });
+
+        it('still expands a text input trigger the consumer gave a role', () => {
+            render(
+                <Dropdown>
+                    <input aria-label="amount" role="combobox" />
+                    <ul>
+                        <li data-ukt-value="one">One</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // combobox does support aria-expanded, so declaring the role gets
+            // the disclosure state back without hand-setting it
+            expect(screen.getByRole('combobox').getAttribute('aria-expanded')).toBe(
+                'false',
+            );
         });
 
         it('still names a listbox from props.label when the trigger is a custom text input', async () => {

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -192,6 +192,31 @@ describe('@acusti/dropdown', () => {
             expect(screen.getByRole('textbox', { name: 'state' })).toBeTruthy();
         });
 
+        it('does not declare a textarea trigger a combobox', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable>
+                    <textarea aria-label="notes" />
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // combobox is a single-line input; a textarea is multi-line, so
+            // the role would misdescribe it
+            expect(screen.queryByRole('combobox')).toBeNull();
+            const trigger = screen.getByRole('textbox', { name: 'notes' });
+            expect(trigger.hasAttribute('aria-autocomplete')).toBe(false);
+
+            await user.click(trigger);
+
+            // still a text input for naming, so it can’t name the listbox
+            expect(screen.getByRole('listbox').hasAttribute('aria-labelledby')).toBe(
+                false,
+            );
+        });
+
         it('does not override a consumer-set role or aria-autocomplete', () => {
             render(
                 <Dropdown isSearchable>

--- a/packages/dropdown/src/Dropdown.test.tsx
+++ b/packages/dropdown/src/Dropdown.test.tsx
@@ -129,7 +129,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const trigger = screen.getByRole('textbox');
+            const trigger = screen.getByRole('combobox');
             expect(trigger.getAttribute('aria-expanded')).toBe('false');
             expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
 
@@ -138,6 +138,86 @@ describe('@acusti/dropdown', () => {
             const popup = screen.getByRole('listbox');
             expect(trigger.getAttribute('aria-expanded')).toBe('true');
             expect(trigger.getAttribute('aria-controls')).toBe(popup.id);
+        });
+
+        it('declares the searchable trigger a combobox', async () => {
+            const user = userEvent.setup();
+            render(
+                <Dropdown isSearchable label="State">
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('combobox', { name: 'State' });
+            // aria-expanded isn’t supported on textbox in ARIA 1.2, so the
+            // role is what makes the disclosure state legal here
+            expect(trigger.getAttribute('aria-expanded')).toBe('false');
+            expect(trigger.getAttribute('aria-autocomplete')).toBe('list');
+
+            await user.click(trigger);
+            expect(trigger.getAttribute('aria-expanded')).toBe('true');
+        });
+
+        it('declares a custom text input trigger a combobox when searchable', async () => {
+            render(
+                <Dropdown isSearchable>
+                    <input aria-label="state" />
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('combobox', { name: 'state' });
+            expect(trigger.getAttribute('aria-autocomplete')).toBe('list');
+        });
+
+        it('does not put combobox on a custom trigger that merely wraps an input', () => {
+            render(
+                <Dropdown isSearchable>
+                    <div>
+                        <input aria-label="state" />
+                    </div>
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            // role=combobox belongs on the input itself; putting it on a
+            // wrapper is the deprecated ARIA 1.1 shape
+            expect(screen.queryByRole('combobox')).toBeNull();
+            expect(screen.getByRole('textbox', { name: 'state' })).toBeTruthy();
+        });
+
+        it('does not override a consumer-set role or aria-autocomplete', () => {
+            render(
+                <Dropdown isSearchable>
+                    <input aria-autocomplete="both" aria-label="state" role="searchbox" />
+                    <ul>
+                        <li>Arizona</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('searchbox', { name: 'state' });
+            expect(trigger.getAttribute('aria-autocomplete')).toBe('both');
+        });
+
+        it('leaves a non-searchable trigger as a plain button', () => {
+            render(
+                <Dropdown>
+                    Menu
+                    <ul>
+                        <li>New Window</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            expect(screen.queryByRole('combobox')).toBeNull();
+            expect(screen.getByRole('button', { name: 'Menu' })).toBeTruthy();
         });
 
         it('uses dialog semantics when the dropdown has no selectable items', async () => {
@@ -276,7 +356,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             expect(screen.getByRole('listbox', { name: 'State' })).toBeTruthy();
         });
@@ -291,7 +371,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             // aria-labelledby resolves a text input to its value, so pointing
             // the listbox at the generated input would name it after whatever
@@ -313,7 +393,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const input = screen.getByRole('textbox');
+            const input = screen.getByRole('combobox');
             await user.click(input);
             fireEvent.input(input, { target: { value: 'Ariz' } });
 
@@ -333,6 +413,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
+            // not searchable, so the trigger stays a plain textbox
             await user.click(screen.getByRole('textbox'));
 
             expect(screen.getByRole('menu').hasAttribute('aria-labelledby')).toBe(false);
@@ -349,7 +430,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             expect(screen.getByRole('listbox', { name: 'State' })).toBeTruthy();
         });
@@ -526,7 +607,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const input = screen.getByRole('textbox');
+            const input = screen.getByRole('combobox');
             await user.click(input);
             await user.keyboard('{ArrowDown}');
 
@@ -913,7 +994,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
             await user.keyboard('{ArrowDown}');
             expect(screen.getByText('One').hasAttribute('data-ukt-active')).toBe(true);
 
@@ -1454,7 +1535,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Warm & Welcoming',
             );
         });
@@ -1468,7 +1549,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Regular',
             );
         });
@@ -1523,7 +1604,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Warm & Welcoming',
             );
         });
@@ -1540,7 +1621,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Font Weight - 400',
             );
         });
@@ -1560,7 +1641,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Fruits',
             );
         });
@@ -1577,7 +1658,7 @@ describe('@acusti/dropdown', () => {
             // A value is an identity, not display text: with no matching item
             // there’s no known label, so the input stays empty and shows its
             // placeholder rather than the raw identifier.
-            const input = screen.getByRole('textbox') as HTMLInputElement;
+            const input = screen.getByRole('combobox') as HTMLInputElement;
             expect(input.value).toBe('');
             expect(input.placeholder).toBe('Pick one');
         });
@@ -1596,7 +1677,7 @@ describe('@acusti/dropdown', () => {
             // entry (a value the user typed that isn’t among the items), so it
             // must still display as typed rather than fall back to the
             // placeholder.
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('650');
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('650');
         });
 
         it('matches a numeric data-ukt-value against a bare string value', () => {
@@ -1609,7 +1690,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Regular',
             );
         });
@@ -1626,7 +1707,7 @@ describe('@acusti/dropdown', () => {
 
             // The cleared state is a selection of the empty-valued item, so
             // the input shows that item’s label rather than the placeholder.
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('None');
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('None');
         });
 
         it('shows the placeholder for an undefined value, even with an empty-valued item', () => {
@@ -1645,7 +1726,7 @@ describe('@acusti/dropdown', () => {
             // label. This is the “Mixed” state a font-weight select uses when
             // several weights are selected at once, separate from an explicit
             // empty-valued “Inherit” option (value: '').
-            const input = screen.getByRole('textbox') as HTMLInputElement;
+            const input = screen.getByRole('combobox') as HTMLInputElement;
             expect(input.value).toBe('');
             expect(input.placeholder).toBe('Mixed');
         });
@@ -1667,7 +1748,7 @@ describe('@acusti/dropdown', () => {
             // The pair states the label explicitly, so an empty-valued
             // selection (the “Inherit” state) shows the pair’s label — not the
             // matching item’s text, and not the placeholder.
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Inherit',
             );
         });
@@ -1681,7 +1762,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+            expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
                 'Toasty',
             );
         });
@@ -1747,7 +1828,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             expect(screen.getByTestId('list').getAttribute('role')).toBe('presentation');
             expect(screen.getByTestId('warm').getAttribute('role')).toBe('option');
@@ -1799,7 +1880,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             expect(screen.getByTestId('plain').getAttribute('role')).toBe('option');
             // A parent item’s aria-haspopup/aria-expanded are invalid on an
@@ -1826,7 +1907,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             // The consumer marked warm selected, so the reveal must not add a
             // second selected option for the item matching props.value
@@ -1881,7 +1962,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
             expect(screen.getByTestId('bold').getAttribute('aria-selected')).toBe('true');
 
             await user.click(screen.getByTestId('warm'));
@@ -1902,7 +1983,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            await user.click(screen.getByRole('textbox'));
+            await user.click(screen.getByRole('combobox'));
 
             expect(screen.getByTestId('item').getAttribute('role')).toBe('menuitemradio');
         });
@@ -2048,7 +2129,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const input = screen.getByRole('textbox');
+            const input = screen.getByRole('combobox');
             await user.click(input);
             // Empty input + allowEmpty (default) → an explicit clear submit.
             await user.keyboard('{Enter}');
@@ -2106,7 +2187,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const input = screen.getByRole('textbox');
+            const input = screen.getByRole('combobox');
             await user.click(input);
             // Cleared input + no active item: an empty “creation” is a clear,
             // so allowEmpty must gate it even though allowCreate is set.
@@ -2129,7 +2210,7 @@ describe('@acusti/dropdown', () => {
                 </Dropdown>,
             );
 
-            const input = screen.getByRole('textbox');
+            const input = screen.getByRole('combobox');
             await user.click(input);
             await user.keyboard('{Enter}');
 
@@ -2713,7 +2794,7 @@ describe('@acusti/dropdown', () => {
             </Dropdown>,
         );
 
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         await user.click(input);
         expect(screen.getByRole('listbox')).toBeTruthy();
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1383,6 +1383,7 @@ function RootDropdown({
         if (isSearchable) {
             trigger = (
                 <input
+                    aria-autocomplete="list"
                     aria-controls={bodyId}
                     aria-expanded={isOpen}
                     aria-haspopup={popupRole}
@@ -1395,6 +1396,7 @@ function RootDropdown({
                     onFocus={() => setIsOpen(true)}
                     placeholder={placeholder}
                     ref={inputElementRef}
+                    role="combobox"
                     tabIndex={tabIndex}
                     type="text"
                 />
@@ -1425,15 +1427,24 @@ function RootDropdown({
         // point the body at whatever id the trigger ends up with, so a
         // consumer-set one is honored rather than overwritten
         const resolvedTriggerId = (triggerProps.id as string | undefined) ?? triggerId;
-        if (!isSearchable && !isTextInputElement(trigger)) {
+        const isTextInputTrigger = isTextInputElement(trigger);
+        if (!isSearchable && !isTextInputTrigger) {
             bodyLabelledBy = resolvedTriggerId;
         }
+        // role="combobox" belongs on the text input itself, so it’s filled in
+        // only when the custom trigger is one. A trigger that merely wraps an
+        // input is left alone: the role on the wrapper is the deprecated ARIA
+        // 1.1 shape, and putting it there would misdescribe the wrapper.
+        const isCombobox = isSearchable && isTextInputTrigger;
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
+            'aria-autocomplete':
+                triggerProps['aria-autocomplete'] ?? (isCombobox ? 'list' : undefined),
             'aria-controls': triggerProps['aria-controls'] ?? bodyId,
             'aria-disabled': triggerProps['aria-disabled'] ?? (disabled || undefined),
             'aria-expanded': triggerProps['aria-expanded'] ?? isOpen,
             'aria-haspopup': triggerProps['aria-haspopup'] ?? popupRole,
             id: resolvedTriggerId,
+            role: triggerProps.role ?? (isCombobox ? 'combobox' : undefined),
         });
     }
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1436,15 +1436,20 @@ function RootDropdown({
         // textareas or non-input wrappers)
         const isCombobox =
             isSearchable && isTextInputTrigger && trigger.type !== 'textarea';
+        const triggerRole = triggerProps.role ?? (isCombobox ? 'combobox' : undefined);
+        // aria-expanded isn’t supported on textbox either, so a text input
+        // only gets one once a role makes it something else
+        const canExpand = !isTextInputTrigger || triggerRole != null;
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
             'aria-autocomplete':
                 triggerProps['aria-autocomplete'] ?? (isCombobox ? 'list' : undefined),
             'aria-controls': triggerProps['aria-controls'] ?? bodyId,
             'aria-disabled': triggerProps['aria-disabled'] ?? (disabled || undefined),
-            'aria-expanded': triggerProps['aria-expanded'] ?? isOpen,
+            'aria-expanded':
+                triggerProps['aria-expanded'] ?? (canExpand ? isOpen : undefined),
             'aria-haspopup': triggerProps['aria-haspopup'] ?? popupRole,
             id: resolvedTriggerId,
-            role: triggerProps.role ?? (isCombobox ? 'combobox' : undefined),
+            role: triggerRole,
         });
     }
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1431,11 +1431,11 @@ function RootDropdown({
         if (!isSearchable && !isTextInputTrigger) {
             bodyLabelledBy = resolvedTriggerId;
         }
-        // role="combobox" belongs on the text input itself, so it’s filled in
-        // only when the custom trigger is one. A trigger that merely wraps an
-        // input is left alone: the role on the wrapper is the deprecated ARIA
-        // 1.1 shape, and putting it there would misdescribe the wrapper.
-        const isCombobox = isSearchable && isTextInputTrigger;
+        // role="combobox" & aria-autocomplete="list" belong on the text input,
+        // but only when the trigger is an actual text input (not valid on
+        // textareas or non-input wrappers)
+        const isCombobox =
+            isSearchable && isTextInputTrigger && trigger.type !== 'textarea';
         trigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
             'aria-autocomplete':
                 triggerProps['aria-autocomplete'] ?? (isCombobox ? 'list' : undefined),

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -1319,7 +1319,7 @@ function RootDropdown({
     // These annotations run once per open (the body unmounts on close and is
     // annotated fresh each time); items rendered into an already-open body —
     // async-loaded or consumer-filtered — aren’t annotated until the next
-    // open. Known limitation until it’s needed.
+    // open. Custom implementations like that should set their own ARIA roles.
     const handleBodyRef = (ref: HTMLDivElement | null) => {
         if (!ref) return;
         // Everything below must run exactly once per open: showPopover() throws


### PR DESCRIPTION
**PR 5 of 6** in the pre-v1-RC a11y stack. Base: #414 — review that first; this diff is only the newest commit.

## The gap

The searchable trigger was documented as "the combobox pattern" (README:1092) but rendered as a bare text input:

```html
<input aria-controls="_r_1_" aria-expanded="false" aria-haspopup="listbox"
       autocomplete="off" class="uktdropdown-trigger" placeholder="search" type="text">
```

Without `role="combobox"` that input is exposed as a `textbox`, and ARIA 1.2 doesn't list `aria-expanded` among the states `textbox` supports — so the disclosure state the whole pattern turns on wasn't conveyed at all.

## The fix

`role="combobox"` plus `aria-autocomplete="list"`. The autocomplete value is `list` rather than `both` because typing here surfaces suggestions in the popup without completing anything inline — the input is only written back on submit.

A custom trigger gets the same treatment, gated on the trigger element **being** the text input, reusing the `isTextInputElement` check from PR 3. A trigger that merely *wraps* an input is left alone: `role="combobox"` on a wrapper is the deprecated ARIA 1.1 shape and would misdescribe the wrapper. A `role` or `aria-autocomplete` you set yourself still wins.

## ⚠️ Changes the trigger's exposed role

This is the one change in the stack that's visible to consumer code. Anything selecting the searchable trigger by role needs `combobox` instead of `textbox` — `getByRole` queries, `[role]` selectors. Non-searchable triggers are unaffected. Called out in both the changeset and the README.

In this repo that meant updating 29 test queries. The five left as `textbox` are genuinely still textboxes: one non-searchable custom input trigger, and inputs living inside dialog bodies.

## Tests

Five new cases: the generated combobox and its `aria-expanded` transition, a custom input trigger, the wrapper-not-labelled case, consumer overrides of `role`/`aria-autocomplete`, and a guard that non-searchable triggers stay plain buttons.

`bun run test` (142 passed), `lint`, `tsc`, and `format` all clean.

## One adjacent case I did *not* change

A **non-searchable** dropdown with a custom text-input trigger still gets `aria-expanded` + `aria-haspopup="menu"` on a plain textbox — the same class of invalid ARIA, in a rarer shape. I left it alone deliberately: `role="combobox"` isn't a clean fix there, because ARIA 1.2 allows a combobox's popup to be `listbox`/`tree`/`grid`/`dialog` but **not** `menu`, so it'd trade one invalid combination for another. Worth deciding separately — happy to take it in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

