### PR TITLE
Keep the menubar’s ←/→ out of a searchable member’s input

### DIFF
--- a/.changeset/dropdown-menubar-searchable-arrow-keys.md
+++ b/.changeset/dropdown-menubar-searchable-arrow-keys.md
@@ -1,0 +1,19 @@
+---
+'@acusti/dropdown': patch
+---
+
+Keep the menubar’s ←/→ out of a searchable member’s input
+
+A `Menubar` member whose popup is a menu joins the bar’s roving tabindex; a
+searchable member is a `combobox` instead, and the role, tab stop, and
+`menuitem` semantics all already exempted it. The bar’s own ←/→ handler
+didn’t: it matched any member containing the event target and skipped only
+disabled ones, so pressing ← or → in a searchable member’s search input was
+consumed by the bar and moved focus to the next menu trigger instead of
+moving the caret. Roving in the other direction landed on the combobox that
+never participates in the bar.
+
+←/→ now stand down while a text input has focus — a searchable member’s own
+input, or one inside a custom trigger — matching the rule the members’ own
+key handling already followed, and the bar’s navigation passes over any
+member that isn’t a menu item.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1043,7 +1043,8 @@ Menubar behaviors:
   tabbing away and back returns you where you were; it starts on (and falls
   back to) the first enabled member. A searchable member sits outside this
   — it’s a `combobox`, not a menu item, so it keeps its own native tab stop
-  and never takes the bar’s
+  and never takes the bar’s. ←/→ inside its input stay caret movement, and
+  the bar’s roving passes over it rather than landing in it
 - at most one menu in the bar is open at a time
 - opening a trigger’s menu (by click or keyboard) engages the bar
   (menu-mode). While engaged, hovering or focusing another trigger switches

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -701,4 +701,65 @@ describe('@acusti/dropdown Menubar', () => {
             expect(screen.queryByTestId('edit-menu')).toBe(null);
         });
     });
