### PR TITLE
Step from a numeric placeholder in CSSValueInput

### DIFF
--- a/.changeset/css-value-input-step-from-placeholder.md
+++ b/.changeset/css-value-input-step-from-placeholder.md
@@ -1,0 +1,6 @@
+---
+'@acusti/css-value-input': minor
+---
+
+Hitting ↑/↓ keys on an empty input with a numeric placeholder sets the
+value from that placeholder, preserving the unit if present

--- a/packages/css-value-input/src/CSSValueInput.test.tsx
+++ b/packages/css-value-input/src/CSSValueInput.test.tsx
@@ -35,6 +35,22 @@ describe('CSSValueInput.tsx', () => {
         expect(input.value).toBe('77%');
     });
 
+    it('steps from a numeric props.placeholder when the input is empty', async () => {
+        const user = userEvent.setup();
+        render(
+            <CSSValueInput
+                allowEmpty
+                onSubmitValue={noop}
+                placeholder="100vw"
+                value=""
+            />,
+        );
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.value).toBe('');
+        await user.type(input, '{ArrowUp}');
+        expect(input.value).toBe('101vw');
+    });
+
     it('supports custom props.step for ↑/↓ key handling', async () => {
         const user = userEvent.setup();
         render(<CSSValueInput onSubmitValue={noop} step={0.1} value="2rem" />);

--- a/packages/css-value-input/src/CSSValueInput.tsx
+++ b/packages/css-value-input/src/CSSValueInput.tsx
@@ -232,7 +232,7 @@ export default function CSSValueInput({
         if (onKeyDown) onKeyDown(event);
         if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
 
-        const currentValue = input.value ?? placeholder ?? `0${unit}`;
+        const currentValue = input.value || (placeholder ?? `0${unit}`);
         const nextValue = getNextValue({
             currentValue,
             multiplier: event.shiftKey ? 10 : 1,


### PR DESCRIPTION
## Summary
- Fix `CSSValueInput`'s ArrowUp/ArrowDown handling so a numeric `placeholder` (e.g. `"100vw"`) is used as the starting value when the input is empty. Previously, hitting the arrow keys on an empty input did nothing at all: 
```ts
input.value ?? placeholder ?? `0${unit}`
```
never reached `placeholder` because an empty input’s `.value` is `''`, not `null`/`undefined`, so `currentValue` was `''`, which `getNextValue` treats as non-numeric and returns unchanged — the handler then bails out before ever updating the DOM.
- Non-numeric placeholders are unaffected — `getNextValue` already leaves the value unchanged when it can't be parsed as a number.

## Test plan
- [x] `bun run --filter '@acusti/css-value-input' test` — added a test asserting ArrowUp with `placeholder="100vw"` and an empty value produces `101vw`
- [x] `bun run build`
- [x] `bun run tsc`
- [x] `bun run lint`
- [x] `bun run format:check`
