### PR TITLE
Bump oxc-transform-react to 0.145.0, pin closure-capture fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -308,7 +308,7 @@
       "name": "@acusti/vite-plugin-react-compiler",
       "version": "0.0.0",
       "dependencies": {
-        "oxc-transform-react": "0.144.0",
+        "oxc-transform-react": "0.145.0",
       },
       "devDependencies": {
         "@types/node": "^26.1.0",
@@ -641,43 +641,43 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw=="],
 
-    "@oxc-transform-react/binding-android-arm-eabi": ["@oxc-transform-react/binding-android-arm-eabi@0.144.0", "", { "os": "android", "cpu": "arm" }, "sha512-PpHbQKiNZgvUg0ccpffsHRZDEIoQOVUqy8XO6Ug14wj2Udzt5ugjw3AqSpgffqepN7oAPl7VzjSaiKG7k/YV8g=="],
+    "@oxc-transform-react/binding-android-arm-eabi": ["@oxc-transform-react/binding-android-arm-eabi@0.145.0", "", { "os": "android", "cpu": "arm" }, "sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA=="],
 
-    "@oxc-transform-react/binding-android-arm64": ["@oxc-transform-react/binding-android-arm64@0.144.0", "", { "os": "android", "cpu": "arm64" }, "sha512-X50TG9qTB0xgMVGn4UfAWtb5hLyC2xofh9k2u2gAvE6N3jW5zlootIlYIJ9SWnmwntj9SgZ3CbH9GrQczlc4tg=="],
+    "@oxc-transform-react/binding-android-arm64": ["@oxc-transform-react/binding-android-arm64@0.145.0", "", { "os": "android", "cpu": "arm64" }, "sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ=="],
 
-    "@oxc-transform-react/binding-darwin-arm64": ["@oxc-transform-react/binding-darwin-arm64@0.144.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Lb4M7FtwjzVBuiz8gS9sf0paeafUWRZTHUCVlB0HfCVMl6eTZ5vP4/koAgyYY3Ocw/5ccTqqWnlC1vBSMUOMgw=="],
+    "@oxc-transform-react/binding-darwin-arm64": ["@oxc-transform-react/binding-darwin-arm64@0.145.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA=="],
 
-    "@oxc-transform-react/binding-darwin-x64": ["@oxc-transform-react/binding-darwin-x64@0.144.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-yTMBB0mUJDkyGZ5+10glqTXx1fTIsEbIxwGY9MihtC5m1RIxA8G7/tnoWwZbRmadZQUpDeRgk0sq6vE5nhSAmQ=="],
+    "@oxc-transform-react/binding-darwin-x64": ["@oxc-transform-react/binding-darwin-x64@0.145.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg=="],
 
-    "@oxc-transform-react/binding-freebsd-x64": ["@oxc-transform-react/binding-freebsd-x64@0.144.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-eljkRMUuTqpFfeZSh3RxJlWl95rl2ySn+9UySXllbKF36JmZ+NHkTBXdYzyH9nCP8cyguLAg1vclEDbUSrLIhg=="],
+    "@oxc-transform-react/binding-freebsd-x64": ["@oxc-transform-react/binding-freebsd-x64@0.145.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA=="],
 
-    "@oxc-transform-react/binding-linux-arm-gnueabihf": ["@oxc-transform-react/binding-linux-arm-gnueabihf@0.144.0", "", { "os": "linux", "cpu": "arm" }, "sha512-QiX/kQ0zUlI7cdMzq65JdpwxVTsol47iZaM+5scKPZZSe2d6mvlvhyUq42r1wvmGMNC3R5we5UfzB53Rc6qZqg=="],
+    "@oxc-transform-react/binding-linux-arm-gnueabihf": ["@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA=="],
 
-    "@oxc-transform-react/binding-linux-arm-musleabihf": ["@oxc-transform-react/binding-linux-arm-musleabihf@0.144.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Q9WQLcCZciwcPYZFZUjSFj/QZBV3oCiP9716JrJcmHpwAhSOHECPkAtI93gmrzkfBda0fG3FBaoHMNNTWhXOlg=="],
+    "@oxc-transform-react/binding-linux-arm-musleabihf": ["@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0", "", { "os": "linux", "cpu": "arm" }, "sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q=="],
 
-    "@oxc-transform-react/binding-linux-arm64-gnu": ["@oxc-transform-react/binding-linux-arm64-gnu@0.144.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-SiKauC0K4mvNbiSaEbwPnZgrgYSUkbZUllpJuVTxxlECrl3YAGRGkO6V3NSPFvFJXZEYFuAoPJ9+iVjBzf62Sw=="],
+    "@oxc-transform-react/binding-linux-arm64-gnu": ["@oxc-transform-react/binding-linux-arm64-gnu@0.145.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw=="],
 
-    "@oxc-transform-react/binding-linux-arm64-musl": ["@oxc-transform-react/binding-linux-arm64-musl@0.144.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iwUOr+tEJ5OCqCSKmx58NAvVT7iX8lTV2SqZWqg0n41u5zIb3xtD+7PshDhpydTglrB7SkEZJRCI8cthNx9bKg=="],
+    "@oxc-transform-react/binding-linux-arm64-musl": ["@oxc-transform-react/binding-linux-arm64-musl@0.145.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw=="],
 
-    "@oxc-transform-react/binding-linux-ppc64-gnu": ["@oxc-transform-react/binding-linux-ppc64-gnu@0.144.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ovuH1kJRUZrZiGrBpo4HRI8M/dw/qtzkyBRAzsgIAx3K0QRBjNlsvr+cQApipGZgQMmD7bk5a8rLh4b5mP8cHw=="],
+    "@oxc-transform-react/binding-linux-ppc64-gnu": ["@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw=="],
 
-    "@oxc-transform-react/binding-linux-riscv64-gnu": ["@oxc-transform-react/binding-linux-riscv64-gnu@0.144.0", "", { "os": "linux", "cpu": "none" }, "sha512-EVTrc51rseSVTXBB/a+fs2Jlfi3Q5BoDHBPAohIANXsF4UPIrEF0MePp1dS41huXAREUsRVKpx62891xaEtY5w=="],
+    "@oxc-transform-react/binding-linux-riscv64-gnu": ["@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0", "", { "os": "linux", "cpu": "none" }, "sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA=="],
 
-    "@oxc-transform-react/binding-linux-riscv64-musl": ["@oxc-transform-react/binding-linux-riscv64-musl@0.144.0", "", { "os": "linux", "cpu": "none" }, "sha512-CGDSWylxJOAfZ0bFl9mFnXSxVgVxhlK51iUFmz3pzRnCiz9XadrADL6+NkrCDO1/YBDZoHbnWefqD5NTedJFug=="],
+    "@oxc-transform-react/binding-linux-riscv64-musl": ["@oxc-transform-react/binding-linux-riscv64-musl@0.145.0", "", { "os": "linux", "cpu": "none" }, "sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA=="],
 
-    "@oxc-transform-react/binding-linux-s390x-gnu": ["@oxc-transform-react/binding-linux-s390x-gnu@0.144.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-DF+FZClbHj3R13NKT/qfgNRG6azpzO0h/uXXKn9zaE5lvwRzZauUbBE+ixif2qe8z96ztn4Yngea32UdkucgOw=="],
+    "@oxc-transform-react/binding-linux-s390x-gnu": ["@oxc-transform-react/binding-linux-s390x-gnu@0.145.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A=="],
 
-    "@oxc-transform-react/binding-linux-x64-gnu": ["@oxc-transform-react/binding-linux-x64-gnu@0.144.0", "", { "os": "linux", "cpu": "x64" }, "sha512-35mYvRYJpIjw70tK5NagEkIeVAu6wkgBZg5AfrFYKxNmbUmLR6kbv7Awhh+9yVvf6t18TGVkJdkic2zB7dc7Qw=="],
+    "@oxc-transform-react/binding-linux-x64-gnu": ["@oxc-transform-react/binding-linux-x64-gnu@0.145.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ=="],
 
-    "@oxc-transform-react/binding-linux-x64-musl": ["@oxc-transform-react/binding-linux-x64-musl@0.144.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GDRz1OCFiNYv0C2FZBVXOWTpI3Qw/tCKIKzAVb4q0Ma0341YSNk5VJ1Ou6bIocgN9o9hjJdYK2A6zpt8dcDGvg=="],
+    "@oxc-transform-react/binding-linux-x64-musl": ["@oxc-transform-react/binding-linux-x64-musl@0.145.0", "", { "os": "linux", "cpu": "x64" }, "sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ=="],
 
-    "@oxc-transform-react/binding-openharmony-arm64": ["@oxc-transform-react/binding-openharmony-arm64@0.144.0", "", { "os": "none", "cpu": "arm64" }, "sha512-d0YOi9u0GeUdmwYRhpn8mQZEaVbOR5JKbfHXmcgCSOzgRc6W1dy6cVnDnlr8ScEKNSnBdzjkKb7B6IO0eo0JtQ=="],
+    "@oxc-transform-react/binding-openharmony-arm64": ["@oxc-transform-react/binding-openharmony-arm64@0.145.0", "", { "os": "none", "cpu": "arm64" }, "sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q=="],
 
-    "@oxc-transform-react/binding-win32-arm64-msvc": ["@oxc-transform-react/binding-win32-arm64-msvc@0.144.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-gpLta9fcH7qpwFGYxEknzjIt4r4nZM5dzJmfMF46AIds1A6iaUAxqwopPzIBiUsE8ewaxCh0Tg3Gpuk4d1/Y3g=="],
+    "@oxc-transform-react/binding-win32-arm64-msvc": ["@oxc-transform-react/binding-win32-arm64-msvc@0.145.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw=="],
 
-    "@oxc-transform-react/binding-win32-ia32-msvc": ["@oxc-transform-react/binding-win32-ia32-msvc@0.144.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-vhAo4JJAWYpW2OJ9Wk/Z+fe31fIZLWFXkAAzduz8WRW7PGjNddk2ohmMm49bOsVCOIjC4Yerx8PKbtH1RKDeMQ=="],
+    "@oxc-transform-react/binding-win32-ia32-msvc": ["@oxc-transform-react/binding-win32-ia32-msvc@0.145.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA=="],
 
-    "@oxc-transform-react/binding-win32-x64-msvc": ["@oxc-transform-react/binding-win32-x64-msvc@0.144.0", "", { "os": "win32", "cpu": "x64" }, "sha512-3RywrPVBMrJ3B76j2KN2r9hIS4r3ESM15MafvG0OMV0YGgVWXu1bWSRmAGjKB2DcTO2KD5gev759XTJTgsynIA=="],
+    "@oxc-transform-react/binding-win32-x64-msvc": ["@oxc-transform-react/binding-win32-x64-msvc@0.145.0", "", { "os": "win32", "cpu": "x64" }, "sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 
@@ -1275,7 +1275,7 @@
 
     "oxc-resolver": ["oxc-resolver@11.24.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.24.2", "@oxc-resolver/binding-android-arm64": "11.24.2", "@oxc-resolver/binding-darwin-arm64": "11.24.2", "@oxc-resolver/binding-darwin-x64": "11.24.2", "@oxc-resolver/binding-freebsd-x64": "11.24.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2", "@oxc-resolver/binding-linux-arm64-musl": "11.24.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-musl": "11.24.2", "@oxc-resolver/binding-openharmony-arm64": "11.24.2", "@oxc-resolver/binding-wasm32-wasi": "11.24.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2", "@oxc-resolver/binding-win32-x64-msvc": "11.24.2" } }, "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw=="],
 