+    describe('searchable members', () => {
+        // A searchable member is a combobox, not a menu item: it keeps its own
+        // semantics, so the bar neither consumes ←/→ within it nor roves to it
+        const renderWithSearchable = () =>
+            render(
+                <Menubar>
+                    <Dropdown isSearchable>
+                        <input data-testid="search" placeholder="Search" />
+                        <ul data-testid="search-menu">
+                            <li data-ukt-item>Alpha</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        Edit
+                        <ul data-testid="edit-menu">
+                            <li data-ukt-item>Undo</li>
+                        </ul>
+                    </Dropdown>
+                    <Dropdown>
+                        View
+                        <ul data-testid="view-menu">
+                            <li data-ukt-item>Zoom In</li>
+                        </ul>
+                    </Dropdown>
+                </Menubar>,
+            );
+
+        it('leaves ←/→ to the caret inside a searchable member’s input', () => {
+            renderWithSearchable();
+
+            const input = screen.getByTestId('search') as HTMLInputElement;
+            input.focus();
+
+            // fireEvent returns false when a handler called preventDefault
+            expect(fireEvent.keyDown(input, { key: 'ArrowLeft' })).toBe(true);
+            expect(document.activeElement).toBe(input);
+
+            expect(fireEvent.keyDown(input, { key: 'ArrowRight' })).toBe(true);
+            expect(document.activeElement).toBe(input);
+        });
+
+        it('passes over a searchable member when roving with ←/→', async () => {
+            const user = userEvent.setup();
+            renderWithSearchable();
+
+            const editTrigger = screen.getByRole('menuitem', { name: 'Edit' });
+            const viewTrigger = screen.getByRole('menuitem', { name: 'View' });
+
+            editTrigger.focus();
+            await user.keyboard('{ArrowRight}');
+            expect(document.activeElement).toBe(viewTrigger);
+
+            // wrapping past the end skips the combobox back to Edit rather
+            // than landing in the search input
+            await user.keyboard('{ArrowRight}');
+            expect(document.activeElement).toBe(editTrigger);
+
+            await user.keyboard('{ArrowLeft}');
+            expect(document.activeElement).toBe(viewTrigger);
+        });
+    });
 });

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -1,3 +1,4 @@
+import { isEventTargetUsingKeyEvent } from '@acusti/use-keyboard-events';
 import clsx from 'clsx';
 import {
     type CSSProperties,
@@ -37,12 +38,18 @@ const compareDocumentOrder = (a: MenubarMember, b: MenubarMember) => {
 // disengaging the menubar.
 const NON_MENU_CONTROL_SELECTOR = 'a[href], button, input, select, textarea, [tabindex]';
 
-// The next member in `direction` that isn’t disabled, wrapping around and
-// skipping disabled ones — like macOS, where a disabled menu is passed over
-// rather than landed on. Returns null when no enabled member other than the
+// The members the bar navigates between: enabled, and menu items rather than
+// comboboxes. A searchable member keeps its own combobox semantics, so it
+// neither holds the bar’s tab stop nor is a destination for ←/→.
+const canHoldTabStop = (member: MenubarMember) =>
+    !member.isDisabled() && member.isMenuPopup();
+
+// The next member in `direction` the bar can land on, wrapping around and
+// passing over the rest — like macOS, where a disabled menu is passed over
+// rather than landed on. Returns null when no such member other than the
 // starting one exists, so an all-disabled bar (or a lone enabled menu) simply
 // stays put instead of closing what’s open and opening nothing.
-const findNextEnabledMember = (
+const findNextTargetMember = (
     members: Array<MenubarMember>,
     fromIndex: number,
     direction: -1 | 1,
@@ -52,14 +59,10 @@ const findNextEnabledMember = (
         // + length keeps the operand positive so % is a true modulo
         const member =
             members[(((fromIndex + direction * step) % length) + length) % length];
-        if (!member.isDisabled()) return member;
+        if (canHoldTabStop(member)) return member;
     }
     return null;
 };
-
-// Only an enabled member whose popup is a menu can hold the bar’s tab stop
-const canHoldTabStop = (member: MenubarMember) =>
-    !member.isDisabled() && member.isMenuPopup();
 
 // Combines sibling Dropdowns into a single menu, like the system menu in the
 // top toolbar of macOS: one menu open at a time, ←/→ move between menus, and
@@ -109,7 +112,7 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                     (member) => member.element === fromElement,
                 );
                 if (index === -1) return;
-                const next = findNextEnabledMember(members, index, direction);
+                const next = findNextTargetMember(members, index, direction);
                 // Nothing enabled to move to: keep the current menu open
                 // rather than closing it and opening nothing
                 if (!next) return;
@@ -161,19 +164,25 @@ export default function Menubar({ children, className, style }: MenubarProps) {
     const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
         const { key } = event;
         if (key !== 'ArrowLeft' && key !== 'ArrowRight') return;
+        // ←/→ are caret movement while a text input has focus (a searchable
+        // member’s input, or one inside a custom trigger), so the bar stands
+        // down — the same rule the members’ own key handling follows
+        if (isEventTargetUsingKeyEvent(event.nativeEvent)) return;
         const members = getOrderedMembers();
         if (members.length < 2) return;
         if (members.some((member) => member.isOpen())) return;
         const eventTarget = event.target as HTMLElement;
         const index = members.findIndex((member) => member.element.contains(eventTarget));
-        if (index === -1) return;
+        // Only the bar’s menu items rove. A searchable member is a combobox
+        // that sits outside the bar’s navigation, so ←/→ within it stay its own
+        if (index === -1 || !members[index].isMenuPopup()) return;
         // Once focus is on a member, ←/→ belong to the bar, so the key is
         // consumed whether or not there's an enabled member to move to —
         // otherwise deciding to stay put would let it through to scroll the page
         event.preventDefault();
         event.stopPropagation();
         const direction = key === 'ArrowRight' ? 1 : -1;
-        const next = findNextEnabledMember(members, index, direction);
+        const next = findNextTargetMember(members, index, direction);
         if (!next) return;
         next.focusTrigger();
     };


### PR DESCRIPTION
Fixes #429.

A `Menubar` member whose popup is a menu joins the bar’s roving tabindex. A searchable member is a `combobox` instead, and the `menuitem` role (`isMenubarItem`), the tab stop (`canHoldTabStop`), and `handleFocus` all already exempted it — the README says so twice, including “A searchable member sits outside this … keeps its own native tab stop and never takes the bar’s”.

The bar’s own ←/→ handler was the one place that didn’t. It matched any member merely *containing* the event target, and `findNextEnabledMember` skipped only `isDisabled()` members, so:

- **←/→ in a searchable member’s search input** were `preventDefault`ed by the bar and moved focus to the next menu trigger, instead of moving the caret.
- **roving the other way** landed on the combobox that never participates in the bar.

Reproduced on `main` before the fix — `fireEvent.keyDown(input, { key: 'ArrowLeft' })` returned `defaultPrevented: true` with `activeElement` becoming the `Edit` button.

## The fix

- ←/→ stand down while a text input has focus, via the same `isEventTargetUsingKeyEvent` guard the members’ **own** key handling already uses (`!isTargetUsingKeyEvents` in `Dropdown.tsx`). This covers a searchable member’s input and a text input inside a custom trigger — exactly the case the Home/End changeset described as “Like ←/→, they stand down while a text input has focus”.
- The bar’s navigation predicate is now `canHoldTabStop` (enabled **and** `isMenuPopup()`) rather than “not disabled”, so roving passes over any member that isn’t a menu item. `findNextEnabledMember` is renamed `findNextTargetMember` to match, and `canHoldTabStop` is hoisted above it.

Because the predicate is shared, this also stops `moveOpen` sliding an open menu onto a combobox member — the same rule, same bug class.

The `index === -1 || !members[index].isMenuPopup()` check is kept alongside the input guard: the guard covers focus in the search field, and the `isMenuPopup` check covers focus elsewhere inside a combobox member while making sure `preventDefault` never fires on the bar’s behalf for one.

## Tests

Two regression tests in a new `searchable members` block. Both were confirmed to **fail without the source change** and pass with it:

- `leaves ←/→ to the caret inside a searchable member’s input` — asserts the key isn’t cancelled and focus stays put.
- `passes over a searchable member when roving with ←/→` — asserts roving wraps Edit → View → Edit rather than landing in the search input.

Full repo `build`, `test` (390 passed / 24 files), `lint`, `tsc`, and `format` all pass.

Includes a patch changeset and a one-clause README addition to the tab-stop bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An3mqqrhHB7b7FCLt6muyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01An3mqqrhHB7b7FCLt6muyK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

