### PR TITLE
Add inputMode prop to @acusti/input-text

### DIFF
--- a/.changeset/input-text-inputmode-prop.md
+++ b/.changeset/input-text-inputmode-prop.md
@@ -1,0 +1,5 @@
+---
+'@acusti/input-text': minor
+---
+
+Add `inputMode` prop to set the virtual keyboard’s input mode

--- a/packages/input-text/README.md
+++ b/packages/input-text/README.md
@@ -132,6 +132,17 @@ type Props = AriaAttributes & {
      */
     initialValue?: string;
 
+    /** Hint for virtual keyboard input mode */
+    inputMode?:
+        | 'none'
+        | 'text'
+        | 'decimal'
+        | 'numeric'
+        | 'tel'
+        | 'search'
+        | 'email'
+        | 'url';
+
     /** ID of a datalist element for autocomplete suggestions */
     list?: string;
 

--- a/packages/input-text/src/InputText.test.tsx
+++ b/packages/input-text/src/InputText.test.tsx
@@ -430,6 +430,16 @@ describe('InputText.tsx', () => {
         expect(input.getAttribute('aria-expanded')).toBe('false');
     });
 
+    it('forwards the inputMode prop to the input and to the textarea when multiLine', () => {
+        const { rerender } = render(<InputText inputMode="numeric" />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.inputMode).toBe('numeric');
+
+        rerender(<InputText inputMode="search" multiLine />);
+        const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        expect(textarea.inputMode).toBe('search');
+    });
+
     it('gives the forwarded ref the element it renders', () => {
         // Typing the ref as the textarea only compiles because props.ref takes
         // InputElement, so this covers the prop type as well as the behavior

--- a/packages/input-text/src/InputText.tsx
+++ b/packages/input-text/src/InputText.tsx
@@ -49,6 +49,7 @@ export type Props = AriaAttributes & {
      * any point, the new value will override the local state of the input.
      */
     initialValue?: string;
+    inputMode?: InputHTMLAttributes<HTMLInputElement>['inputMode'];
     /**
      * If true, pressing enter/return while submitOnEnter is enabled keeps
      * focus on the input instead of blurring.
@@ -116,6 +117,7 @@ export default function InputText({
     form,
     id,
     initialValue,
+    inputMode,
     keepFocusOnSubmit,
     list,
     max,
@@ -365,6 +367,7 @@ export default function InputText({
             enterKeyHint={enterKeyHint}
             form={form}
             id={id}
+            inputMode={inputMode}
             list={list}
             maxLength={maxLength}
             minLength={minLength}


### PR DESCRIPTION
## Summary
- Add `inputMode` prop to `@acusti/input-text`'s `Props`, typed via `InputHTMLAttributes<HTMLInputElement>['inputMode']`, and forward it to the rendered `<input>`/`<textarea>` element so consumers can hint the virtual keyboard (e.g. `numeric`, `decimal`, `search`).
- Document the new prop in the package README.
- Add a changeset (`minor` bump for `@acusti/input-text`).

## Test plan
- [x] `bun run --filter '@acusti/input-text' tsc`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run --filter '@acusti/input-text' test` (20 passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpFVcdf8wDTBxE8VppgQUu)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