-    "oxc-transform-react": ["oxc-transform-react@0.144.0", "", { "optionalDependencies": { "@oxc-transform-react/binding-android-arm-eabi": "0.144.0", "@oxc-transform-react/binding-android-arm64": "0.144.0", "@oxc-transform-react/binding-darwin-arm64": "0.144.0", "@oxc-transform-react/binding-darwin-x64": "0.144.0", "@oxc-transform-react/binding-freebsd-x64": "0.144.0", "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.144.0", "@oxc-transform-react/binding-linux-arm-musleabihf": "0.144.0", "@oxc-transform-react/binding-linux-arm64-gnu": "0.144.0", "@oxc-transform-react/binding-linux-arm64-musl": "0.144.0", "@oxc-transform-react/binding-linux-ppc64-gnu": "0.144.0", "@oxc-transform-react/binding-linux-riscv64-gnu": "0.144.0", "@oxc-transform-react/binding-linux-riscv64-musl": "0.144.0", "@oxc-transform-react/binding-linux-s390x-gnu": "0.144.0", "@oxc-transform-react/binding-linux-x64-gnu": "0.144.0", "@oxc-transform-react/binding-linux-x64-musl": "0.144.0", "@oxc-transform-react/binding-openharmony-arm64": "0.144.0", "@oxc-transform-react/binding-win32-arm64-msvc": "0.144.0", "@oxc-transform-react/binding-win32-ia32-msvc": "0.144.0", "@oxc-transform-react/binding-win32-x64-msvc": "0.144.0" } }, "sha512-98G1A7nteiSUshb3mN7kXqd+pBzelB6O+cbvmvdEXAhzfgVER6vDJs9GtGE/g+gaRQfs1bnAPk/mQCguAKAmvw=="],
+    "oxc-transform-react": ["oxc-transform-react@0.145.0", "", { "optionalDependencies": { "@oxc-transform-react/binding-android-arm-eabi": "0.145.0", "@oxc-transform-react/binding-android-arm64": "0.145.0", "@oxc-transform-react/binding-darwin-arm64": "0.145.0", "@oxc-transform-react/binding-darwin-x64": "0.145.0", "@oxc-transform-react/binding-freebsd-x64": "0.145.0", "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.145.0", "@oxc-transform-react/binding-linux-arm-musleabihf": "0.145.0", "@oxc-transform-react/binding-linux-arm64-gnu": "0.145.0", "@oxc-transform-react/binding-linux-arm64-musl": "0.145.0", "@oxc-transform-react/binding-linux-ppc64-gnu": "0.145.0", "@oxc-transform-react/binding-linux-riscv64-gnu": "0.145.0", "@oxc-transform-react/binding-linux-riscv64-musl": "0.145.0", "@oxc-transform-react/binding-linux-s390x-gnu": "0.145.0", "@oxc-transform-react/binding-linux-x64-gnu": "0.145.0", "@oxc-transform-react/binding-linux-x64-musl": "0.145.0", "@oxc-transform-react/binding-openharmony-arm64": "0.145.0", "@oxc-transform-react/binding-win32-arm64-msvc": "0.145.0", "@oxc-transform-react/binding-win32-ia32-msvc": "0.145.0", "@oxc-transform-react/binding-win32-x64-msvc": "0.145.0" } }, "sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw=="],
 
     "oxfmt": ["oxfmt@0.57.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.57.0", "@oxfmt/binding-android-arm64": "0.57.0", "@oxfmt/binding-darwin-arm64": "0.57.0", "@oxfmt/binding-darwin-x64": "0.57.0", "@oxfmt/binding-freebsd-x64": "0.57.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0", "@oxfmt/binding-linux-arm-musleabihf": "0.57.0", "@oxfmt/binding-linux-arm64-gnu": "0.57.0", "@oxfmt/binding-linux-arm64-musl": "0.57.0", "@oxfmt/binding-linux-ppc64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-musl": "0.57.0", "@oxfmt/binding-linux-s390x-gnu": "0.57.0", "@oxfmt/binding-linux-x64-gnu": "0.57.0", "@oxfmt/binding-linux-x64-musl": "0.57.0", "@oxfmt/binding-openharmony-arm64": "0.57.0", "@oxfmt/binding-win32-arm64-msvc": "0.57.0", "@oxfmt/binding-win32-ia32-msvc": "0.57.0", "@oxfmt/binding-win32-x64-msvc": "0.57.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA=="],
 

