### PR TITLE
Reconcile the menubar’s tab stop only when its holder actually leaves

### DIFF
--- a/.changeset/dropdown-menubar-reconcile-only-for-holder.md
+++ b/.changeset/dropdown-menubar-reconcile-only-for-holder.md
@@ -2,16 +2,19 @@
 '@acusti/dropdown': patch
 ---
 
-Reconcile the menubar’s tab stop only when its holder leaves
+Reconcile the menubar’s tab stop only when its holder actually leaves
 
 Menubar members re-register on every render, so the cleanup that removes a
 member from the set runs far more often than a member actually leaves. It
 bumped the reconcile reducer unconditionally, which scheduled a Menubar
-state update and re-render for every member render — and the effect it woke
-almost always early-returned, because the tab stop was still held by an
-eligible member.
+state update and re-render each time, and the effect it woke almost always
+early-returned because the tab stop was still held by an eligible member.
 
-Only the holder going (or becoming ineligible, which re-registers it here
-too) can strand the tab stop, so only that case now reconciles. On a
-four-member bar, engaging it and hover-switching around it three times went
-from 27 Menubar renders to 12.
+Only the holder really going can strand the tab stop, and by the time the
+cleanup runs React has already detached its element — which is what
+distinguishes a departure from a re-render. Losing eligibility without
+leaving (a holder that becomes disabled, or stops being a menu) is now
+settled where the member re-registers, against the props that changed.
+
+Measured on the compiled build, opening and closing the tab stop holder’s
+own menu three times: 19 Menubar commits before, 9 after.

--- a/.changeset/dropdown-menubar-reconcile-only-for-holder.md
+++ b/.changeset/dropdown-menubar-reconcile-only-for-holder.md
@@ -10,11 +10,12 @@ bumped the reconcile reducer unconditionally, which scheduled a Menubar
 state update and re-render each time, and the effect it woke almost always
 early-returned because the tab stop was still held by an eligible member.
 
-Only the holder really going can strand the tab stop, and by the time the
-cleanup runs React has already detached its element — which is what
-distinguishes a departure from a re-render. Losing eligibility without
-leaving (a holder that becomes disabled, or stops being a menu) is now
-settled where the member re-registers, against the props that changed.
+Only the holder really going can strand the tab stop, and a member that
+merely re-rendered re-registers during the same commit — so the bump now
+waits for the commit to settle and fires only if that member never came
+back. Losing eligibility without leaving (a holder that becomes disabled,
+or stops being a menu) is settled where the member re-registers, against
+the props that changed.
 
 Measured on the compiled build, opening and closing the tab stop holder’s
 own menu three times: 19 Menubar commits before, 9 after.

--- a/.changeset/dropdown-menubar-reconcile-only-for-holder.md
+++ b/.changeset/dropdown-menubar-reconcile-only-for-holder.md
@@ -1,0 +1,17 @@
+---
+'@acusti/dropdown': patch
+---
+
+Reconcile the menubar’s tab stop only when its holder leaves
+
+Menubar members re-register on every render, so the cleanup that removes a
+member from the set runs far more often than a member actually leaves. It
+bumped the reconcile reducer unconditionally, which scheduled a Menubar
+state update and re-render for every member render — and the effect it woke
+almost always early-returned, because the tab stop was still held by an
+eligible member.
+
+Only the holder going (or becoming ineligible, which re-registers it here
+too) can strand the tab stop, so only that case now reconciles. On a
+four-member bar, engaging it and hover-switching around it three times went
+from 27 Menubar renders to 12.

--- a/.changeset/dropdown-menubar-reconcile-only-for-holder.md
+++ b/.changeset/dropdown-menubar-reconcile-only-for-holder.md
@@ -2,20 +2,4 @@
 '@acusti/dropdown': patch
 ---
 
