### PR TITLE
Give Menubar real menubar semantics

### DIFF
--- a/.changeset/dropdown-menubar-semantics.md
+++ b/.changeset/dropdown-menubar-semantics.md
@@ -1,0 +1,20 @@
+---
+'@acusti/dropdown': minor
+---
+
+Give Menubar real menubar semantics
+
+Each member's trigger now takes `role="menuitem"`, and the wrapper elements
+between it and the bar are neutralized with `role="none"`. Previously the
+bar owned only generic elements, so it was reported as a menubar with no
+menu items at all. Its menu items also share a single tab stop now (a
+roving tabindex that follows the last-focused trigger), where every trigger
+used to be its own tab stop.
+
+A searchable member keeps its `combobox` semantics and stays out of the
+roving set. Note that a combobox isn't valid menubar content in the first
+place — put a search field outside the `Menubar`.
+
+**Upgrading:** this changes the triggers' exposed role, so anything
+selecting a menubar member's trigger by role needs `menuitem` rather than
+`button`. Standalone dropdowns outside a `Menubar` are unaffected.

--- a/.changeset/dropdown-menubar-semantics.md
+++ b/.changeset/dropdown-menubar-semantics.md
@@ -4,7 +4,7 @@
 
 Give Menubar real menubar semantics
 
-Each member's trigger now takes `role="menuitem"`, and the wrapper elements
+Each member’s trigger now takes `role="menuitem"`, and the wrapper elements
 between it and the bar are neutralized with `role="none"`. Previously the
 bar owned only generic elements, so it was reported as a menubar with no
 menu items at all. Its menu items also share a single tab stop now (a
@@ -12,9 +12,9 @@ roving tabindex that follows the last-focused trigger), where every trigger
 used to be its own tab stop.
 
 A searchable member keeps its `combobox` semantics and stays out of the
-roving set. Note that a combobox isn't valid menubar content in the first
+roving set. Note that a combobox isn’t valid menubar content in the first
 place — put a search field outside the `Menubar`.
 
-**Upgrading:** this changes the triggers' exposed role, so anything
-selecting a menubar member's trigger by role needs `menuitem` rather than
+**Upgrading:** this changes the triggers’ exposed role, so anything
+selecting a menubar member’s trigger by role needs `menuitem` rather than
 `button`. Standalone dropdowns outside a `Menubar` are unaffected.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1030,8 +1030,12 @@ Menubar behaviors:
   `role="menuitem"` that the bar owns directly — the wrapper elements
   between them are neutralized with `role="none"`, since a generic element
   in between would leave the menubar owning no menu items at all. A
-  searchable member is exempt: its trigger is a `combobox`, which isn’t a
-  valid menubar child, so it keeps its own semantics
+  searchable member is exempt from the `menuitem` role: its trigger is a
+  `combobox`, so it keeps its own semantics rather than being mislabelled.
+  Its wrappers are still neutralized, but note that a `combobox` isn’t
+  valid menubar content in the first place — no markup arrangement fixes
+  that, so a search field belongs **outside** the `<Menubar>` (a container
+  mixing menus and other controls is a `toolbar`, not a menubar)
 - the bar’s **menu items share a single tab stop**, as the APG menubar
   pattern expects: one `menuitem` trigger is tabbable and the rest are
   reached with ←/→. The tab stop follows the trigger you last focused, so

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1026,7 +1026,17 @@ import Dropdown, { Menubar } from '@acusti/dropdown';
 
 Menubar behaviors:
 
-- renders `role="menubar"`; each dropdown trigger is a menubar item
+- renders `role="menubar"`, and each member’s trigger is a real
+  `role="menuitem"` that the bar owns directly — the wrapper elements
+  between them are neutralized with `role="none"`, since a generic element
+  in between would leave the menubar owning no menu items at all. A
+  searchable member is exempt: its trigger is a `combobox`, which isn’t a
+  valid menubar child, so it keeps its own semantics
+- the bar is a **single tab stop**, as the APG menubar pattern expects: one
+  trigger is tabbable and the rest are reached with ←/→. The tab stop
+  follows the trigger you last focused, so tabbing away and back returns
+  you where you were; it starts on (and falls back to) the first enabled
+  member
 - at most one menu in the bar is open at a time
 - opening a trigger’s menu (by click or keyboard) engages the bar
   (menu-mode). While engaged, hovering or focusing another trigger switches

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1032,11 +1032,13 @@ Menubar behaviors:
   in between would leave the menubar owning no menu items at all. A
   searchable member is exempt: its trigger is a `combobox`, which isn’t a
   valid menubar child, so it keeps its own semantics