--- a/packages/vite-plugin-react-compiler/package.json
+++ b/packages/vite-plugin-react-compiler/package.json
@@ -41,7 +41,7 @@
         "tsc": "tsc --noEmit"
     },
     "dependencies": {
-        "oxc-transform-react": "0.144.0"
+        "oxc-transform-react": "0.145.0"
     },
     "devDependencies": {
         "@types/node": "^26.1.0",

--- a/packages/vite-plugin-react-compiler/src/index.test.ts
+++ b/packages/vite-plugin-react-compiler/src/index.test.ts
@@ -65,13 +65,6 @@ describe('vite-plugin-react-compiler', () => {
             null,
         );
         expect(await transformCode('body { color: red; }', '/src/styles.css')).toBe(null);
-        // node_modules only excludes the exact path segment (matching the
-        // @rolldown/plugin-babel default the Babel compiler path uses)
-        const lookalike = await transformCode(
-            COMPONENT,
-            '/src/not_actually_node_modules/Greeting.tsx',
-        );
-        expect(lookalike?.code).toContain('react/compiler-runtime');
 
         const scoped = createTransformer({ include: /\/compiled\// });
         expect(await scoped.transformCode(COMPONENT, '/src/Greeting.tsx')).toBe(null);

--- a/packages/vite-plugin-react-compiler/src/upstream.test.ts
+++ b/packages/vite-plugin-react-compiler/src/upstream.test.ts
@@ -96,12 +96,13 @@ export function Counter({ step }: { step: number }) {
     });
 
     // reassigning a destructured prop identifier that a nested closure also
-    // captures bails the whole component out via two diagnostics —
+    // captures used to bail the whole component out via two diagnostics —
     // "Todo: Support destructuring of context variables" and "Immutability:
     // This value cannot be modified" — that eslint-plugin-react-hooks'
     // react-hooks/todo and react-hooks/immutability report but oxlint's
-    // react/todo and react/immutability miss
-    it.fails('compiles reassignment of a destructured prop captured by a closure', async () => {
+    // react/todo and react/immutability miss; fixed upstream in 0.145.0,
+    // pinned since
+    it('compiles reassignment of a destructured prop captured by a closure', async () => {
         const result = await transformCode(
             `
 export default function Repro({ value }: { value: string }) {

--- a/packages/vite-plugin-react-compiler/src/upstream.test.ts
+++ b/packages/vite-plugin-react-compiler/src/upstream.test.ts
@@ -94,4 +94,23 @@ export function Counter({ step }: { step: number }) {
         );
         expect(result?.code).not.toContain('react/compiler-runtime');
     });
+
+    // reassigning a destructured prop identifier that a nested closure also
+    // captures bails the whole component out via two diagnostics —
+    // "Todo: Support destructuring of context variables" and "Immutability:
+    // This value cannot be modified" — that eslint-plugin-react-hooks'
+    // react-hooks/todo and react-hooks/immutability report but oxlint's
+    // react/todo and react/immutability miss
+    it.fails('compiles reassignment of a destructured prop captured by a closure', async () => {
+        const result = await transformCode(
+            `
+export default function Repro({ value }: { value: string }) {
+    value = value + '!';
+    return <button onClick={() => console.log(value)}>{value}</button>;
+}
+`,
+            '/src/Repro.tsx',
+        );
+        expect(result?.code).toContain('react/compiler-runtime');
+    });
 });

--- a/packages/vite-plugin-react-compiler/src/upstream.test.ts
+++ b/packages/vite-plugin-react-compiler/src/upstream.test.ts
@@ -98,10 +98,7 @@ export function Counter({ step }: { step: number }) {
     // reassigning a destructured prop identifier that a nested closure also
     // captures used to bail the whole component out via two diagnostics —
     // "Todo: Support destructuring of context variables" and "Immutability:
-    // This value cannot be modified" — that eslint-plugin-react-hooks'
-    // react-hooks/todo and react-hooks/immutability report but oxlint's
-    // react/todo and react/immutability miss; fixed upstream in 0.145.0,
-    // pinned since
+    // This value cannot be modified"; fixed upstream in 0.145.0
     it('compiles reassignment of a destructured prop captured by a closure', async () => {
         const result = await transformCode(
             `


### PR DESCRIPTION
## Summary

- Add an `it.fails` test pinning a known React Compiler bailout in `oxc-transform-react@0.144.0`: reassigning a destructured prop that a nested closure also captures triggers "Todo: Support destructuring of context variables" and "Immutability: This value cannot be modified" diagnostics — a gap that oxlint's `react/todo` and `react/immutability` rules currently miss (per [the linked upstream issue](https://github.com/oxc-project/oxc/issues)), even though `eslint-plugin-react-hooks`'s equivalent rules catch it.
- Bump `oxc-transform-react` to `0.145.0`, which adds support for this pattern — the tracking test flips from `it.fails` to a plain, enabled `it`.
- Drop the `sources: ['']` workaround in `index.ts` that neutralized `oxc-transform-react`'s own default `node_modules` substring filter (previously added so the plugin's own exact-path-segment filter stayed the sole authority on inclusion). 0.145.0's default filter behavior is adopted as-is rather than worked around, since the divergence — a directory name that merely contains "node_modules" as a substring — is a vanishingly rare edge case not worth diverging from upstream for. The `index.test.ts` case that pinned the old exact-segment guarantee is removed, since it was really pinning `oxc-transform-react`'s behavior rather than this plugin's own filter logic.

## Test plan

- [x] `bun run build`
- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run tsc`
- [x] `bun run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbcr4iu8ZgZ7PJZRet8Bok)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

