### PR TITLE
Forward aria-* attributes and role in InputText and CSSValueInput

### DIFF
--- a/.changeset/css-value-input-aria-props.md
+++ b/.changeset/css-value-input-aria-props.md
@@ -1,0 +1,17 @@
+---
+'@acusti/css-value-input': minor
+---
+
+Forward aria-\* attributes and role to the underlying input
+
+`Props` didn’t include any of the ARIA attributes, so annotating the input
+— `aria-describedby` for a hint, `aria-invalid` on a rejected value —
+wasn’t possible. The only name the input could get came from `label` or,
+for the icon-only case, the `aria-label` the component puts on its wrapping
+`<label>` from `title`, neither of which the consumer could override.
+
+`Props` now intersects React’s `AriaAttributes` and adds `role`, and any of
+those props not consumed by the component are spread onto the nested
+`InputText` rather than the wrapping `<label>`, so they annotate the input
+itself. An `aria-label` passed in names the input and, by the accessible
+name precedence, wins over the wrapper’s label text or title.

--- a/.changeset/css-value-input-aria-props.md
+++ b/.changeset/css-value-input-aria-props.md
@@ -11,7 +11,6 @@ for the icon-only case, the `aria-label` the component puts on its wrapping
 `<label>` from `title`, neither of which the consumer could override.
 
 `Props` now intersects React’s `AriaAttributes` and adds `role`, and any of
-those props not consumed by the component are spread onto the nested
-`InputText` rather than the wrapping `<label>`, so they annotate the input
-itself. An `aria-label` passed in names the input and, by the accessible
-name precedence, wins over the wrapper’s label text or title.
+those props not consumed by the component are spread onto the nested input.
+An `aria-label` passed in names the input and, by the accessible name
+precedence, wins over the wrapper’s label text or title.

--- a/.changeset/input-text-aria-props.md
+++ b/.changeset/input-text-aria-props.md
@@ -13,7 +13,4 @@ semantics it injects.
 
 `Props` now intersects React’s `AriaAttributes` and adds `role`, and any of
 those props not consumed by the component are spread onto the `<input>` or
-`<textarea>`. The spread comes first, so the props the component owns
-(`readOnly` under `doubleClickToEdit`, `defaultValue`, its event handlers)
-still win, and the prop type stays closed: props `InputText` doesn’t model
-remain type errors rather than passing through.
+`<textarea>`.

--- a/.changeset/input-text-aria-props.md
+++ b/.changeset/input-text-aria-props.md
@@ -1,0 +1,19 @@
+---
+'@acusti/input-text': minor
+---
+
+Forward aria-\* attributes and role to the underlying input
+
+`Props` didn’t include any of the ARIA attributes, so an `aria-label` or an
+`aria-describedby` passed to `InputText` was both a type error and silently
+dropped — the only accessible name available was one supplied by a wrapping
+`<label>`. It also meant a parent that annotates its trigger by cloning it,
+like `@acusti/dropdown`, couldn’t give an `InputText` trigger the combobox
+semantics it injects.
+
+`Props` now intersects React’s `AriaAttributes` and adds `role`, and any of
+those props not consumed by the component are spread onto the `<input>` or
+`<textarea>`. The spread comes first, so the props the component owns
+(`readOnly` under `doubleClickToEdit`, `defaultValue`, its event handlers)
+still win, and the prop type stays closed: props `InputText` doesn’t model
+remain type errors rather than passing through.

