### PR TITLE
Run tests with the React Compiler applied

### DIFF
--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { Activity, useState } from 'react';
+import { Activity, Profiler, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Dropdown, { Menubar } from './Dropdown.js';
@@ -428,6 +428,47 @@ describe('@acusti/dropdown Menubar', () => {
                         .getAttribute('tabindex'),
                 ).toBe('0');
             });
+        });
+
+        it('does not re-render the bar for re-registrations that leave the tab stop alone', async () => {
+            const user = userEvent.setup();
+            // Members re-register on every render, so bumping the reducer on
+            // every cleanup cost the bar a wasted render each time. Three
+            // open/close cycles below: 19 commits bumping unconditionally, 9
+            // as it stands. The gap only shows compiled (see vitest.config.js);
+            // uncompiled it’s 19 vs 18.
+            let commits = 0;
+            render(
+                <Profiler
+                    id="menubar"
+                    onRender={() => {
+                        commits += 1;
+                    }}
+                >
+                    <Menubar>
+                        <Dropdown>
+                            File
+                            <ul>
+                                <li data-ukt-item>New</li>
+                            </ul>
+                        </Dropdown>
+                        <Dropdown>
+                            Edit
+                            <ul>
+                                <li data-ukt-item>Undo</li>
+                            </ul>
+                        </Dropdown>
+                    </Menubar>
+                </Profiler>,
+            );
+
+            const afterMount = commits;
+            for (let index = 0; index < 3; index++) {
+                await user.click(screen.getByRole('menuitem', { name: 'File' }));
+                await user.keyboard('{Escape}');
+            }
+
+            expect(commits - afterMount).toBeLessThanOrEqual(12);
         });
     });
 

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -465,7 +465,11 @@ describe('@acusti/dropdown Menubar', () => {
             const afterMount = commits;
             for (let index = 0; index < 3; index++) {
                 await user.click(screen.getByRole('menuitem', { name: 'File' }));
+                // the count only means anything if each cycle really opened
+                // and closed the menu
+                expect(screen.getByRole('menu')).toBeTruthy();
                 await user.keyboard('{Escape}');
+                expect(screen.queryByRole('menu')).toBeNull();
             }
 
             expect(commits - afterMount).toBeLessThanOrEqual(12);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,8 +1,11 @@
-import { configDefaults, defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        exclude: [...configDefaults.exclude, '**/dist/**'],
-        setupFiles: ['./vitest.setup.js'],
+        // Run each package's tests through its own build config, so code is
+        // tested as it ships: compiled by the React Compiler for the packages
+        // that build with it, uncompiled for the one that opts out. The root
+        // config used to carry no react plugin, so nothing was compiled.
+        projects: ['packages/*/vite.config.js'],
     },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,10 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        // Run each package's tests through its own build config, so code is
-        // tested as it ships: compiled by the React Compiler for the packages
-        // that build with it, uncompiled for the one that opts out. The root
-        // config used to carry no react plugin, so nothing was compiled.
+        // run each package’s tests through its own build config, so code is
+        // tested as it ships
         projects: ['packages/*/vite.config.js'],
     },
 });


### PR DESCRIPTION
The root `vitest.config.js` carried no react plugin, so `bun run test` — what CI runs — exercised every package uncompiled, while every package ships compiled by the React Compiler.

Pointing vitest at the per-package configs (`projects: ['packages/*/vite.config.js']`) tests each package the way it builds. That respects `use-is-out-of-bounds`'s deliberate `react: 'no-compiler'` opt-out, which a single global react plugin at the root could not.

Then it uses that: a `<Profiler>`-based test in `Menubar.test.tsx` counts the bar's commits over three open/close cycles, guarding the render-count fix from #434. The bound only separates the fixed and unfixed code when tests run compiled — 19 vs 9 compiled, 19 vs 18 uncompiled — so this guard wasn't writable before.

### Verification

- `bun run test` → 24 files, 399 tests passing (was 398 under the old config; same 24 files, so no coverage was lost in the switch).
- Red/green: reverting the `Menubar` cleanup to an unconditional `reconcile()` fails the new test at 19 > 12.
- The compiler is confirmed active under the new config — the same three cycles measure 9 commits here vs 18 under the old root config.
- `bun run build`, `lint`, `tsc`, `format` all clean.

No changeset: neither the root vitest config nor a test file ships in any published package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An3mqqrhHB7b7FCLt6muyK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

