### PR TITLE
Rename vite-plugin-react-compiler's reactCompiler option to compiler

### DIFF
--- a/.changeset/vite-plugin-react-compiler-compiler-option.md
+++ b/.changeset/vite-plugin-react-compiler-compiler-option.md
@@ -1,0 +1,8 @@
+---
+'@acusti/vite-plugin-react-compiler': minor
+---
+
+Rename the `reactCompiler` option to `compiler`, matching the option name
+`@vitejs/plugin-react@6.1.0` uses for its own native React Compiler
+support. Update `reactCompiler: {...}` to `compiler: {...}` in your plugin
+config.

--- a/.changeset/vite-plugin-react-compiler-compiler-option.md
+++ b/.changeset/vite-plugin-react-compiler-compiler-option.md
@@ -1,5 +1,5 @@
 ---
-'@acusti/vite-plugin-react-compiler': minor
+'@acusti/vite-plugin-react-compiler': major
 ---
 
 Rename the `reactCompiler` option to `compiler`, matching the option name

--- a/packages/vite-plugin-react-compiler/README.md
+++ b/packages/vite-plugin-react-compiler/README.md
@@ -87,14 +87,15 @@ The plugin takes an optional options object with four properties:
   [`createFilter`](https://vite.dev/guide/api-plugin#filtering-include-exclude-pattern)
   patterns selecting which modules get the compiler pass. Defaults:
   `include: /\.[jt]sx?$/`, `exclude: /[/\\]node_modules[/\\]/`.
-- **`reactCompiler`**: options passed verbatim to React Compiler, using the
-  same names as [babel-plugin-react-compiler][compiler options]:
+- **`compiler`**: options passed verbatim to React Compiler, using the same
+  names as [babel-plugin-react-compiler][compiler options]:
   `compilationMode`, `panicThreshold` (defaults to `'none'`), `target`
   (defaults to `'19'`), `environment` flags like
   `enableTreatRefLikeIdentifiersAsRefs`, and so on. Callback-valued options
   (e.g. `logger`, function-valued `sources`) don’t cross the native
   boundary and aren’t supported; `sources` accepts an array of filename
-  substrings instead.
+  substrings instead. Named to match [@vitejs/plugin-react][]’s own
+  `compiler` option.
 - **`memoize`**: cache transform results per module id, keyed by a content
   hash (bounded to one entry per file). Multi-environment builds (e.g.
   React Router apps building client + SSR environments) run every transform
@@ -104,7 +105,7 @@ The plugin takes an optional options object with four properties:
 ```ts
 reactCompiler({
     exclude: [/node_modules/, /\.stories\./],
-    reactCompiler: {
+    compiler: {
         environment: { enableTreatRefLikeIdentifiersAsRefs: true },
     },
 });
@@ -116,6 +117,8 @@ Babel syntax error would. Nonfatal compiler bail-outs behave as they do
 with the Babel plugin under `panicThreshold: 'none'`: the affected function
 is left uncompiled and the build continues.
 
+[@vitejs/plugin-react]:
+    https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react
 [compiler options]:
     https://react.dev/reference/react-compiler/configuration
 

--- a/packages/vite-plugin-react-compiler/README.md
+++ b/packages/vite-plugin-react-compiler/README.md
@@ -94,8 +94,7 @@ The plugin takes an optional options object with four properties:
   `enableTreatRefLikeIdentifiersAsRefs`, and so on. Callback-valued options
   (e.g. `logger`, function-valued `sources`) don’t cross the native
   boundary and aren’t supported; `sources` accepts an array of filename
-  substrings instead. Named to match [@vitejs/plugin-react][]’s own
-  `compiler` option.
+  substrings instead.
 - **`memoize`**: cache transform results per module id, keyed by a content
   hash (bounded to one entry per file). Multi-environment builds (e.g.
   React Router apps building client + SSR environments) run every transform
@@ -117,8 +116,6 @@ Babel syntax error would. Nonfatal compiler bail-outs behave as they do
 with the Babel plugin under `panicThreshold: 'none'`: the affected function
 is left uncompiled and the build continues.
 
-[@vitejs/plugin-react]:
-    https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react
 [compiler options]:
     https://react.dev/reference/react-compiler/configuration
 

--- a/packages/vite-plugin-react-compiler/src/index.test.ts
+++ b/packages/vite-plugin-react-compiler/src/index.test.ts
@@ -75,17 +75,17 @@ describe('vite-plugin-react-compiler', () => {
         expect(result?.code).toContain('react/compiler-runtime');
     });
 
-    it('passes reactCompiler options through to the compiler', async () => {
+    it('passes compiler options through to React Compiler', async () => {
         // target '18' memoizes via the react-compiler-runtime package
         const { transformCode } = createTransformer({
-            reactCompiler: { target: '18' },
+            compiler: { target: '18' },
         });
         const result = await transformCode(COMPONENT, '/src/Greeting.tsx');
         expect(result?.code).toContain('react-compiler-runtime');
 
         // annotation mode skips components without a 'use memo' directive
         const annotation = createTransformer({
-            reactCompiler: { compilationMode: 'annotation' },
+            compiler: { compilationMode: 'annotation' },
         });
         const annotationResult = await annotation.transformCode(
             COMPONENT,

--- a/packages/vite-plugin-react-compiler/src/index.ts
+++ b/packages/vite-plugin-react-compiler/src/index.ts
@@ -31,7 +31,6 @@ export type Options = {
      * Options passed verbatim to React Compiler, using the same names as
      * babel-plugin-react-compiler (compilationMode, panicThreshold
      * (defaults to 'none'), target (defaults to '19'), environment, etc.).
-     * Named to match @vitejs/plugin-react’s `compiler` option.
      */
     compiler?: ReactCompilerOptions;
 };

--- a/packages/vite-plugin-react-compiler/src/index.ts
+++ b/packages/vite-plugin-react-compiler/src/index.ts
@@ -31,8 +31,9 @@ export type Options = {
      * Options passed verbatim to React Compiler, using the same names as
      * babel-plugin-react-compiler (compilationMode, panicThreshold
      * (defaults to 'none'), target (defaults to '19'), environment, etc.).
+     * Named to match @vitejs/plugin-react’s `compiler` option.
      */
-    reactCompiler?: ReactCompilerOptions;
+    compiler?: ReactCompilerOptions;
 };
 
 type CachedTransform = {
@@ -72,7 +73,7 @@ export default function vitePluginReactCompiler(options: Options = {}): Plugin {
                 const transformed = await transform(filepath, code, {
                     // leave JSX for vite’s own pipeline (refresh, dev runtime)
                     jsx: 'preserve',
-                    reactCompiler: options.reactCompiler ?? {},
+                    reactCompiler: options.compiler ?? {},
                     sourcemap: true,
                 });
 


### PR DESCRIPTION
## Summary
- Rename `@acusti/vite-plugin-react-compiler`'s `reactCompiler` config option to `compiler`, matching the option name `@vitejs/plugin-react@6.1.0` introduced for its own native React Compiler support (both wrap the same `oxc-transform-react` bindings)
- Update the README's options docs and example, and the test suite, to use the new option name
- Add a `major` changeset, since this renames a public option and is a breaking change for anyone currently passing `reactCompiler`

## Test plan
- [x] `bun run build`
- [x] `bun run test` (388 passing)
- [x] `bun run lint`
- [x] `bun run tsc`
- [x] `bun run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqurajqGbzPppEdWGwDVkp)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