-- the bar is a **single tab stop**, as the APG menubar pattern expects: one
-  trigger is tabbable and the rest are reached with ←/→. The tab stop
-  follows the trigger you last focused, so tabbing away and back returns
-  you where you were; it starts on (and falls back to) the first enabled
-  member
+- the bar’s **menu items share a single tab stop**, as the APG menubar
+  pattern expects: one `menuitem` trigger is tabbable and the rest are
+  reached with ←/→. The tab stop follows the trigger you last focused, so
+  tabbing away and back returns you where you were; it starts on (and falls
+  back to) the first enabled member. A searchable member sits outside this
+  — it’s a `combobox`, not a menu item, so it keeps its own native tab stop
+  and never takes the bar’s
 - at most one menu in the bar is open at a time
 - opening a trigger’s menu (by click or keyboard) engages the bar
   (menu-mode). While engaged, hovering or focusing another trigger switches

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -297,6 +297,19 @@ function RootDropdown({
     const labelId = `${bodyId}-label`;
     const popupRole = isSearchable ? 'listbox' : hasItems ? 'menu' : 'dialog';
     const menubar = useContext(MenubarContext);
+    // A menubar owns menuitems, so a member's trigger takes role="menuitem"
+    // and the elements between the bar and it are neutralized — a generic div
+    // (or label) in between leaves the menubar owning no menuitems at all.
+    // Only a menu trigger qualifies: a searchable member is a combobox, which
+    // isn't a valid menubar child, so it keeps its own semantics.
+    const isMenubarItem = menubar != null && popupRole === 'menu';
+    // The bar keeps a single tab stop (APG roving tabindex); the members that
+    // don't hold it stay reachable with ←/→
+    const menubarTabIndex = !isMenubarItem
+        ? undefined
+        : menubar.tabbableElement === dropdownElement
+          ? 0
+          : -1;
     const inputElementRef = useRef<HTMLInputElement | null>(null);
     // Whether the consumer authors aria-selected in the body themselves, in
     // which case this component’s aria-selected fill-ins stand down (set per
@@ -1411,7 +1424,8 @@ function RootDropdown({
                     className="uktdropdown-trigger"
                     disabled={disabled}
                     id={triggerId}
-                    tabIndex={0}
+                    role={isMenubarItem ? 'menuitem' : undefined}
+                    tabIndex={menubarTabIndex ?? 0}
                     type="button"
                 >
                     {trigger}
@@ -1436,7 +1450,9 @@ function RootDropdown({
         // textareas or non-input wrappers)
         const isCombobox =
             isSearchable && isTextInputTrigger && trigger.type !== 'textarea';
-        const triggerRole = triggerProps.role ?? (isCombobox ? 'combobox' : undefined);
+        const triggerRole =
+            triggerProps.role ??
+            (isCombobox ? 'combobox' : isMenubarItem ? 'menuitem' : undefined);
         // aria-expanded isn’t supported on textbox either, so a text input
         // only gets one once a role makes it something else
         const canExpand = !isTextInputTrigger || triggerRole != null;
@@ -1450,13 +1466,17 @@ function RootDropdown({
             'aria-haspopup': triggerProps['aria-haspopup'] ?? popupRole,
             id: resolvedTriggerId,
             role: triggerRole,
+            tabIndex: triggerProps.tabIndex ?? menubarTabIndex,
         });
     }
 
     if (label != null) {
         bodyLabelledBy = labelId;
         trigger = (
-            <label className="uktdropdown-label">
+            <label
+                className="uktdropdown-label"
+                role={isMenubarItem ? 'none' : undefined}
+            >
                 <div className="uktdropdown-label-text" id={labelId}>
                     {label}
                 </div>
@@ -1477,6 +1497,7 @@ function RootDropdown({
                     'is-searchable': isSearchable,
                 })}
                 onClick={onClick}
+                role={isMenubarItem ? 'none' : undefined}
                 onMouseDown={handleMouseDown}
                 onMouseEnter={handleDropdownMouseEnter}
                 onMouseLeave={handleDropdownMouseLeave}

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -297,24 +297,23 @@ function RootDropdown({
     const labelId = `${bodyId}-label`;
     const popupRole = isSearchable ? 'listbox' : hasItems ? 'menu' : 'dialog';
     const menubar = useContext(MenubarContext);
-    // A menubar owns menuitems, so a member's trigger takes role="menuitem"
-    // and the elements between the bar and it are neutralized — a generic div
-    // (or label) in between leaves the menubar owning no menuitems at all.
-    // Only a menu trigger qualifies: a searchable member is a combobox, which
-    // isn't a valid menubar child, so it keeps its own semantics.
-    const isMenubarItem = menubar != null && popupRole === 'menu';
+    // Every member’s wrapper elements are neutralized, so the bar owns the
+    // controls themselves rather than the generic divs (and label) around
+    // them — a generic in between leaves the menubar owning no menu items at
+    // all. This applies to any member, including a searchable one.
+    const isMenubarMember = menubar != null;
+    // Only a member whose popup is a menu joins the roving tabindex, and takes
+    // role=menuitem unless the trigger declares its own. A searchable member is
+    // a combobox, which is neither a valid menubar child nor part of the bar’s
+    // tab stop, so it keeps its own semantics.
+    const isMenubarItem = isMenubarMember && popupRole === 'menu';
     // The bar keeps a single tab stop (APG roving tabindex); the members that
-    // don't hold it stay reachable with ←/→.
+    // don’t hold it stay reachable with ←/→.
     //
     // Before registration both sides are null, so every member renders
-    // tabbable on the first render. That's deliberate: the first render is
-    // also the SSR render, and the roving tabindex is only navigable because
-    // JS is running (←/→ is the Menubar's own key handler). Without JS, all
-    // triggers tabbable degrades to plain buttons — every menu still
-    // reachable — whereas defaulting them to -1 would leave the bar with no
-    // keyboard entry point and no arrow navigation to compensate. On the
-    // client the window is a single render: members register in their effects
-    // during the mount commit, so the first paint already has one stop.
+    // tabbable on the first render to ensure the UI works without JS. Members
+    // proceed to register in their effects, so the bar settles to one stop as
+    // soon as those run.
     const menubarTabIndex = !isMenubarItem
         ? undefined
         : menubar.tabbableElement === dropdownElement
@@ -674,11 +673,9 @@ function RootDropdown({
             element: dropdownElement,
             focusTrigger,
             isDisabled: () => Boolean(disabled),
-            // Only a member rendered as a menuitem takes part in the bar's
-            // roving tabindex; a searchable member is a combobox with its own
-            // native tab stop, and letting it hold the bar's would leave every
-            // menuitem at -1
-            isMenuItem: () => isMenubarItem,
+            // Only a member whose popup is a menu takes part in the bar’s
+            // roving tabindex
+            isMenuPopup: () => isMenubarItem,
             isOpen: () => isOpenRef.current,
             // Gated as well as skipped by the menubar: open() is the one
             // opening path that doesn’t go through this component’s own
@@ -1490,12 +1487,12 @@ function RootDropdown({
         trigger = (
             <label
                 className="uktdropdown-label"
-                role={isMenubarItem ? 'none' : undefined}
+                role={isMenubarMember ? 'none' : undefined}
             >
                 <div
                     className="uktdropdown-label-text"
                     id={labelId}
-                    role={isMenubarItem ? 'none' : undefined}
+                    role={isMenubarMember ? 'none' : undefined}
                 >
                     {label}
                 </div>
@@ -1516,7 +1513,7 @@ function RootDropdown({
                     'is-searchable': isSearchable,
                 })}
                 onClick={onClick}
-                role={isMenubarItem ? 'none' : undefined}
+                role={isMenubarMember ? 'none' : undefined}
                 onMouseDown={handleMouseDown}
                 onMouseEnter={handleDropdownMouseEnter}
                 onMouseLeave={handleDropdownMouseLeave}

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -304,7 +304,17 @@ function RootDropdown({
     // isn't a valid menubar child, so it keeps its own semantics.
     const isMenubarItem = menubar != null && popupRole === 'menu';
     // The bar keeps a single tab stop (APG roving tabindex); the members that
-    // don't hold it stay reachable with ←/→
+    // don't hold it stay reachable with ←/→.
+    //
+    // Before registration both sides are null, so every member renders
+    // tabbable on the first render. That's deliberate: the first render is
+    // also the SSR render, and the roving tabindex is only navigable because
+    // JS is running (←/→ is the Menubar's own key handler). Without JS, all
+    // triggers tabbable degrades to plain buttons — every menu still
+    // reachable — whereas defaulting them to -1 would leave the bar with no
+    // keyboard entry point and no arrow navigation to compensate. On the
+    // client the window is a single render: members register in their effects
+    // during the mount commit, so the first paint already has one stop.
     const menubarTabIndex = !isMenubarItem
         ? undefined
         : menubar.tabbableElement === dropdownElement
@@ -664,6 +674,11 @@ function RootDropdown({
             element: dropdownElement,
             focusTrigger,
             isDisabled: () => Boolean(disabled),
+            // Only a member rendered as a menuitem takes part in the bar's
+            // roving tabindex; a searchable member is a combobox with its own
+            // native tab stop, and letting it hold the bar's would leave every
+            // menuitem at -1
+            isMenuItem: () => isMenubarItem,
             isOpen: () => isOpenRef.current,
             // Gated as well as skipped by the menubar: open() is the one
             // opening path that doesn’t go through this component’s own
@@ -1477,7 +1492,11 @@ function RootDropdown({
                 className="uktdropdown-label"
                 role={isMenubarItem ? 'none' : undefined}
             >
-                <div className="uktdropdown-label-text" id={labelId}>
+                <div
+                    className="uktdropdown-label-text"
+                    id={labelId}
+                    role={isMenubarItem ? 'none' : undefined}
+                >
                     {label}
                 </div>
                 {trigger}

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -38,19 +38,148 @@ describe('@acusti/dropdown Menubar', () => {
         renderMenubar();
         const menubar = screen.getByRole('menubar');
         expect(menubar.classList.contains('uktmenubar')).toBe(true);
-        expect(screen.getByRole('button', { name: 'File' })).toBeTruthy();
-        expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy();
+        expect(screen.getByRole('menuitem', { name: 'File' })).toBeTruthy();
+        expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeTruthy();
+    });
+
+    describe('menubar semantics', () => {
+        it('owns its triggers as menuitems with nothing generic in between', () => {
+            renderMenubar();
+
+            const menubar = screen.getByRole('menubar');
+            // aria-required-children: a menubar owns menuitems, so every
+            // element between it and a trigger has to be neutralized
+            for (const trigger of screen.getAllByRole('menuitem')) {
+                let ancestor = trigger.parentElement;
+                while (ancestor && ancestor !== menubar) {
+                    expect(ancestor.getAttribute('role')).toBe('none');
+                    ancestor = ancestor.parentElement;
+                }
+                expect(ancestor).toBe(menubar);
+            }
+        });
+
+        it('keeps a single tab stop, moving it to the focused trigger', () => {
+            renderMenubar();
+
+            const [file, edit, view] = screen.getAllByRole('menuitem');
+            expect(file.getAttribute('tabindex')).toBe('0');
+            expect(edit.getAttribute('tabindex')).toBe('-1');
+            expect(view.getAttribute('tabindex')).toBe('-1');
+
+            act(() => edit.focus());
+
+            expect(file.getAttribute('tabindex')).toBe('-1');
+            expect(edit.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('gives the tab stop to the first enabled member', () => {
+            render(
+                <Menubar>
+                    <Dropdown disabled>
+                        File
+                        <ul>
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            const [file, edit] = screen.getAllByRole('menuitem');
+            expect(file.getAttribute('tabindex')).toBe('-1');
+            expect(edit.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('hands the tab stop on when the holder unmounts', () => {
+            const { rerender } = render(
+                <Menubar>
+                    <Dropdown>
+                        File
+                        <ul>
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            expect(screen.getByRole('menuitem', { name: 'File' })).toBeTruthy();
+
+            rerender(
+                <Menubar>
+                    <Dropdown>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            // the bar would otherwise be left with no tab stop at all
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('0');
+        });
+
+        it('leaves a standalone dropdown’s trigger a plain tabbable button', () => {
+            render(
+                <Dropdown>
+                    Standalone
+                    <ul>
+                        <li data-ukt-item>New</li>
+                    </ul>
+                </Dropdown>,
+            );
+
+            const trigger = screen.getByRole('button', { name: 'Standalone' });
+            expect(trigger.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('leaves a searchable member as a combobox rather than a menuitem', () => {
+            render(
+                <Menubar>
+                    <Dropdown isSearchable label="Search">
+                        <ul>
+                            <li data-ukt-value="one">One</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            // a combobox isn’t a valid menubar child, so it keeps its own
+            // semantics rather than being forced into menuitem
+            expect(screen.getByRole('combobox', { name: 'Search' })).toBeTruthy();
+            expect(screen.getAllByRole('menuitem')).toHaveLength(1);
+        });
     });
 
     it('keeps at most one menu open at a time', async () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         // focusing + opening another member closes the open one
-        const viewTrigger = screen.getByRole('button', { name: 'View' });
+        const viewTrigger = screen.getByRole('menuitem', { name: 'View' });
         act(() => viewTrigger.focus());
         await user.keyboard('{Enter}');
         expect(screen.getByTestId('view-menu')).toBeTruthy();
@@ -61,13 +190,13 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         // Clicking another trigger hovers it first, which switches the open
         // menu to it (macOS behavior); the click then toggles it closed like
         // any click on an open menu’s trigger
-        await user.click(screen.getByRole('button', { name: 'Edit' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.queryByTestId('file-menu')).toBe(null);
         expect(screen.queryByTestId('edit-menu')).toBe(null);
     });
@@ -76,17 +205,17 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
-        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.getByTestId('edit-menu')).toBeTruthy();
         expect(screen.queryByTestId('file-menu')).toBe(null);
     });
 
     it('does not open a menu on hover when no menu is open', () => {
         renderMenubar();
-        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.queryByTestId('edit-menu')).toBe(null);
     });
 
@@ -113,7 +242,7 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubarWithButton();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         // Hovering the plain button closes the open menu…
@@ -122,7 +251,7 @@ describe('@acusti/dropdown Menubar', () => {
 
         // …but the bar stays engaged, so hovering a trigger reopens a menu
         // without another click
-        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.getByTestId('edit-menu')).toBeTruthy();
     });
 
@@ -130,7 +259,7 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubarWithButton();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         // The gaps between triggers aren’t interactive controls, so sliding
@@ -143,13 +272,13 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubarWithButton();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         await user.keyboard('{Escape}');
         expect(screen.queryByTestId('file-menu')).toBe(null);
 
         // Escape is a deliberate dismissal, so it leaves menu-mode: hovering a
         // trigger no longer opens a menu until a click re-engages the bar
-        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.queryByTestId('edit-menu')).toBe(null);
     });
 
@@ -175,14 +304,14 @@ describe('@acusti/dropdown Menubar', () => {
         );
         const { rerender } = render(<Bar showFile />);
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         // Remove the engaged dropdown without dismissing it. With the engaging
         // member gone, the bar is no longer engaged, so hovering another
         // trigger doesn’t reopen a menu.
         rerender(<Bar showFile={false} />);
-        fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
         expect(screen.queryByTestId('edit-menu')).toBe(null);
     });
 
@@ -190,10 +319,10 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
-        act(() => screen.getByRole('button', { name: 'Edit' }).focus());
+        act(() => screen.getByRole('menuitem', { name: 'Edit' }).focus());
         expect(screen.getByTestId('edit-menu')).toBeTruthy();
         expect(screen.queryByTestId('file-menu')).toBe(null);
     });
@@ -202,9 +331,9 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        const fileTrigger = screen.getByRole('button', { name: 'File' });
-        const editTrigger = screen.getByRole('button', { name: 'Edit' });
-        const viewTrigger = screen.getByRole('button', { name: 'View' });
+        const fileTrigger = screen.getByRole('menuitem', { name: 'File' });
+        const editTrigger = screen.getByRole('menuitem', { name: 'Edit' });
+        const viewTrigger = screen.getByRole('menuitem', { name: 'View' });
 
         fileTrigger.focus();
         await user.keyboard('{ArrowRight}');
@@ -226,13 +355,15 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
         await user.keyboard('{ArrowRight}');
         expect(screen.queryByTestId('file-menu')).toBe(null);
         expect(screen.getByTestId('edit-menu')).toBeTruthy();
-        expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Edit' }));
+        expect(document.activeElement).toBe(
+            screen.getByRole('menuitem', { name: 'Edit' }),
+        );
 
         await user.keyboard('{ArrowLeft}');
         expect(screen.queryByTestId('edit-menu')).toBe(null);
@@ -243,7 +374,7 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         await user.keyboard('{ArrowLeft}');
 
         expect(screen.queryByTestId('file-menu')).toBe(null);
@@ -255,7 +386,7 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar({ onSubmitItem: handleSubmitItem });
 
-        await user.click(screen.getByRole('button', { name: 'File' }));
+        await user.click(screen.getByRole('menuitem', { name: 'File' }));
         await user.keyboard('{ArrowDown}{ArrowDown}');
         await user.keyboard('{Enter}');
 
@@ -269,7 +400,7 @@ describe('@acusti/dropdown Menubar', () => {
         const user = userEvent.setup();
         renderMenubar();
 
-        const fileTrigger = screen.getByRole('button', { name: 'File' });
+        const fileTrigger = screen.getByRole('menuitem', { name: 'File' });
         await user.click(fileTrigger);
         expect(screen.getByTestId('file-menu')).toBeTruthy();
 
@@ -307,7 +438,7 @@ describe('@acusti/dropdown Menubar', () => {
             const user = userEvent.setup();
             renderWithDisabledMiddle();
 
-            await user.click(screen.getByRole('button', { name: 'File' }));
+            await user.click(screen.getByRole('menuitem', { name: 'File' }));
             expect(screen.getByTestId('file-menu')).toBeTruthy();
 
             await user.keyboard('{ArrowRight}');
@@ -321,7 +452,7 @@ describe('@acusti/dropdown Menubar', () => {
             const user = userEvent.setup();
             renderWithDisabledMiddle();
 
-            await user.click(screen.getByRole('button', { name: 'View' }));
+            await user.click(screen.getByRole('menuitem', { name: 'View' }));
             await user.keyboard('{ArrowLeft}');
 
             expect(screen.queryByTestId('edit-menu')).toBe(null);
@@ -333,12 +464,12 @@ describe('@acusti/dropdown Menubar', () => {
 
             // the roving path is a separate branch from sliding an open menu:
             // it only runs while nothing is open
-            const file = screen.getByRole('button', { name: 'File' });
+            const file = screen.getByRole('menuitem', { name: 'File' });
             act(() => file.focus());
             fireEvent.keyDown(file, { key: 'ArrowRight' });
 
             expect(document.activeElement).toBe(
-                screen.getByRole('button', { name: 'View' }),
+                screen.getByRole('menuitem', { name: 'View' }),
             );
             expect(screen.queryByTestId('edit-menu')).toBe(null);
         });
@@ -361,7 +492,7 @@ describe('@acusti/dropdown Menubar', () => {
                 </Menubar>,
             );
 
-            const file = screen.getByRole('button', { name: 'File' });
+            const file = screen.getByRole('menuitem', { name: 'File' });
             act(() => file.focus());
             // deciding to stay put is still handling the key — letting it
             // through would scroll the page under the focused menubar
@@ -375,10 +506,10 @@ describe('@acusti/dropdown Menubar', () => {
             const user = userEvent.setup();
             renderWithDisabledMiddle();
 
-            await user.click(screen.getByRole('button', { name: 'File' }));
+            await user.click(screen.getByRole('menuitem', { name: 'File' }));
             // hovering the disabled member’s root leaves File open rather than
             // switching to (or clearing for) Edit
-            fireEvent.mouseOver(screen.getByRole('button', { name: 'Edit' }));
+            fireEvent.mouseOver(screen.getByRole('menuitem', { name: 'Edit' }));
 
             expect(screen.queryByTestId('edit-menu')).toBe(null);
             expect(screen.getByTestId('file-menu')).toBeTruthy();
@@ -403,7 +534,7 @@ describe('@acusti/dropdown Menubar', () => {
                 </Menubar>,
             );
 
-            await user.click(screen.getByRole('button', { name: 'File' }));
+            await user.click(screen.getByRole('menuitem', { name: 'File' }));
             await user.keyboard('{ArrowRight}');
 
             // nothing enabled to move to, so File stays open rather than

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Dropdown, { Menubar } from './Dropdown.js';
@@ -43,19 +44,71 @@ describe('@acusti/dropdown Menubar', () => {
     });
 
     describe('menubar semantics', () => {
-        it('owns its triggers as menuitems with nothing generic in between', () => {
-            renderMenubar();
-
+        // aria-required-children: a menubar owns menuitems and nothing else.
+        // Checking ancestors alone isn’t enough — a presentational wrapper
+        // promotes *all* its children to the bar, so an un-roled sibling of
+        // the trigger (props.label’s text div) is owned by the menubar too.
+        // This walks everything the bar ends up owning: an element whose
+        // ancestors are all role="none" is owned directly, and must carry a
+        // role of its own rather than being a bare generic.
+        const expectNoGenericsOwnedByMenubar = () => {
             const menubar = screen.getByRole('menubar');
-            // aria-required-children: a menubar owns menuitems, so every
-            // element between it and a trigger has to be neutralized
-            for (const trigger of screen.getAllByRole('menuitem')) {
-                let ancestor = trigger.parentElement;
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems.length).toBeGreaterThan(0);
+
+            for (const element of Array.from(menubar.querySelectorAll('*'))) {
+                // anything inside a menuitem is that item's own content
+                if (
+                    menuitems.some((item) => item !== element && item.contains(element))
+                ) {
+                    continue;
+                }
+                let ancestor = element.parentElement;
+                let isOwnedByMenubar = true;
                 while (ancestor && ancestor !== menubar) {
-                    expect(ancestor.getAttribute('role')).toBe('none');
+                    if (ancestor.getAttribute('role') !== 'none') {
+                        isOwnedByMenubar = false;
+                        break;
+                    }
                     ancestor = ancestor.parentElement;
                 }
-                expect(ancestor).toBe(menubar);
+                if (!isOwnedByMenubar) continue;
+                expect({
+                    html: element.outerHTML.slice(0, 120),
+                    role: element.getAttribute('role'),
+                }).toMatchObject({ role: expect.any(String) });
+            }
+        };
+
+        it('owns its triggers as menuitems with nothing generic in between', () => {
+            renderMenubar();
+            expectNoGenericsOwnedByMenubar();
+        });
+
+        it('neutralizes the label wrapper and its text for a labelled member', () => {
+            render(
+                <Menubar>
+                    <Dropdown label="File">
+                        <ul>
+                            <li data-ukt-item>New</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown label="Edit">
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            // props.label is the documented way to build a Menubar, and it
+            // puts a text div beside the trigger inside a presentational
+            // label — which the bar would otherwise own as a generic
+            expectNoGenericsOwnedByMenubar();
+            for (const labelText of Array.from(
+                document.querySelectorAll('.uktdropdown-label-text'),
+            )) {
+                expect(labelText.getAttribute('role')).toBe('none');
             }
         });
 
@@ -168,6 +221,88 @@ describe('@acusti/dropdown Menubar', () => {
             // semantics rather than being forced into menuitem
             expect(screen.getByRole('combobox', { name: 'Search' })).toBeTruthy();
             expect(screen.getAllByRole('menuitem')).toHaveLength(1);
+        });
+
+        it('does not let a searchable member take the bar’s tab stop', () => {
+            render(
+                <Menubar>
+                    <Dropdown isSearchable label="Search">
+                        <ul>
+                            <li data-ukt-value="one">One</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        Edit
+                        <ul>
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+            // the combobox comes first in document order, but it has its own
+            // native tab stop and never reads the roving value — if it held
+            // the bar's stop, every menuitem would be left at -1
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('0');
+
+            act(() => screen.getByRole('combobox', { name: 'Search' }).focus());
+
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('0');
+        });
+
+        it('hands the tab stop on when an intermediate component unmounts the holder', async () => {
+            const user = userEvent.setup();
+            // The removal is driven by this component's own state, so Menubar
+            // never re-renders — its children prop keeps the same identity.
+            // Without the removal scheduling its own reconciliation, the tab
+            // stop stays stranded on the unmounted holder and the bar is left
+            // with no entry point at all.
+            const Members = () => {
+                const [showFile, setShowFile] = useState(true);
+                return (
+                    <>
+                        <button onClick={() => setShowFile(false)} type="button">
+                            hide File
+                        </button>
+                        {showFile ? (
+                            <Dropdown>
+                                File
+                                <ul>
+                                    <li data-ukt-item>New</li>
+                                </ul>
+                            </Dropdown>
+                        ) : null}
+                        <Dropdown>
+                            Edit
+                            <ul>
+                                <li data-ukt-item>Undo</li>
+                            </ul>
+                        </Dropdown>
+                    </>
+                );
+            };
+            render(
+                <Menubar>
+                    <Members />
+                </Menubar>,
+            );
+
+            expect(
+                screen.getByRole('menuitem', { name: 'File' }).getAttribute('tabindex'),
+            ).toBe('0');
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('-1');
+
+            await user.click(screen.getByRole('button', { name: 'hide File' }));
+
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('0');
         });
     });
 

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -44,45 +44,55 @@ describe('@acusti/dropdown Menubar', () => {
     });
 
     describe('menubar semantics', () => {
-        // aria-required-children: a menubar owns menuitems and nothing else.
+        // aria-required-children: a menubar owns its menu items, the menu an
+        // open member discloses (the canonical APG shape puts a menuitem and
+        // its menu inside the same presentational wrapper), and the
+        // neutralized wrappers, which are transparent. Nothing else.
+        //
         // Checking ancestors alone isn’t enough — a presentational wrapper
         // promotes *all* its children to the bar, so an un-roled sibling of
         // the trigger (props.label’s text div) is owned by the menubar too.
-        // This walks everything the bar ends up owning: an element whose
-        // ancestors are all role="none" is owned directly, and must carry a
-        // role of its own rather than being a bare generic.
-        const expectNoGenericsOwnedByMenubar = () => {
+        const ALLOWED_OWNED_ROLES = ['menu', 'menuitem', 'none'];
+
+        const expectMenubarOwnsOnlyAllowedRoles = () => {
             const menubar = screen.getByRole('menubar');
-            const menuitems = screen.getAllByRole('menuitem');
-            expect(menuitems.length).toBeGreaterThan(0);
+            expect(screen.getAllByRole('menuitem').length).toBeGreaterThan(0);
 
             for (const element of Array.from(menubar.querySelectorAll('*'))) {
-                // anything inside a menuitem is that item's own content
-                if (
-                    menuitems.some((item) => item !== element && item.contains(element))
-                ) {
+                // an element is owned by the bar when the nearest roled
+                // ancestor is the bar itself or a transparent wrapper;
+                // anything deeper belongs to that menuitem or open menu
+                const owner = element.parentElement?.closest('[role]');
+                if (owner && owner !== menubar && owner.getAttribute('role') !== 'none') {
                     continue;
                 }
-                let ancestor = element.parentElement;
-                let isOwnedByMenubar = true;
-                while (ancestor && ancestor !== menubar) {
-                    if (ancestor.getAttribute('role') !== 'none') {
-                        isOwnedByMenubar = false;
-                        break;
-                    }
-                    ancestor = ancestor.parentElement;
-                }
-                if (!isOwnedByMenubar) continue;
                 expect({
-                    html: element.outerHTML.slice(0, 120),
+                    html: element.outerHTML.slice(0, 100),
                     role: element.getAttribute('role'),
-                }).toMatchObject({ role: expect.any(String) });
+                }).toMatchObject({
+                    role: expect.stringMatching(
+                        new RegExp(`^(${ALLOWED_OWNED_ROLES.join('|')})$`),
+                    ),
+                });
             }
         };
 
         it('owns its triggers as menuitems with nothing generic in between', () => {
             renderMenubar();
-            expectNoGenericsOwnedByMenubar();
+            expectMenubarOwnsOnlyAllowedRoles();
+        });
+
+        it('still owns only allowed roles once a menu is open', async () => {
+            const user = userEvent.setup();
+            renderMenubar();
+
+            // the open body mounts inside the member’s neutralized wrapper, so
+            // the bar owns it directly — the state this is really about, and
+            // the one a closed-bar assertion never reaches
+            await user.click(screen.getByRole('menuitem', { name: 'File' }));
+            expect(screen.getByTestId('file-menu')).toBeTruthy();
+
+            expectMenubarOwnsOnlyAllowedRoles();
         });
 
         it('neutralizes the label wrapper and its text for a labelled member', () => {
@@ -104,7 +114,7 @@ describe('@acusti/dropdown Menubar', () => {
             // props.label is the documented way to build a Menubar, and it
             // puts a text div beside the trigger inside a presentational
             // label — which the bar would otherwise own as a generic
-            expectNoGenericsOwnedByMenubar();
+            expectMenubarOwnsOnlyAllowedRoles();
             for (const labelText of Array.from(
                 document.querySelectorAll('.uktdropdown-label-text'),
             )) {
@@ -219,8 +229,21 @@ describe('@acusti/dropdown Menubar', () => {
 
             // a combobox isn’t a valid menubar child, so it keeps its own
             // semantics rather than being forced into menuitem
-            expect(screen.getByRole('combobox', { name: 'Search' })).toBeTruthy();
+            const combobox = screen.getByRole('combobox', { name: 'Search' });
+            expect(combobox).toBeTruthy();
             expect(screen.getAllByRole('menuitem')).toHaveLength(1);
+
+            // Its wrappers are still neutralized, so the bar doesn’t own a
+            // bare generic on top of the combobox. The combobox itself remains
+            // invalid menubar content — no arrangement fixes that, which is
+            // why the README says a search field belongs outside the bar.
+            let ancestor = combobox.parentElement;
+            const menubar = screen.getByRole('menubar');
+            while (ancestor && ancestor !== menubar) {
+                expect(ancestor.getAttribute('role')).toBe('none');
+                ancestor = ancestor.parentElement;
+            }
+            expect(ancestor).toBe(menubar);
         });
 
         it('does not let a searchable member take the bar’s tab stop', () => {
@@ -242,7 +265,7 @@ describe('@acusti/dropdown Menubar', () => {
 
             // the combobox comes first in document order, but it has its own
             // native tab stop and never reads the roving value — if it held
-            // the bar's stop, every menuitem would be left at -1
+            // the bar’s stop, every menuitem would be left at -1
             expect(
                 screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
             ).toBe('0');
@@ -256,7 +279,7 @@ describe('@acusti/dropdown Menubar', () => {
 
         it('hands the tab stop on when an intermediate component unmounts the holder', async () => {
             const user = userEvent.setup();
-            // The removal is driven by this component's own state, so Menubar
+            // The removal is driven by this component’s own state, so Menubar
             // never re-renders — its children prop keeps the same identity.
             // Without the removal scheduling its own reconciliation, the tab
             // stop stays stranded on the unmounted holder and the bar is left

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -57,12 +57,9 @@ const findNextEnabledMember = (
     return null;
 };
 
-// Only an enabled member that actually renders as a menuitem can hold the bar's
-// tab stop. A searchable member is a combobox with its own native tab stop and
-// never reads the roving value, so letting it take ownership would leave every
-// menuitem at -1 and the bar without a menu entry point.
+// Only an enabled member whose popup is a menu can hold the bar’s tab stop
 const canHoldTabStop = (member: MenubarMember) =>
-    !member.isDisabled() && member.isMenuItem();
+    !member.isDisabled() && member.isMenuPopup();
 
 // Combines sibling Dropdowns into a single menu, like the system menu in the
 // top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
@@ -73,7 +70,7 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     // rest are reached with ←/→. This holds whichever member currently owns
     // it, moving to whichever trigger the user last focused.
     const [tabbableElement, setTabbableElement] = useState<HTMLElement | null>(null);
-    const [, reconcile] = useReducer((count: number) => count + 1, 0);
+    const [reconcileCount, reconcile] = useReducer((count: number) => count + 1, 0);
     // The member that engaged the bar (menu-mode). It keeps pointing at that
     // member even if that member’s menu was closed by hovering a non-menu
     // control, which allows the bar to stay engaged even with nothing open.
@@ -89,20 +86,16 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     // falls to the first enabled member in document order. Without this an
     // unmounted or disabled owner would leave the bar with no tab stop at all.
     //
-    // Deliberately runs on every render rather than on a dependency list. An
-    // unmounting member changes no state here — it only removes itself from
-    // membersRef during its own cleanup — so there is nothing to depend on
-    // that would catch it. The setState the lint rule warns about can't chain:
-    // it only fires when the current holder is missing or disabled, and the
-    // value it sets makes the guard above return on the next run.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // reconcileCount is the dependency that catches a member leaving: membership
+    // changes in the member’s own effect, which re-renders nothing here, so its
+    // cleanup bumps the reducer to say the set has settled.
     useEffect(() => {
         const members = getOrderedMembersRef.current();
         const owner = members.find((member) => member.element === tabbableElement);
         if (owner && canHoldTabStop(owner)) return;
         const nextOwner = members.find(canHoldTabStop);
         setTabbableElement(nextOwner?.element ?? null);
-    });
+    }, [reconcileCount, tabbableElement]);
 
     const contextValue: MenubarContextValue = useMemo(
         () => ({
@@ -139,32 +132,20 @@ export default function Menubar({ children, className, style }: MenubarProps) {
             },
             registerMember(member: MenubarMember) {
                 membersRef.current.add(member);
-                // Members register from their own effects, which don’t
-                // re-render this component, so the reconciliation effect below
-                // would never see them arrive — claim the tab stop here
-                // instead when it’s going spare. Members register in document
-                // order, so the first enabled one gets it.
+                // Claim the tab stop when it’s going spare; members register
+                // in document order, so the first enabled one gets it
                 setTabbableElement((current) =>
                     current == null && canHoldTabStop(member) ? member.element : current,
                 );
                 return () => {
                     membersRef.current.delete(member);
-                    // Membership changes in a member's own effect, which
-                    // doesn't re-render this component — and an intermediate
-                    // component can unmount a member without Menubar
-                    // re-rendering at all, which would strand the tab stop on
-                    // an element that's gone. Force the render so the effect
-                    // above reconciles; it reads the settled member set,
-                    // since React runs every cleanup and setup before the
-                    // batched re-render.
+                    // say the set has settled, so the effect above can pick
+                    // up a tab stop stranded on an unmounted member
                     reconcile();
-                    // Deliberately not released here. Members re-register on
-                    // every render, and React runs every cleanup before any
-                    // setup — so releasing would hand the tab stop to whichever
-                    // member re-registers first (always the first in the bar)
-                    // rather than back to the one that held it. A genuinely
-                    // unmounted holder is picked up by the effect below, which
-                    // no longer finds it among the members.
+                    // the tab stop is deliberately not released here: members
+                    // re-register on every render, and React runs every cleanup
+                    // before any setup, so releasing would hand it to whichever
+                    // member re-registers first rather than back to the holder
                 };
             },
             tabbableElement,
@@ -224,7 +205,7 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         }
     };
 
-    // Focusing a trigger hands it the bar's tab stop, so tabbing away and back
+    // focusing a trigger hands it the bar’s tab stop, so tabbing away and back
     // returns to the trigger the user was last on rather than to the first
     const handleFocus = (event: ReactFocusEvent<HTMLDivElement>) => {
         const eventTarget = event.target as HTMLElement;

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -5,8 +5,10 @@ import {
     type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
     type ReactNode,
+    useEffect,
     useMemo,
     useRef,
+    useState,
 } from 'react';
 
 import {
@@ -59,6 +61,10 @@ const findNextEnabledMember = (
 // once any menu is open, hovering or focusing another trigger switches to it.
 export default function Menubar({ children, className, style }: MenubarProps) {
     const membersRef = useRef<Set<MenubarMember>>(new Set());
+    // APG gives a menubar a single tab stop: one trigger is tabbable and the
+    // rest are reached with ←/→. This holds whichever member currently owns
+    // it, moving to whichever trigger the user last focused.
+    const [tabbableElement, setTabbableElement] = useState<HTMLElement | null>(null);
     // The member that engaged the bar (menu-mode). It keeps pointing at that
     // member even if that member’s menu was closed by hovering a non-menu
     // control, which allows the bar to stay engaged even with nothing open.
@@ -68,6 +74,26 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         Array.from(membersRef.current).sort(compareDocumentOrder),
     );
     const getOrderedMembers = getOrderedMembersRef.current;
+
+    // Keep the tab stop on a member that still exists and can take focus: on
+    // first render, and whenever the owner unmounts or becomes disabled, it
+    // falls to the first enabled member in document order. Without this an
+    // unmounted or disabled owner would leave the bar with no tab stop at all.
+    //
+    // Deliberately runs on every render rather than on a dependency list. An
+    // unmounting member changes no state here — it only removes itself from
+    // membersRef during its own cleanup — so there is nothing to depend on
+    // that would catch it. The setState the lint rule warns about can't chain:
+    // it only fires when the current holder is missing or disabled, and the
+    // value it sets makes the guard above return on the next run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => {
+        const members = getOrderedMembersRef.current();
+        const owner = members.find((member) => member.element === tabbableElement);
+        if (owner && !owner.isDisabled()) return;
+        const nextOwner = members.find((member) => !member.isDisabled());
+        setTabbableElement(nextOwner?.element ?? null);
+    });
 
     const contextValue: MenubarContextValue = useMemo(
         () => ({
@@ -104,12 +130,28 @@ export default function Menubar({ children, className, style }: MenubarProps) {
             },
             registerMember(member: MenubarMember) {
                 membersRef.current.add(member);
+                // Members register from their own effects, which don’t
+                // re-render this component, so the reconciliation effect below
+                // would never see them arrive — claim the tab stop here
+                // instead when it’s going spare. Members register in document
+                // order, so the first enabled one gets it.
+                setTabbableElement((current) =>
+                    current == null && !member.isDisabled() ? member.element : current,
+                );
                 return () => {
                     membersRef.current.delete(member);
+                    // Deliberately not released here. Members re-register on
+                    // every render, and React runs every cleanup before any
+                    // setup — so releasing would hand the tab stop to whichever
+                    // member re-registers first (always the first in the bar)
+                    // rather than back to the one that held it. A genuinely
+                    // unmounted holder is picked up by the effect below, which
+                    // no longer finds it among the members.
                 };
             },
+            tabbableElement,
         }),
-        [],
+        [tabbableElement],
     );
 
     // Rove focus between triggers with ←/→ while no menu is open (the open
@@ -164,8 +206,13 @@ export default function Menubar({ children, className, style }: MenubarProps) {
         }
     };
 
+    // Focusing a trigger hands it the bar's tab stop, so tabbing away and back
+    // returns to the trigger the user was last on rather than to the first
     const handleFocus = (event: ReactFocusEvent<HTMLDivElement>) => {
-        switchToMemberAt(event.target as HTMLElement);
+        const eventTarget = event.target as HTMLElement;
+        const member = getOrderedMembers().find((m) => m.element.contains(eventTarget));
+        if (member && !member.isDisabled()) setTabbableElement(member.element);
+        switchToMemberAt(eventTarget);
     };
 
     const handleMouseOver = (event: ReactMouseEvent<HTMLDivElement>) => {

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -7,6 +7,7 @@ import {
     type ReactNode,
     useEffect,
     useMemo,
+    useReducer,
     useRef,
     useState,
 } from 'react';
@@ -56,6 +57,13 @@ const findNextEnabledMember = (
     return null;
 };
 
+// Only an enabled member that actually renders as a menuitem can hold the bar's
+// tab stop. A searchable member is a combobox with its own native tab stop and
+// never reads the roving value, so letting it take ownership would leave every
+// menuitem at -1 and the bar without a menu entry point.
+const canHoldTabStop = (member: MenubarMember) =>
+    !member.isDisabled() && member.isMenuItem();
+
 // Combines sibling Dropdowns into a single menu, like the system menu in the
 // top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
 // once any menu is open, hovering or focusing another trigger switches to it.
@@ -65,6 +73,7 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     // rest are reached with ←/→. This holds whichever member currently owns
     // it, moving to whichever trigger the user last focused.
     const [tabbableElement, setTabbableElement] = useState<HTMLElement | null>(null);
+    const [, reconcile] = useReducer((count: number) => count + 1, 0);
     // The member that engaged the bar (menu-mode). It keeps pointing at that
     // member even if that member’s menu was closed by hovering a non-menu
     // control, which allows the bar to stay engaged even with nothing open.
@@ -90,8 +99,8 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     useEffect(() => {
         const members = getOrderedMembersRef.current();
         const owner = members.find((member) => member.element === tabbableElement);
-        if (owner && !owner.isDisabled()) return;
-        const nextOwner = members.find((member) => !member.isDisabled());
+        if (owner && canHoldTabStop(owner)) return;
+        const nextOwner = members.find(canHoldTabStop);
         setTabbableElement(nextOwner?.element ?? null);
     });
 
@@ -136,10 +145,19 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 // instead when it’s going spare. Members register in document
                 // order, so the first enabled one gets it.
                 setTabbableElement((current) =>
-                    current == null && !member.isDisabled() ? member.element : current,
+                    current == null && canHoldTabStop(member) ? member.element : current,
                 );
                 return () => {
                     membersRef.current.delete(member);
+                    // Membership changes in a member's own effect, which
+                    // doesn't re-render this component — and an intermediate
+                    // component can unmount a member without Menubar
+                    // re-rendering at all, which would strand the tab stop on
+                    // an element that's gone. Force the render so the effect
+                    // above reconciles; it reads the settled member set,
+                    // since React runs every cleanup and setup before the
+                    // batched re-render.
+                    reconcile();
                     // Deliberately not released here. Members re-register on
                     // every render, and React runs every cleanup before any
                     // setup — so releasing would hand the tab stop to whichever
@@ -211,7 +229,7 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     const handleFocus = (event: ReactFocusEvent<HTMLDivElement>) => {
         const eventTarget = event.target as HTMLElement;
         const member = getOrderedMembers().find((m) => m.element.contains(eventTarget));
-        if (member && !member.isDisabled()) setTabbableElement(member.element);
+        if (member && canHoldTabStop(member)) setTabbableElement(member.element);
         switchToMemberAt(eventTarget);
     };
 

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -38,10 +38,10 @@ export type MenubarMember = {
     // without this the Dropdown’s own pointer and key guards never see those
     // opens and props.disabled wouldn’t hold inside a Menubar.
     isDisabled: () => boolean;
-    // Whether this member renders as a menuitem. A searchable member is a
-    // combobox instead, which is neither a valid menubar child nor part of the
-    // bar's roving tabindex — it keeps its own native tab stop.
-    isMenuItem: () => boolean;
+    // Whether this member’s popup is a menu, which is what puts it in the bar’s
+    // roving tabindex. A searchable member is a combobox instead, which isn’t
+    // valid menubar content — it keeps its own native tab stop.
+    isMenuPopup: () => boolean;
     isOpen: () => boolean;
     open: () => void;
 };

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -38,6 +38,10 @@ export type MenubarMember = {
     // without this the Dropdown’s own pointer and key guards never see those
     // opens and props.disabled wouldn’t hold inside a Menubar.
     isDisabled: () => boolean;
+    // Whether this member renders as a menuitem. A searchable member is a
+    // combobox instead, which is neither a valid menubar child nor part of the
+    // bar's roving tabindex — it keeps its own native tab stop.
+    isMenuItem: () => boolean;
     isOpen: () => boolean;
     open: () => void;
 };

--- a/packages/dropdown/src/context.ts
+++ b/packages/dropdown/src/context.ts
@@ -23,6 +23,10 @@ export type MenubarContextValue = {
     notifyClosed: (element: HTMLElement) => void;
     notifyOpened: (element: HTMLElement) => void;
     registerMember: (member: MenubarMember) => () => void;
+    // The member that holds the bar’s single tab stop (APG roving tabindex):
+    // its trigger is tabbable, every other member’s is reachable only with
+    // ←/→. Null before any member has registered.
+    tabbableElement: HTMLElement | null;
 };
 
 export type MenubarMember = {


### PR DESCRIPTION
**PR 6 of 6** in the pre-v1-RC a11y stack. Base: #415 — review that first; this diff is only the newest commit.

## The gap

`Menubar` rendered `role="menubar"` but owned nothing a menubar can own:

```html
<div class="uktmenubar" role="menubar">
  <div class="uktdropdown"><label…><button aria-haspopup="menu" tabindex="0">File</button>
```

A menubar's required owned elements are menu items. The generic `div` (and `<label>`, with `props.label`) sat in between and the trigger stayed a plain button, so the bar was reported as having none — the `aria-required-children` failure. Every trigger was also its own tab stop, where APG expects the whole bar to be one.

## The fix

Triggers take `role="menuitem"`; the elements between them and the bar are neutralized with `role="none"`. A **searchable member is exempt** — its trigger is a `combobox`, which isn't a valid menubar child, so it keeps its own semantics rather than being forced into a menu item it isn't.

The roving tabindex is held as state on the bar, since only the bar knows document order. It follows the trigger you last focused, and starts on — and falls back to — the first enabled member, so a disabled or unmounted holder can't leave the bar unreachable.

## Two subtleties worth flagging for review

Both cost me a debugging pass, and both are commented in place:

1. **Registration claims the tab stop itself.** Members register from their own effects, which don't re-render `Menubar`, so the reconciliation effect would never see them arrive. Members register in document order, so the first enabled one gets it.

2. **Registration cleanup deliberately does *not* release the tab stop.** Members re-register on every render, and React runs every cleanup before any setup — so releasing handed the stop to whichever member re-registered first (always the first in the bar) rather than back to its holder. The symptom was that focusing any trigger but the first appeared to do nothing. A genuinely unmounted holder is caught by the reconciliation effect instead, which no longer finds it among the members.

The reconciliation effect intentionally runs on every render rather than on a dependency list — an unmounting member changes no state to depend on. The `exhaustive-deps` suppression carries that reasoning, plus why the setState can't chain.

## ⚠️ Changes the triggers' exposed role

Like #415, this is visible to consumer code: selecting a menubar member's trigger by role needs `menuitem` rather than `button`. Standalone dropdowns outside a `Menubar` are unaffected. The Menubar tests are updated accordingly; the one plain `<button>` in those fixtures is a non-menu control and stays a button.

## Tests

Six new cases under `describe('menubar semantics')`, including a structural one that walks from each menuitem up to the bar asserting every ancestor is `role="none"` — that's the `aria-required-children` condition expressed directly.

`bun run test` (148 passed), `lint`, `tsc`, and `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPoB7JevJjKsuiEZjaw3UL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

