### PR TITLE
Type InputText’s props.ref as the element it actually renders

### DIFF
--- a/.changeset/input-text-ref-element-type.md
+++ b/.changeset/input-text-ref-element-type.md
@@ -1,0 +1,17 @@
+---
+'@acusti/input-text': patch
+---
+
+Type props.ref as the element the component actually renders
+
+`props.ref` promised an `HTMLInputElement`, but under `multiLine` the
+component renders a `<textarea>` and the ref receives an
+`HTMLTextAreaElement`. Anything reading an input-only API off the ref was
+unsound in multi-line mode, and the README’s own chat example passes a ref
+to a `multiLine` input.
+
+`props.ref` and the internal ref type are now `InputElement`, the union
+this package already exports and uses for its event handler types. Existing
+refs keep working: a narrowly typed object ref stays assignable, and so
+does a narrowly typed callback ref, since React declares `RefCallback` with
+the bivariance hack.

--- a/.changeset/input-text-ref-element-type.md
+++ b/.changeset/input-text-ref-element-type.md
@@ -10,8 +10,8 @@ component renders a `<textarea>` and the ref receives an
 unsound in multi-line mode, and the README’s own chat example passes a ref
 to a `multiLine` input.
 
-`props.ref` and the internal ref type are now `InputElement`, the union
-this package already exports and uses for its event handler types. Existing
-refs keep working: a narrowly typed object ref stays assignable, and so
-does a narrowly typed callback ref, since React declares `RefCallback` with
-the bivariance hack.
+Updated `props.ref` and the internal ref type from `HTMLInputElement` to
+`InputElement`, the union of `<input>` and `<textarea>` this package
+already exports and uses for its event handler types. Existing refs keep
+working: a narrowly typed object ref stays assignable, and so does a
+narrowly typed callback ref.

--- a/packages/input-text/src/InputText.test.tsx
+++ b/packages/input-text/src/InputText.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Props } from './InputText.js';
@@ -427,6 +428,19 @@ describe('InputText.tsx', () => {
         expect(input.getAttribute('aria-label')).toBe('City');
         expect(input.getAttribute('aria-controls')).toBe('listbox-id');
         expect(input.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('gives the forwarded ref the element it renders', () => {
+        // Typing the ref as the textarea only compiles because props.ref takes
+        // InputElement, so this covers the prop type as well as the behavior
+        const textareaRef = createRef<HTMLTextAreaElement>();
+        render(<InputText multiLine ref={textareaRef} />);
+        expect(textareaRef.current?.tagName).toBe('TEXTAREA');
+
+        // …and a narrowly typed input ref still works for the single-line case
+        const inputRef = createRef<HTMLInputElement>();
+        render(<InputText ref={inputRef} />);
+        expect(inputRef.current?.tagName).toBe('INPUT');
     });
 
     it('forwards aria-* attributes to the textarea when multiLine', () => {

--- a/packages/input-text/src/InputText.tsx
+++ b/packages/input-text/src/InputText.tsx
@@ -81,7 +81,7 @@ export type Props = AriaAttributes & {
     pattern?: string;
     placeholder?: string;
     readOnly?: boolean;
-    ref?: Ref<HTMLInputElement>;
+    ref?: Ref<InputElement>;
     required?: boolean;
     role?: AriaRole;
     rows?: number;
@@ -101,7 +101,7 @@ export type Props = AriaAttributes & {
     type?: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 };
 
-type InputRef = HTMLInputElement | null;
+type InputRef = InputElement | null;
 
 export default function InputText({
     autoCapitalize,


### PR DESCRIPTION
Follow-up to the `ref` typing raised on #436 and deferred there as pre-existing and out of scope.

`props.ref` promised an `HTMLInputElement`, but under `multiLine` the component renders a `<textarea>`, so the ref receives an `HTMLTextAreaElement`. Any consumer reaching for an input-only API off that ref was unsound in multi-line mode — including the README's own chat example, which passes a ref to a `multiLine` input.

```diff
-    ref?: Ref<HTMLInputElement>;
+    ref?: Ref<InputElement>;

-type InputRef = HTMLInputElement | null;
+type InputRef = InputElement | null;
```

`InputElement` is the `HTMLInputElement | HTMLTextAreaElement` union this package already exports and uses for its event-handler prop types, so this makes `ref` consistent with the rest of `Props` rather than introducing a new type.

### Compatibility

Widening is not a breaking change for existing consumers, in either ref form:

- **Object refs** — `RefObject<HTMLInputElement | null>` stays assignable, since TypeScript checks object properties covariantly.
- **Callback refs** — the case worth checking, because under `strictFunctionTypes` a `(el: HTMLInputElement | null) => void` should stop being assignable to a widened `Ref`. It doesn't: React declares `RefCallback` with the bivariance hack. Confirmed by compiling both ref forms against the widened signature under `--strict`.

`CSSValueInput` needs no change — it never sets `multiLine`, so its own `Ref<HTMLInputElement>` is accurate, and it still passes through to the widened prop.

The alternative of making `ref` conditional on `multiLine` via a discriminated union would be more precise, but it complicates every consumer that holds a ref without knowing the mode. Not worth it over the widening.

### Testing

One test added. It types its ref as `HTMLTextAreaElement` — which only compiles under the widened prop — so it guards the type as well as the runtime behavior, and asserts a narrowly typed `HTMLInputElement` ref still works for the single-line case. Verified as a real guard: reverting `props.ref` to `Ref<HTMLInputElement>` fails the build with `TS2322` on that line.

Full repo: 396 tests pass, `build` / `tsc` / `lint` / `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2mNX6d9jrshUKLugpsuWz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2mNX6d9jrshUKLugpsuWz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