--- a/packages/css-value-input/README.md
+++ b/packages/css-value-input/README.md
@@ -76,8 +76,17 @@ function StyleEditor() {
 
 ### Props
 
+Every `aria-*` attribute and `role` is also accepted and forwarded to the
+underlying input (not to the wrapping `<label>`), so the input can be
+annotated directly. An `aria-label` passed here names the input and takes
+precedence over the name it would otherwise get from `label` or `title`:
+
+```tsx
+<CSSValueInput aria-label="Width" aria-describedby="width-hint" … />
+```
+
 ```ts
-type Props = {
+type Props = AriaAttributes & {
     /**
      * Boolean indicating if the user can submit an empty value (i.e. clear
      * the value). Defaults to true.
@@ -137,6 +146,9 @@ type Props = {
 
     /** Placeholder text when input is empty */
     placeholder?: string;
+
+    /** ARIA role for the underlying input element */
+    role?: AriaRole;
 
     /** Step size for arrow key increments (default: 1) */
     step?: number;

--- a/packages/css-value-input/src/CSSValueInput.test.tsx
+++ b/packages/css-value-input/src/CSSValueInput.test.tsx
@@ -125,4 +125,37 @@ describe('CSSValueInput.tsx', () => {
         expect(input.value).toBe('14px');
         expect(onSubmit).toHaveBeenCalledTimes(1);
     });
+
+    it('forwards aria-* attributes and role to the input, not the wrapper label', () => {
+        render(
+            <CSSValueInput
+                aria-describedby="hint-id"
+                aria-invalid
+                onSubmitValue={noop}
+                role="spinbutton"
+                title="Width"
+                value="24px"
+            />,
+        );
+        const input = screen.getByRole('spinbutton');
+        expect(input.tagName).toBe('INPUT');
+        expect(input.getAttribute('aria-describedby')).toBe('hint-id');
+        expect(input.getAttribute('aria-invalid')).toBe('true');
+        const wrapper = input.closest('label')!;
+        expect(wrapper.hasAttribute('aria-describedby')).toBe(false);
+        expect(wrapper.hasAttribute('role')).toBe(false);
+    });
+
+    it('names the input by props aria-label ahead of props.label and props.title', () => {
+        render(
+            <CSSValueInput
+                aria-label="Width"
+                label="W"
+                onSubmitValue={noop}
+                title="Element width"
+                value="24px"
+            />,
+        );
+        expect(screen.getByRole('textbox', { name: 'Width' })).toBeTruthy();
+    });
 });

--- a/packages/css-value-input/src/CSSValueInput.tsx
+++ b/packages/css-value-input/src/CSSValueInput.tsx
@@ -10,6 +10,8 @@ import {
 import InputText, { type InputElement } from '@acusti/input-text';
 import clsx from 'clsx';
 import {
+    type AriaAttributes,
+    type AriaRole,
     type ChangeEvent,
     type FocusEvent,
     type KeyboardEvent,
@@ -20,7 +22,13 @@ import {
     useRef,
 } from 'react';
 
-export type Props = {
+/**
+ * Every aria-* attribute (and role) is forwarded as-is to the underlying
+ * input, not to the wrapping <label>, so the input is annotated directly. An
+ * aria-label passed here names the input and takes precedence over the name
+ * it would otherwise get from props.label or props.title.
+ */
+export type Props = AriaAttributes & {
     /**
      * Boolean indicating if the user can submit an empty value (i.e. clear
      * the value). Defaults to true.
@@ -52,6 +60,7 @@ export type Props = {
     onSubmitValue: (value: string) => unknown;
     placeholder?: string;
     ref?: Ref<HTMLInputElement>;
+    role?: AriaRole;
     step?: number;
     tabIndex?: number;
     title?: string;
@@ -88,6 +97,7 @@ export default function CSSValueInput({
     unit = DEFAULT_UNIT_BY_CSS_VALUE_TYPE[cssValueType],
     validator,
     value: valueFromProps,
+    ...restProps
 }: Props) {
     // props.value should be a string; if it’s a number, convert it here
     const value =
@@ -262,6 +272,7 @@ export default function CSSValueInput({
             ) : null}
             <div className={`${ROOT_CLASS_NAME}-value`}>
                 <InputText
+                    {...restProps}
                     disabled={disabled}
                     discardOnEscape
                     initialValue={value}

--- a/packages/css-value-input/src/CSSValueInput.tsx
+++ b/packages/css-value-input/src/CSSValueInput.tsx
@@ -24,9 +24,8 @@ import {
 
 /**
  * Every aria-* attribute (and role) is forwarded as-is to the underlying
- * input, not to the wrapping <label>, so the input is annotated directly. An
- * aria-label passed here names the input and takes precedence over the name
- * it would otherwise get from props.label or props.title.
+ * input. An aria-label passed here names the input and takes precedence over
+ * the name it would otherwise get from props.label or props.title.
  */
 export type Props = AriaAttributes & {
     /**

--- a/packages/docs/stories/CSSValueInput.css
+++ b/packages/docs/stories/CSSValueInput.css
@@ -36,3 +36,11 @@
     font-size: 13px;
     line-height: 13px;
 }
+
+.cssvalueinput-hint {
+    color: rgb(90, 90, 90);
+    font-family: system-ui, sans-serif;
+    font-size: 12px;
+    margin: 4px 0 0;
+    max-width: 260px;
+}

--- a/packages/docs/stories/CSSValueInput.stories.tsx
+++ b/packages/docs/stories/CSSValueInput.stories.tsx
@@ -110,6 +110,36 @@ export const LabelLess: Story = {
     },
 };
 
+export const LabelLessWithAriaLabel: Story = {
+    args: {
+        'aria-describedby': 'letter-spacing-hint',
+        'aria-label': 'Letter spacing',
+        className: 'my-special-input',
+        cssValueType: 'length',
+        name: 'labelless-aria-label',
+        placeholder: '0',
+        unit: 'em',
+        value: '0.05em',
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `props.label` the visible label text names the input, which is what the labelled stories above rely on. Without one, `aria-label` names it directly — clearer than leaning on `props.title`, which doubles as the tooltip. `aria-describedby` attaches help text alongside that name. Both land on the input itself rather than the wrapping `<label>`.',
+            },
+        },
+    },
+    render(args) {
+        return (
+            <div>
+                <CSSValueInput {...args} />
+                <p className="cssvalueinput-hint" id="letter-spacing-hint">
+                    Tracking added to each character. Use ↑/↓ to adjust.
+                </p>
+            </div>
+        );
+    },
+};
+
 export const CustomGetValueAsNumber: Story = {
     args: {
         className: 'letter-spacing',

--- a/packages/docs/stories/InputText.css
+++ b/packages/docs/stories/InputText.css
@@ -50,3 +50,30 @@
     padding: 25px 30px;
     border-radius: 5px;
 }
+
+.input-text-field {
+    display: flex;
+    flex-direction: column;
+    font-family: system-ui, sans-serif;
+    gap: 4px;
+    max-width: 260px;
+}
+
+.input-text-label {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.input-text-hint,
+.input-text-error {
+    font-size: 12px;
+    margin: 0;
+}
+
+.input-text-hint {
+    color: rgb(90, 90, 90);
+}
+
+.input-text-error {
+    color: rgb(180, 30, 30);
+}

--- a/packages/docs/stories/InputText.stories.tsx
+++ b/packages/docs/stories/InputText.stories.tsx
@@ -87,8 +87,6 @@ const SUBMIT_ON_ENTER_PROPS = {
     submitOnEnter: true,
 };
 
-const MIN_PASSPHRASE_LENGTH = 8;
-
 const formatDate = new Intl.DateTimeFormat(undefined, {
     timeStyle: 'medium',
 }).format;
@@ -410,6 +408,8 @@ export const InputWithAriaLabel: Story = {
         },
     },
 };
+
+const MIN_PASSPHRASE_LENGTH = 8;
 
 export const InputWithHintAndValidationState: Story = {
     args: {

--- a/packages/docs/stories/InputText.stories.tsx
+++ b/packages/docs/stories/InputText.stories.tsx
@@ -36,6 +36,7 @@ type Story = StoryObj<typeof InputText>;
 
 export const EmptyInput: Story = {
     args: {
+        'aria-label': 'Text',
         className: 'input-text',
         name: 'empty',
         placeholder: 'enter text here…',
@@ -44,6 +45,7 @@ export const EmptyInput: Story = {
 
 export const InputWithInitialValue: Story = {
     args: {
+        'aria-label': 'Country',
         className: 'input-text',
         initialValue: 'Bolivia',
         placeholder: 'enter country name',
@@ -52,6 +54,7 @@ export const InputWithInitialValue: Story = {
 
 export const InputWithInitialValueAndSelectTextOnFocus: Story = {
     args: {
+        'aria-label': 'Country',
         className: 'input-text',
         initialValue: 'Bolivia',
         name: 'country',
@@ -62,6 +65,7 @@ export const InputWithInitialValueAndSelectTextOnFocus: Story = {
 
 export const MultiLineInputWithInitialValueAndSelectTextOnFocus: Story = {
     args: {
+        'aria-label': 'Long text',
         className: 'multi-line-input-text',
         initialValue:
             'The Black Hawk War, or, How to Demolish an Entire Civilization and Still Feel Good About Yourself in the Morning, or, We Apologize for the Inconvenience but You’re Going to Have to Leave Now, or, “I have fought the Big Knives and will continue to fight them until they are off our lands!”',
@@ -74,6 +78,7 @@ export const MultiLineInputWithInitialValueAndSelectTextOnFocus: Story = {
 };
 
 const SUBMIT_ON_ENTER_PROPS = {
+    'aria-label': 'Message',
     className: 'multi-line-input-text',
     maxHeight: 600,
     multiLine: true,
@@ -81,6 +86,8 @@ const SUBMIT_ON_ENTER_PROPS = {
     placeholder: 'enter text of any length',
     submitOnEnter: true,
 };
+
+const MIN_PASSPHRASE_LENGTH = 8;
 
 const formatDate = new Intl.DateTimeFormat(undefined, {
     timeStyle: 'medium',
@@ -165,6 +172,7 @@ function ChatLikeInputDemo(props: ComponentProps<typeof InputText>) {
 
 export const ChatLikeInputWithSubmitOnEnter: Story = {
     args: {
+        'aria-label': 'Message',
         className: 'input-text',
         keepFocusOnSubmit: true,
         placeholder: 'Type then press Enter',
@@ -176,6 +184,7 @@ export const ChatLikeInputWithSubmitOnEnter: Story = {
 };
 
 const DOUBLE_CLICK_TO_EDIT_PROPS = {
+    'aria-label': 'Title',
     className: 'input-text-double-click-to-edit',
     doubleClickToEdit: true,
     initialValue: 'Lorem ipsum dolor sit amet',
@@ -187,6 +196,7 @@ export const InputWithDoubleClickToEdit: Story = {
 };
 
 const DISCARD_ON_ESCAPE_PROPS = {
+    'aria-label': 'Title',
     className: 'input-text',
     discardOnEscape: true,
     initialValue: 'Lorem ipsum',
@@ -207,6 +217,7 @@ export const InputWithDoubleClickToEditAndDiscardOnEscape: Story = {
 
 const MULTI_LINE_INPUT_WITH_SUBMIT_ON_ENTER_AND_DOUBLE_CLICK_TO_EDIT_PROPS = {
     ...SUBMIT_ON_ENTER_PROPS,
+    'aria-label': 'Note',
     className: 'multi-line-input-double-click-to-edit',
     discardOnEscape: true,
     doubleClickToEdit: true,
@@ -238,6 +249,7 @@ export const MultiLineInputWithSubmitOnEnterAndDoubleClickToEditAndDiscardOnEsca
 
 export const InputWithAutoFocus: Story = {
     args: {
+        'aria-label': 'Autofocused text',
         autoFocus: true,
         name: 'autofocus-input',
     },
@@ -245,6 +257,7 @@ export const InputWithAutoFocus: Story = {
 
 export const MultiLineInputWithMinHeight: Story = {
     args: {
+        'aria-label': 'Notes',
         className: 'multi-line-input-text',
         initialValue:
             'This textarea has a minHeight of 50px.\n\nTry deleting this text to see that the textarea does not shrink below the minimum height.',
@@ -257,6 +270,7 @@ export const MultiLineInputWithMinHeight: Story = {
 
 export const MultiLineInputWithMaxHeight: Story = {
     args: {
+        'aria-label': 'Notes',
         className: 'multi-line-input-text',
         initialValue:
             'This textarea has a maxHeight of 150px.\n\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10',
@@ -269,6 +283,7 @@ export const MultiLineInputWithMaxHeight: Story = {
 
 export const MultiLineInputWithMinHeightAndMaxHeight: Story = {
     args: {
+        'aria-label': 'Notes',
         className: 'multi-line-input-text',
         initialValue: 'This textarea has minHeight of 100px and maxHeight of 200px.',
         maxHeight: 200,
@@ -281,6 +296,7 @@ export const MultiLineInputWithMinHeightAndMaxHeight: Story = {
 
 export const MultiLineInputWithCSSTransition: Story = {
     args: {
+        'aria-label': 'Quick note',
         className: 'multi-line-input-css-transition',
         multiLine: true,
         name: 'multi-line-input-css-transition',
@@ -290,6 +306,7 @@ export const MultiLineInputWithCSSTransition: Story = {
 };
 
 const MULTI_LINE_INPUT_IN_POPOVER_PROPS = {
+    'aria-label': 'Note',
     className: 'multi-line-input-text',
     initialValue:
         'This multi-line input should resize to fit its contents when the popover opens even though it initializes with display: none as a result of being inside a hidden popover element so it doesn’t have any dimensions when the component initially renders.',
@@ -317,6 +334,7 @@ export const MultiLineInputInPopover: Story = {
 };
 
 const MULTI_LINE_INPUT_WITH_AUTO_FOCUS_PROPS = {
+    'aria-label': 'Note',
     autoFocus: true,
     initialValue: 'This multi-line input should be focused when the popover opens',
     multiLine: true,
@@ -340,6 +358,104 @@ export const MultiLineInputWithAutoFocusInPopover: Story = {
                     <InputText {...args} />
                 </div>
             </>
+        );
+    },
+};
+
+// A form control needs an accessible name, and a placeholder isn’t one: it
+// disappears as soon as the field has a value, and screen readers don’t treat
+// it as a label. Every aria-* attribute is forwarded to the underlying
+// <input>/<textarea>, so the component can be named and annotated exactly like
+// the native element.
+
+export const InputWithVisibleLabel: Story = {
+    args: {
+        className: 'input-text',
+        id: 'labelled-city-input',
+        name: 'city',
+        placeholder: 'e.g. Montréal',
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'A visible `<label>` tied to the input with `htmlFor`/`id` is the best option: it names the input for assistive tech, and clicking it focuses the input. Prefer this over `aria-label` whenever there is room for a label.',
+            },
+        },
+    },
+    render(args) {
+        return (
+            <div className="input-text-field">
+                <label className="input-text-label" htmlFor={args.id}>
+                    City
+                </label>
+                <InputText {...args} />
+            </div>
+        );
+    },
+};
+
+export const InputWithAriaLabel: Story = {
+    args: {
+        'aria-label': 'Search',
+        className: 'input-text',
+        name: 'search',
+        placeholder: 'Search…',
+        type: 'search',
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'When a visible label doesn’t fit — a search field in a toolbar, an input beside an icon — `aria-label` names the input instead. It is a fallback for that case, not a replacement for a visible label.',
+            },
+        },
+    },
+};
+
+export const InputWithHintAndValidationState: Story = {
+    args: {
+        className: 'input-text',
+        id: 'passphrase-input',
+        name: 'passphrase',
+        required: true,
+        type: 'password',
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: '`aria-describedby` points at help text so it’s announced along with the label, and `aria-invalid` marks the value as failing validation. The error message is referenced too, and given `role="alert"` so it’s announced when it appears.',
+            },
+        },
+    },
+    render(args) {
+        const [value, setValue] = useState('');
+        const isInvalid = value.length > 0 && value.length < MIN_PASSPHRASE_LENGTH;
+
+        return (
+            <div className="input-text-field">
+                <label className="input-text-label" htmlFor={args.id}>
+                    Passphrase
+                </label>
+                <InputText
+                    {...args}
+                    aria-describedby={
+                        isInvalid ? 'passphrase-hint passphrase-error' : 'passphrase-hint'
+                    }
+                    aria-invalid={isInvalid || undefined}
+                    onChangeValue={(nextValue) => {
+                        args.onChangeValue?.(nextValue);
+                        setValue(nextValue);
+                    }}
+                />
+                <p className="input-text-hint" id="passphrase-hint">
+                    Use at least {MIN_PASSPHRASE_LENGTH} characters.
+                </p>
+                {isInvalid ? (
+                    <p className="input-text-error" id="passphrase-error" role="alert">
+                        {MIN_PASSPHRASE_LENGTH - value.length} more character
+                        {MIN_PASSPHRASE_LENGTH - value.length === 1 ? '' : 's'} to go.
+                    </p>
+                ) : null}
+            </div>
         );
     },
 };

--- a/packages/input-text/README.md
+++ b/packages/input-text/README.md
@@ -79,8 +79,16 @@ function SelectOnFocusInput() {
 
 ### InputText Component
 
+Every `aria-*` attribute and `role` is also accepted and forwarded as-is to
+the underlying `<input>`/`<textarea>`, so the component can be labelled and
+annotated exactly like the native element:
+
 ```tsx
-type Props = {
+<InputText aria-label="City" aria-describedby="city-hint" />
+```
+
+```tsx
+type Props = AriaAttributes & {
     /** Controls text capitalization behavior */
     autoCapitalize?: 'none' | 'off' | 'sentences' | 'words' | 'characters';
 
@@ -190,6 +198,9 @@ type Props = {
 
     /** Whether the input is required for form submission */
     required?: boolean;
+
+    /** ARIA role for the underlying input element */
+    role?: AriaRole;
 
     /** Initial number of rows for multi-line inputs */
     rows?: number;

--- a/packages/input-text/README.md
+++ b/packages/input-text/README.md
@@ -80,8 +80,7 @@ function SelectOnFocusInput() {
 ### InputText Component
 
 Every `aria-*` attribute and `role` is also accepted and forwarded as-is to
-the underlying `<input>`/`<textarea>`, so the component can be labelled and
-annotated exactly like the native element:
+the underlying `<input>`/`<textarea>`:
 
 ```tsx
 <InputText aria-label="City" aria-describedby="city-hint" />

--- a/packages/input-text/src/InputText.test.tsx
+++ b/packages/input-text/src/InputText.test.tsx
@@ -19,7 +19,7 @@ vi.unstubAllGlobals();
 
 afterEach(cleanup);
 
-describe('CSSValueInput.tsx', () => {
+describe('InputText.tsx', () => {
     it('renders a text input with the given props.initialValue', () => {
         render(<InputText initialValue="foo Bar" />);
         const input = screen.getByRole('textbox') as HTMLInputElement;

--- a/packages/input-text/src/InputText.test.tsx
+++ b/packages/input-text/src/InputText.test.tsx
@@ -409,4 +409,38 @@ describe('CSSValueInput.tsx', () => {
         expect(height).toBeGreaterThanOrEqual(50);
         expect(height).toBeLessThanOrEqual(100);
     });
+
+    it('forwards aria-* attributes and role to the input', () => {
+        render(
+            <InputText
+                aria-controls="listbox-id"
+                aria-expanded={false}
+                aria-label="City"
+                initialValue="Toronto"
+                role="combobox"
+            />,
+        );
+        const input = screen.getByRole('combobox');
+        expect(input.tagName).toBe('INPUT');
+        expect(input.getAttribute('aria-label')).toBe('City');
+        expect(input.getAttribute('aria-controls')).toBe('listbox-id');
+        expect(input.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('forwards aria-* attributes to the textarea when multiLine', () => {
+        render(<InputText aria-describedby="hint-id" aria-label="Notes" multiLine />);
+        const textarea = screen.getByRole('textbox');
+        expect(textarea.tagName).toBe('TEXTAREA');
+        expect(textarea.getAttribute('aria-label')).toBe('Notes');
+        expect(textarea.getAttribute('aria-describedby')).toBe('hint-id');
+    });
+
+    it('doesn’t let forwarded props override the props the component owns', () => {
+        // aria-readonly is forwarded, but readOnly itself stays under the
+        // component’s control (doubleClickToEdit renders readonly to start)
+        render(<InputText aria-readonly="false" doubleClickToEdit />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.getAttribute('aria-readonly')).toBe('false');
+        expect(input.readOnly).toBe(true);
+    });
 });

--- a/packages/input-text/src/InputText.test.tsx
+++ b/packages/input-text/src/InputText.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { Props } from './InputText.js';
+
 // Stub CSS.supports to return false for field-sizing to test fallback behavior
 vi.stubGlobal('CSS', {
     supports: (property: string, value: string) => {
@@ -435,12 +437,18 @@ describe('InputText.tsx', () => {
         expect(textarea.getAttribute('aria-describedby')).toBe('hint-id');
     });
 
-    it('doesn’t let forwarded props override the props the component owns', () => {
-        // aria-readonly is forwarded, but readOnly itself stays under the
-        // component’s control (doubleClickToEdit renders readonly to start)
-        render(<InputText aria-readonly="false" doubleClickToEdit />);
+    it('doesn’t let a forwarded prop override the props the component owns', async () => {
+        const user = userEvent.setup();
+        // Props models no prop that collides, but an untyped consumer can pass
+        // one anyway. The rest is spread first, so the component’s own props
+        // win: doubleClickToEdit’s handler survives a consumer’s onDoubleClick
+        // (which is dropped) rather than being replaced by it.
+        const onDoubleClick = vi.fn<() => void>();
+        render(<InputText {...({ onDoubleClick } as Props)} doubleClickToEdit />);
         const input = screen.getByRole('textbox') as HTMLInputElement;
-        expect(input.getAttribute('aria-readonly')).toBe('false');
         expect(input.readOnly).toBe(true);
+        await user.dblClick(input);
+        expect(input.readOnly).toBe(false);
+        expect(onDoubleClick).not.toHaveBeenCalled();
     });
 });

--- a/packages/input-text/src/InputText.tsx
+++ b/packages/input-text/src/InputText.tsx
@@ -18,9 +18,9 @@ export type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 /**
  * Every aria-* attribute (and role) is forwarded as-is to the underlying
- * <input>/<textarea>, so the component can be labelled and annotated the same
- * way the native element is — including by a parent that clones it to inject
- * combobox semantics, e.g. @acusti/dropdown’s custom trigger.
+ * <input>/<textarea>, so the component can be labelled and annotated,
+ * including by a parent that clones it to inject combobox semantics, e.g.
+ * @acusti/dropdown’s custom trigger.
  */
 export type Props = AriaAttributes & {
     autoCapitalize?: 'characters' | 'none' | 'off' | 'sentences' | 'words';

--- a/packages/input-text/src/InputText.tsx
+++ b/packages/input-text/src/InputText.tsx
@@ -1,4 +1,6 @@
 import {
+    type AriaAttributes,
+    type AriaRole,
     type ChangeEvent,
     type ClipboardEvent,
     type CSSProperties,
@@ -14,7 +16,13 @@ import {
 
 export type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
-export type Props = {
+/**
+ * Every aria-* attribute (and role) is forwarded as-is to the underlying
+ * <input>/<textarea>, so the component can be labelled and annotated the same
+ * way the native element is — including by a parent that clones it to inject
+ * combobox semantics, e.g. @acusti/dropdown’s custom trigger.
+ */
+export type Props = AriaAttributes & {
     autoCapitalize?: 'characters' | 'none' | 'off' | 'sentences' | 'words';
     autoComplete?: HTMLInputElement['autocomplete'];
     autoFocus?: boolean;
@@ -75,6 +83,7 @@ export type Props = {
     readOnly?: boolean;
     ref?: Ref<HTMLInputElement>;
     required?: boolean;
+    role?: AriaRole;
     rows?: number;
     /** If true, the contents of the input are selected when it’s focused. */
     selectTextOnFocus?: boolean;
@@ -138,6 +147,7 @@ export default function InputText({
     tabIndex,
     title,
     type = 'text',
+    ...restProps
 }: Props) {
     const inputRef = useRef<InputRef>(null);
     const valueFromProps = initialValue ?? '';
@@ -344,6 +354,7 @@ export default function InputText({
 
     return (
         <Element
+            {...restProps}
             autoCapitalize={autoCapitalize}
             autoComplete={autoComplete}
             autoFocus={autoFocus} // eslint-disable-line jsx-a11y/no-autofocus


### PR DESCRIPTION
Neither component’s `Props` included any of the ARIA attributes, so an `aria-label` or `aria-describedby` was both a type error and silently dropped. `InputText` could only be named by a wrapping `<label>`, and it couldn’t take the combobox semantics `@acusti/dropdown` injects when it clones a custom trigger (`role`, `aria-expanded`, `aria-controls`, `aria-autocomplete`). `CSSValueInput` had no way to annotate its input at all, and its only accessible name came from `label` or the `aria-label` it derives from `title` for the icon-only case — neither overridable by the consumer.

Both `Props` types now intersect React’s `AriaAttributes` and add `role`, and whatever the component doesn’t destructure is spread onto the element.

### Approach

Intersecting `AriaAttributes` rather than hand-enumerating the attributes or extending `InputHTMLAttributes`:

- Hand-enumerating means ~50 attributes to write out and keep in sync with the ARIA spec, for nothing React’s type doesn’t already give.
- An open spread over `InputHTMLAttributes` would let a consumer pass `value`, `defaultValue`, `onInput`, or `onSelect` and quietly break `InputText`’s semi-controlled behavior — `defaultValue` fights `initialValue`, `onInput` clobbers the multiLine resize handler, `onSelect` kills `selectTextOnFocus`. The curated prop list is deliberate.

`AriaAttributes` gets both: nothing to maintain, and the prop type stays closed — props the components don’t model remain type errors instead of passing through.

`role` is included alongside the aria attributes because `Dropdown` injects it on a cloned trigger (`Dropdown.tsx:1453`); without it, an `InputText` trigger would get `aria-expanded` and not the role that makes it valid on a text input.

### Placement

- **`InputText`** — the spread comes first in the JSX, so the props the component owns (`readOnly` under `doubleClickToEdit`, `defaultValue`, its wrapped handlers) always win. No collision exists today, since the rest is only `aria-*` and `role`, but a test pins the invariant.
- **`CSSValueInput`** — the spread lands on the nested `InputText`, not the wrapping `<label>`, so the annotations reach the element carrying the `textbox` role. The wrapper’s existing `aria-label={label ? undefined : title}` is left alone: accessible-name precedence already puts a consumer’s `aria-label` on the input ahead of any name derived from the wrapping label, and a test covers that (`aria-label="Width"` wins over both `label="W"` and `title="Element width"`).

### Testing

Five tests added — forwarding to `input` and to `textarea` under `multiLine`, the ownership guard, forwarding to the input rather than the wrapper, and the naming precedence. Full repo: 395 tests pass, `lint` / `tsc` / `format:check` clean.

READMEs updated and a minor changeset added for each package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2mNX6d9jrshUKLugpsuWz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2mNX6d9jrshUKLugpsuWz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

