### PR TITLE
Widen InputText's autoComplete to every token browsers honour

### DIFF
--- a/.changeset/input-text-autocomplete-any-token.md
+++ b/.changeset/input-text-autocomplete-any-token.md
@@ -1,0 +1,5 @@
+---
+'@acusti/input-text': patch
+---
+
+Accept every autocomplete token the browser does, like a plain `<input>`

--- a/.changeset/input-text-autocomplete-any-token.md
+++ b/.changeset/input-text-autocomplete-any-token.md
@@ -2,4 +2,4 @@
 '@acusti/input-text': patch
 ---
 
-Match React's `autoComplete` prop type, so every valid token is accepted
+Match React’s `autoComplete` prop type, so every valid token is accepted

--- a/.changeset/input-text-autocomplete-any-token.md
+++ b/.changeset/input-text-autocomplete-any-token.md
@@ -2,4 +2,4 @@
 '@acusti/input-text': patch
 ---
 
-Accept every autocomplete token the browser does, like a plain `<input>`
+Match React's `autoComplete` prop type, so every valid token is accepted

--- a/packages/input-text/README.md
+++ b/packages/input-text/README.md
@@ -92,7 +92,7 @@ type Props = AriaAttributes & {
     autoCapitalize?: 'none' | 'off' | 'sentences' | 'words' | 'characters';
 
     /** Browser autocomplete hint */
-    autoComplete?: HTMLInputElement['autocomplete'];
+    autoComplete?: HTMLInputAutoCompleteAttribute;
 
     /** Whether input should be focused on mount */
     autoFocus?: boolean;

--- a/packages/input-text/src/InputText.tsx
+++ b/packages/input-text/src/InputText.tsx
@@ -5,6 +5,7 @@ import {
     type ClipboardEvent,
     type CSSProperties,
     type FocusEvent,
+    type HTMLInputAutoCompleteAttribute,
     type InputHTMLAttributes,
     type KeyboardEvent,
     type Ref,
@@ -24,7 +25,7 @@ export type InputElement = HTMLInputElement | HTMLTextAreaElement;
  */
 export type Props = AriaAttributes & {
     autoCapitalize?: 'characters' | 'none' | 'off' | 'sentences' | 'words';
-    autoComplete?: HTMLInputElement['autocomplete'];
+    autoComplete?: HTMLInputAutoCompleteAttribute;
     autoFocus?: boolean;
     className?: string;
     disabled?: boolean;


### PR DESCRIPTION
`InputText` typed the prop as `HTMLInputElement['autocomplete']`, which resolves to `AutoFill` in `lib.dom.d.ts`. That union omits nine autofill tokens from the HTML spec:

`bday` · `cc-additional-name` · `impp` · `language` · `nickname` · `organization-title` · `photo` · `sex` · `url`

All nine are real tokens browsers honour. They compile fine on a bare `<input>` and failed on `InputText`:

```
error TS2322: Type '"url"' is not assignable to type 'AutoFill | undefined'.
```

Two of them (`autoComplete="url"`) appear in this package's own README examples, which therefore didn't typecheck.

React types the attribute as `AutoFill | (string & {})` — the idiom that accepts any string while still offering the union as editor suggestions. Reusing React's own `HTMLInputAutoCompleteAttribute` matches the element `InputText` actually renders, so nothing is lost from IntelliSense and no valid usage is newly rejected.

### Verification

Probed all 47 spec field names before and after. Before: the nine above error. After: all compile, along with the existing forms — `off`, `username`, `email`, `shipping street-address`, `section-a billing cc-number webauthn`.

`bun run build`, `test` (398 passing), `lint`, `tsc`, `format` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An3mqqrhHB7b7FCLt6muyK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