-Reconcile the menubar’s tab stop only when its holder actually leaves
-
-Menubar members re-register on every render, so the cleanup that removes a
-member from the set runs far more often than a member actually leaves. It
-bumped the reconcile reducer unconditionally, which scheduled a Menubar
-state update and re-render each time, and the effect it woke almost always
-early-returned because the tab stop was still held by an eligible member.
-
-Only the holder really going can strand the tab stop, and a member that
-merely re-rendered re-registers during the same commit — so the bump now
-waits for the commit to settle and fires only if that member never came
-back. Losing eligibility without leaving (a holder that becomes disabled,
-or stops being a menu) is settled where the member re-registers, against
-the props that changed.
-
-Measured on the compiled build, opening and closing the tab stop holder’s
-own menu three times: 19 Menubar commits before, 9 after.
+Halve the renders a Menubar does as its menus open and close

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -327,6 +327,54 @@ describe('@acusti/dropdown Menubar', () => {
                 screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
             ).toBe('0');
         });
+
+        it('hands the tab stop on when the holder becomes disabled', async () => {
+            const user = userEvent.setup();
+            // Like the unmount above, this is driven by the members’ own state,
+            // so Menubar never re-renders on its own. The holder stops being
+            // eligible without leaving the set, so it’s the holder’s own
+            // re-registration that has to schedule the reconciliation.
+            const Members = () => {
+                const [isFileDisabled, setIsFileDisabled] = useState(false);
+                return (
+                    <>
+                        <button onClick={() => setIsFileDisabled(true)} type="button">
+                            disable File
+                        </button>
+                        <Dropdown disabled={isFileDisabled}>
+                            File
+                            <ul>
+                                <li data-ukt-item>New</li>
+                            </ul>
+                        </Dropdown>
+                        <Dropdown>
+                            Edit
+                            <ul>
+                                <li data-ukt-item>Undo</li>
+                            </ul>
+                        </Dropdown>
+                    </>
+                );
+            };
+            render(
+                <Menubar>
+                    <Members />
+                </Menubar>,
+            );
+
+            expect(
+                screen.getByRole('menuitem', { name: 'File' }).getAttribute('tabindex'),
+            ).toBe('0');
+
+            await user.click(screen.getByRole('button', { name: 'disable File' }));
+
+            expect(
+                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
+            ).toBe('0');
+            expect(
+                screen.getByRole('menuitem', { name: 'File' }).getAttribute('tabindex'),
+            ).toBe('-1');
+        });
     });
 
     it('keeps at most one menu open at a time', async () => {

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { useState } from 'react';
+import { Activity, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Dropdown, { Menubar } from './Dropdown.js';
@@ -374,6 +374,60 @@ describe('@acusti/dropdown Menubar', () => {
             expect(
                 screen.getByRole('menuitem', { name: 'File' }).getAttribute('tabindex'),
             ).toBe('-1');
+        });
+
+        it('hands the tab stop on when the holder is hidden with <Activity>', async () => {
+            const user = userEvent.setup();
+            // Hiding a subtree with <Activity> unmounts its effects while
+            // leaving the DOM in place, so the holder deregisters with its
+            // trigger still in the document. Deciding it stayed because its
+            // element is still connected would strand the tab stop on a
+            // trigger nobody can reach.
+            const Members = () => {
+                const [isFileHidden, setIsFileHidden] = useState(false);
+                return (
+                    <>
+                        <button onClick={() => setIsFileHidden(true)} type="button">
+                            hide File
+                        </button>
+                        <Activity mode={isFileHidden ? 'hidden' : 'visible'}>
+                            <Dropdown>
+                                File
+                                <ul>
+                                    <li data-ukt-item>New</li>
+                                </ul>
+                            </Dropdown>
+                        </Activity>
+                        <Dropdown>
+                            Edit
+                            <ul>
+                                <li data-ukt-item>Undo</li>
+                            </ul>
+                        </Dropdown>
+                    </>
+                );
+            };
+            render(
+                <Menubar>
+                    <Members />
+                </Menubar>,
+            );
+
+            expect(
+                screen.getByRole('menuitem', { name: 'File' }).getAttribute('tabindex'),
+            ).toBe('0');
+
+            await user.click(screen.getByRole('button', { name: 'hide File' }));
+
+            // the reconciliation waits for the commit to settle, so that a
+            // member that merely re-rendered isn’t mistaken for one that left
+            await waitFor(() => {
+                expect(
+                    screen
+                        .getByRole('menuitem', { name: 'Edit' })
+                        .getAttribute('tabindex'),
+                ).toBe('0');
+            });
         });
     });
 

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -138,21 +138,16 @@ export default function Menubar({ children, className, style }: MenubarProps) {
             },
             registerMember(member: MenubarMember) {
                 membersRef.current.add(member);
-                // Claim the tab stop when it’s going spare; members register
-                // in document order, so the first enabled one gets it
                 setTabbableElement((current) => {
-                    // Claim the tab stop when it’s going spare; members
-                    // register in document order, so the first enabled one
-                    // gets it
+                    // members register in document order, so a stop going
+                    // spare lands on the first eligible one
                     if (current == null) {
                         return canHoldTabStop(member) ? member.element : current;
                     }
-                    // A holder that re-registers no longer able to hold it
-                    // (disabled, or no longer a menu) gives it up here, where
-                    // the fresh member reflects the props that changed; the
-                    // effect above then rehomes it. Every other
-                    // re-registration returns `current` untouched, so React
-                    // bails out instead of re-rendering the bar.
+                    // the holder re-registering ineligible — now disabled, or
+                    // no longer a menu — drops the stop for the effect above
+                    // to rehome. Every other re-registration returns `current`
+                    // unchanged, so React bails out of rendering the bar.
                     if (current === member.element && !canHoldTabStop(member)) {
                         return null;
                     }
@@ -160,19 +155,13 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 });
                 return () => {
                     membersRef.current.delete(member);
-                    // Say the set has settled, so the effect above can pick
-                    // up a tab stop stranded on a member that has gone.
-                    // Members re-register on every render, so this cleanup
-                    // runs far more often than one actually leaves, and
-                    // bumping for the rest would schedule a Menubar render
-                    // that changes nothing. Only the holder can strand the
-                    // stop, and a re-render re-registers it during this same
-                    // commit — so let the commit settle and bump only if this
-                    // element never came back. Whether the element is still in
-                    // the document doesn’t answer it: <Activity mode="hidden">
-                    // unmounts effects while keeping the DOM in place. Losing
-                    // eligibility without leaving is handled on the
-                    // registration side above.
+                    // Only the holder leaving strands the stop, and members
+                    // re-register on every render — so wait out the commit and
+                    // bump only if this element never came back. Still being in
+                    // the document proves nothing: <Activity mode="hidden">
+                    // tears down effects but keeps the DOM. Releasing the stop
+                    // here instead would hand it to whichever member
+                    // re-registers first, not back to the holder.
                     if (member.element !== tabbableElement) return;
                     queueMicrotask(() => {
                         for (const registered of membersRef.current) {
@@ -180,10 +169,6 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                         }
                         reconcile();
                     });
-                    // the tab stop is deliberately not released here: members
-                    // re-register on every render, and React runs every cleanup
-                    // before any setup, so releasing would hand it to whichever
-                    // member re-registers first rather than back to the holder
                 };
             },
             tabbableElement,

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -145,9 +145,14 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 );
                 return () => {
                     membersRef.current.delete(member);
-                    // say the set has settled, so the effect above can pick
-                    // up a tab stop stranded on an unmounted member
-                    reconcile();
+                    // Say the set has settled, so the effect above can pick up
+                    // a tab stop stranded on an unmounted member. Members
+                    // re-register on every render, so this cleanup runs far
+                    // more often than one actually leaves; only the holder
+                    // going (or becoming ineligible, which re-renders it here
+                    // too) can strand the tab stop, so bumping for the rest
+                    // would schedule a Menubar render that changes nothing.
+                    if (member.element === tabbableElement) reconcile();
                     // the tab stop is deliberately not released here: members
                     // re-register on every render, and React runs every cleanup
                     // before any setup, so releasing would hand it to whichever

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -161,21 +161,25 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 return () => {
                     membersRef.current.delete(member);
                     // Say the set has settled, so the effect above can pick
-                    // up a tab stop stranded on an unmounted member. Members
-                    // re-register on every render, so this cleanup runs far
-                    // more often than one actually leaves: only the holder
-                    // actually going strands the tab stop, and React has
-                    // already detached its element by the time this runs,
-                    // which is what tells a departure from a re-render.
-                    // Bumping for the rest would schedule a Menubar render
-                    // that changes nothing. Losing eligibility without leaving
-                    // is handled on the registration side above.
-                    if (
-                        member.element === tabbableElement &&
-                        !member.element.isConnected
-                    ) {
+                    // up a tab stop stranded on a member that has gone.
+                    // Members re-register on every render, so this cleanup
+                    // runs far more often than one actually leaves, and
+                    // bumping for the rest would schedule a Menubar render
+                    // that changes nothing. Only the holder can strand the
+                    // stop, and a re-render re-registers it during this same
+                    // commit — so let the commit settle and bump only if this
+                    // element never came back. Whether the element is still in
+                    // the document doesn’t answer it: <Activity mode="hidden">
+                    // unmounts effects while keeping the DOM in place. Losing
+                    // eligibility without leaving is handled on the
+                    // registration side above.
+                    if (member.element !== tabbableElement) return;
+                    queueMicrotask(() => {
+                        for (const registered of membersRef.current) {
+                            if (registered.element === member.element) return;
+                        }
                         reconcile();
-                    }
+                    });
                     // the tab stop is deliberately not released here: members
                     // re-register on every render, and React runs every cleanup
                     // before any setup, so releasing would hand it to whichever

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -139,15 +139,17 @@ export default function Menubar({ children, className, style }: MenubarProps) {
             registerMember(member: MenubarMember) {
                 membersRef.current.add(member);
                 setTabbableElement((current) => {
-                    // members register in document order, so a stop going
-                    // spare lands on the first eligible one
+                    // no member holds the tab stop yet, so the first
+                    // eligible one to register takes it — and they register
+                    // in document order
                     if (current == null) {
                         return canHoldTabStop(member) ? member.element : current;
                     }
-                    // the holder re-registering ineligible — now disabled, or
-                    // no longer a menu — drops the stop for the effect above
-                    // to rehome. Every other re-registration returns `current`
-                    // unchanged, so React bails out of rendering the bar.
+                    // this member holds the tab stop but can no longer keep
+                    // it: it has just been disabled, or has stopped being a
+                    // menu. Clearing the stop lets the effect above hand it
+                    // to another member. Every other re-registration returns
+                    // `current` untouched, so React skips re-rendering the bar.
                     if (current === member.element && !canHoldTabStop(member)) {
                         return null;
                     }

--- a/packages/dropdown/src/Menubar.tsx
+++ b/packages/dropdown/src/Menubar.tsx
@@ -140,19 +140,42 @@ export default function Menubar({ children, className, style }: MenubarProps) {
                 membersRef.current.add(member);
                 // Claim the tab stop when it’s going spare; members register
                 // in document order, so the first enabled one gets it
-                setTabbableElement((current) =>
-                    current == null && canHoldTabStop(member) ? member.element : current,
-                );
+                setTabbableElement((current) => {
+                    // Claim the tab stop when it’s going spare; members
+                    // register in document order, so the first enabled one
+                    // gets it
+                    if (current == null) {
+                        return canHoldTabStop(member) ? member.element : current;
+                    }
+                    // A holder that re-registers no longer able to hold it
+                    // (disabled, or no longer a menu) gives it up here, where
+                    // the fresh member reflects the props that changed; the
+                    // effect above then rehomes it. Every other
+                    // re-registration returns `current` untouched, so React
+                    // bails out instead of re-rendering the bar.
+                    if (current === member.element && !canHoldTabStop(member)) {
+                        return null;
+                    }
+                    return current;
+                });
                 return () => {
                     membersRef.current.delete(member);
-                    // Say the set has settled, so the effect above can pick up
-                    // a tab stop stranded on an unmounted member. Members
+                    // Say the set has settled, so the effect above can pick
+                    // up a tab stop stranded on an unmounted member. Members
                     // re-register on every render, so this cleanup runs far
-                    // more often than one actually leaves; only the holder
-                    // going (or becoming ineligible, which re-renders it here
-                    // too) can strand the tab stop, so bumping for the rest
-                    // would schedule a Menubar render that changes nothing.
-                    if (member.element === tabbableElement) reconcile();
+                    // more often than one actually leaves: only the holder
+                    // actually going strands the tab stop, and React has
+                    // already detached its element by the time this runs,
+                    // which is what tells a departure from a re-render.
+                    // Bumping for the rest would schedule a Menubar render
+                    // that changes nothing. Losing eligibility without leaving
+                    // is handled on the registration side above.
+                    if (
+                        member.element === tabbableElement &&
+                        !member.element.isConnected
+                    ) {
+                        reconcile();
+                    }
                     // the tab stop is deliberately not released here: members
                     // re-register on every render, and React runs every cleanup
                     // before any setup, so releasing would hand it to whichever


### PR DESCRIPTION
Fixes #431.

`registerMember`'s cleanup bumped the reconcile reducer unconditionally. Because the register effect in `Dropdown.tsx` is deps-less (`useEffect(() => {…})`), members re-register on **every** render, so that cleanup runs far more often than a member actually leaves — and each bump scheduled a `Menubar` state update whose effect then almost always early-returned, the tab stop still being held by an eligible member.

The change splits two situations the old code conflated:

- **A genuine departure.** A member that merely re-rendered re-registers during the same commit, so the decision is deferred until the commit settles and the bump fires only if that element never came back.
- **An eligibility transition** (the holder becomes `disabled`, or stops being a menu). Settled on the registration side, where the freshly registered member reflects the props that changed: it returns `null` and the effect rehomes the tab stop. Every other re-registration returns `current` untouched, so React bails out instead of re-rendering the bar.

## Measured, not assumed

Counting `Menubar` commits with a `<Profiler>`, opening and closing the tab stop holder's own menu three times — the common interaction, which re-registers the holder repeatedly while it stays eligible:

| | Menubar commits |
|---|---|
| before | 19 |
| after | 9 |

## Two corrections along the way

Both from measuring or reproducing rather than reasoning, and both worth reading before reviewing the diff:

1. **#431 overstated the cost.** It predicted "one wasted render per member render". React batches the bumps within a commit, so the real cost is roughly one extra render per commit in which members re-render.
2. **The first two attempts were each wrong, and cubic caught both.**
   - `member.element === tabbableElement` alone (b676aa7) left the common case at **19 commits — identical to no fix at all**. The 27 → 12 figure quoted in an earlier description came only from *other* members churning during hover-switching.
   - Adding `&& !member.element.isConnected` (a6ae04c) regressed `<Activity mode="hidden">`: React unmounts a hidden subtree's effects while leaving its DOM in place, so the holder deregistered with its trigger still connected, the bump was skipped, and the tab stop stranded on an unreachable trigger. Reproduced on React 19.2.8 before fixing. The unconditional bump had handled that correctly.

   The lesson in both: the question is "did this registration go away?", and neither "is it the holder?" nor "is its element still in the document?" answers it. 8ce1ca3 stops inspecting the DOM and lets the commit settle instead, which covers unmount, hidden subtrees, and any other teardown without a special case for each.

## Correctness

Two tests for cases the existing suite didn't reach, each failing on the attempt it rules out:

- **the holder becoming `disabled` without unmounting** — fails on `isConnected`-style narrowing, which is what forced the eligibility half of the design.
- **the holder hidden with `<Activity>`** — fails on a6ae04c, passes on 8ce1ca3.

## A gap worth naming

There is no CI guard against a future regression to unconditional bumping. I wrote a `<Profiler>` render-count test and removed it, because it can't be reliable here:

| config | before | after |
|---|---|---|
| `packages/dropdown/vite.config.js` (`react: true`, compiler on) | 19 | 9 |
| root `vitest.config.js` (no react plugin, compiler off) | 19 | **18** |

CI runs `bun run test` from the root, where the compiler is off and the gap is one commit — too tight for a threshold that wouldn't flake on a React bump. Without the compiler the bar re-renders for other reasons that mask the reconcile bumps; with it (as in the shipped build) they're the dominant remaining cost. Covering this properly would need a compiler-enabled test project rather than a threshold in the shared suite; happy to open a follow-up issue if that's wanted.

Full repo `build`, `test` (392 passed / 24 files), `lint`, `tsc`, and `format:check` pass, as does the compiled path (`bun run --filter '@acusti/dropdown' test`, 167 passed). Includes a patch changeset.

Left as three commits so cubic's reviews stay anchored to what they reviewed — squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An3mqqrhHB7b7FCLt6muyK