### PR TITLE
docs(vite-plugin-react-compiler): fix TypeScript handling claim

### DIFF
--- a/packages/vite-plugin-react-compiler/README.md
+++ b/packages/vite-plugin-react-compiler/README.md
@@ -38,8 +38,9 @@ This plugin is the compiler pass, decoupled from `@vitejs/plugin-react` so
 it can run under any of them: a `transform`-hook plugin that calls
 oxc-transform-react directly, with `enforce: 'pre'` (the position
 `@vitejs/plugin-react`’s own native pass occupies) and emits JSX untouched
-(`jsx: 'preserve'`), so whatever plugin is handling JSX/refresh/TypeScript
-downstream stays in charge of that.
+(`jsx: 'preserve'`), so whatever plugin is handling JSX/refresh downstream
+stays in charge of that. (oxc-transform-react strips TypeScript syntax
+itself, matching how the Babel path uses @babel/preset-typescript.)
 
 ## Usage
 


### PR DESCRIPTION
Follow-up to #445. A [review comment](https://github.com/acusti/uikit/pull/445#discussion_r3941138979) on that PR (caught by cubic after it merged) pointed out that the rewritten "Why this exists" section said the downstream plugin handles "JSX/refresh/TypeScript," but `oxc-transform-react` strips TypeScript syntax itself before the downstream transform ever runs — the downstream plugin only owns JSX/refresh. This restores the caveat that TS stripping matches how the Babel path uses `@babel/preset-typescript`, which the prior rewrite had dropped.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PQyJ9eL5E4opefRnL5nskX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQyJ9eL5E4opefRnL5nskX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQyJ9eL5E4opefRnL5nskX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

