### PR TITLE
feat(vite-plugin-svg-react): add an opt-in OXVG optimization pass

### DIFF
--- a/.changeset/lucky-pens-repeat.md
+++ b/.changeset/lucky-pens-repeat.md
@@ -1,0 +1,39 @@
+---
+'@acusti/vite-plugin-svg-react': minor
+---
+
+Add an opt-in `optimize` option that shrinks each SVG with
+[OXVG](https://github.com/noahbald/oxvg) — the Rust, SVGO-compatible SVG
+toolchain — before it’s converted to a component. This is the replacement
+for the SVGO pass SVGR offered. It’s off by default, and `@oxvg/napi` is an
+optional peer dependency, so nothing changes unless you opt in:
+
+```
+npm install --save-dev @oxvg/napi
+```
+
+```ts
+svgReact({ optimize: true });
+```
+
+`optimize: true` is the safe setting: it drops comments, metadata and
+editor cruft, and rewrites path data and colors more compactly, but it
+leaves every `id` and `class` exactly as you authored them, so app CSS,
+`getElementById`, and `aria-labelledby` that point into an SVG keep
+working. If you’d rather have the smaller output and don’t reference those
+ids from anywhere else, pass an OXVG config object instead of `true`; the
+README shows how.
+
+Two things to know before turning it on. Optimization runs on the raw SVG
+source, ahead of everything else, so the `svg` options and the components
+you get out are unaffected. But OXVG parses the file before this plugin
+does and is stricter about XML than this plugin is: an SVG with a doctype
+that declares entities (classic Illustrator 10–CS4 did this), an
+HTML-flavored entity like `&nbsp;`, or a valueless attribute
+(`<svg hidden>`) will now fail the build. Each failure names the file and
+the line, and each file still builds with `optimize` off; the README lists
+all three.
+
+A missing `@oxvg/napi`, or a config OXVG can’t read, fails when Vite
+resolves your config rather than partway through a build, and the message
+names the option instead of whichever SVG happened to load first.

--- a/bun.lock
+++ b/bun.lock
@@ -301,7 +301,7 @@
     },
     "packages/vite-plugin-react-compiler": {
       "name": "@acusti/vite-plugin-react-compiler",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "oxc-transform-react": "0.148.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -319,6 +319,7 @@
       "name": "@acusti/vite-plugin-svg-react",
       "version": "0.2.0",
       "devDependencies": {
+        "@oxvg/napi": "^0.0.7",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
@@ -755,6 +756,24 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.81.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-ksqPP5jbFXcYreEQ7zdJh06rJQBymCTyGRCdaXjfcf2aG4f8KxUWY5wcgYHmaTK+FJ4bPG5sUAdOX+6trnH1JA=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.81.0", "", { "os": "win32", "cpu": "x64" }, "sha512-IZuUCwGw9emG5JtCp+fYGB+Z4OWEoeEcM8R5BA1pYw63/ieYFVdcU2ylxTpHbVHSenZnsYE+ZZ20uHAJszQ4cA=="],
+
+    "@oxvg/napi": ["@oxvg/napi@0.0.7", "", { "optionalDependencies": { "@oxvg/napi-darwin-arm64": "0.0.7", "@oxvg/napi-darwin-x64": "0.0.7", "@oxvg/napi-linux-arm64-gnu": "0.0.7", "@oxvg/napi-linux-arm64-musl": "0.0.7", "@oxvg/napi-linux-x64-gnu": "0.0.7", "@oxvg/napi-linux-x64-musl": "0.0.7", "@oxvg/napi-win32-arm64-msvc": "0.0.7", "@oxvg/napi-win32-x64-msvc": "0.0.7" } }, "sha512-yqqemUhCCBGVfbqTjPmMXhXaKLkdXxEf4MLFaZPa00edfKP965CHHrPwggc6/KuusjQ9+zcA09mFE3nUEyt0dA=="],
+
+    "@oxvg/napi-darwin-arm64": ["@oxvg/napi-darwin-arm64@0.0.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wB1sMzdR0tDHv0+oqBgCFp1A+hbwgul9ZmOJBIVgcamJAwa7kAeNli4HYlZtUASmbZIZpc6ERmIXz5N2Siukyg=="],
+
+    "@oxvg/napi-darwin-x64": ["@oxvg/napi-darwin-x64@0.0.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-oDgkpExxzn12xAQEQzU58OMUXPh88+mj4lMocxluSaNX8sx7zDBV8LMVjpUDJxxGFko4TSSj5VtdC4f62XueFw=="],
+
+    "@oxvg/napi-linux-arm64-gnu": ["@oxvg/napi-linux-arm64-gnu@0.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-G5rjAsdTpBXJdXof3+G0h8udO3oV5UHRkV+B5goBG4r4N599A+AtJvmxRs5N75lDUuPY8W8WY+ZT5Nqr+RJf2A=="],
+
+    "@oxvg/napi-linux-arm64-musl": ["@oxvg/napi-linux-arm64-musl@0.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-T1NOQjnoGjE9q6bOjFyfUoHjcJEMjwLq71p51Rx802WWp89AnJB1ahuhSSbwwZ/FbaWZ/Bnu9PCnhMUs4J6mkQ=="],
+
+    "@oxvg/napi-linux-x64-gnu": ["@oxvg/napi-linux-x64-gnu@0.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-FDHlb6Ss8jPREoAk4sdprcnlBJcKz5N30CxLdOyKbOUC7nkodmnhKRyUseP1SuQofElsxGZUq9CPwW7VNwBx0w=="],
+
+    "@oxvg/napi-linux-x64-musl": ["@oxvg/napi-linux-x64-musl@0.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-7N1vVBV/QHQ5yMBRQM9vMU9rB0SKOqccXFFKk3m+h54EhkMIlycZL0xxeNO7lx0DDsosc0+KuprprRZAxz6+/A=="],
+
+    "@oxvg/napi-win32-arm64-msvc": ["@oxvg/napi-win32-arm64-msvc@0.0.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-rCvsnfkqfZYsFoCb9dOU9vCt17BJkygzCgAUbmOrzv5CIOyseLLONspsCL7gv/HnCk/d4h+q4UClyvURBbRzoA=="],
+
+    "@oxvg/napi-win32-x64-msvc": ["@oxvg/napi-win32-x64-msvc@0.0.7", "", { "os": "win32", "cpu": "x64" }, "sha512-IrgikB6itQOqFg9VxK6YT6OWXfsZpV7l/PZgtfMG4A8p9IIgTT9A/7qyxMCQwJkccWG2ChmLv203L3XsVo9Kdw=="],
 
     "@pnpm/deps.graph-sequencer": ["@pnpm/deps.graph-sequencer@1100.0.1", "", {}, "sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A=="],
 

--- a/packages/vite-plugin-svg-react/README.md
+++ b/packages/vite-plugin-svg-react/README.md
@@ -65,20 +65,13 @@ below. What consumers get out of it:
   only when that round-trips, so `id="001"` stays `001` rather than turning
   into `1` and breaking the `<use href="#001">` pointing at it.
 
-One thing SVGR could do that this plugin doesn’t: run [SVGO][] optimization
-via `@svgr/plugin-svgo`. Optimizing SVGs is a build concern you can handle
-before they reach the bundler (e.g. `svgo --folder`).
-
-### Future work
-
-An optional pre-optimization pass built on [OXVG][] — the Rust,
-SVGO-compatible SVG toolchain — would fit the plugin’s all-native pipeline
-and could slot in ahead of component generation without reintroducing a JS
-compiler. If you want it, add your 👍 to [this issue][oxvg issue].
+[SVGO][]-style optimization is available as an opt-in: the `optimize`
+option below runs each SVG through [OXVG][] — the Rust, SVGO-compatible SVG
+toolchain — ahead of component generation. Its dependency is optional, so
+the default install stays dependency-free.
 
 [svgo]: https://github.com/svg/svgo
 [oxvg]: https://github.com/noahbald/oxvg
-[oxvg issue]: https://github.com/acusti/uikit/issues/422
 
 ## Usage
 
@@ -139,10 +132,10 @@ project (e.g. `src/vite-env.d.ts`):
 
 ### Options
 
-The plugin takes an optional options object with a single property: `svg`,
-which shapes the generated `<svg>` element. It supports a deliberately
-small subset of the [SVGR options][svgr options], with the same names and
-semantics (the nesting keeps the top level free for plugin-level options):
+The plugin takes an optional options object with two properties:
+`optimize`, documented below, and `svg`, which shapes the generated `<svg>`
+element. `svg` supports a deliberately small subset of the [SVGR
+options][svgr options], with the same names and semantics:
 
 ```ts
 svgReact({
@@ -160,6 +153,126 @@ svgReact({
 - `svgProps` adds extra props to the root `<svg>` (string values, or
   `{expression}` strings inserted verbatim)
 
+#### `optimize`
+
+Off by default. Set `optimize: true` to run each SVG through OXVG before
+it’s converted to a component:
+
+```
+npm install --save-dev @oxvg/napi
+```
+
+```ts
+svgReact({ optimize: true });
+```
+
+`@oxvg/napi` is an optional peer dependency: install it to use `optimize`,
+and the plugin stays dependency-free if you don’t. Optimization runs on the
+raw SVG source, so the rest of the pipeline is unchanged by it.
+
+The default preset we pass is OXVG’s default preset with `cleanupIds`
+dropped. That preset already leaves `viewBox` alone (unlike SVGO’s
+`preset-default`), and nothing it runs renames an id or a class.
+
+`cleanupIds` minifies ids and removes unreferenced ones, which is a rename
+the optimizer can’t verify: anything pointing at an id from outside the
+file — your app’s CSS, `getElementById`, an `aria-labelledby` — breaks
+silently. It’s also what makes inlined components collide, since every
+file’s ids collapse to the same `a` and `b`, and then an internal
+`<use href="#a">` or `fill="url(#a)"` resolves against whichever component
+rendered first. `@svgr/plugin-svgo` works around that by adding `prefixIds`
+on top, which renames the ids a second time and renames class names with
+them; this plugin defaults to not renaming either, so ids stay exactly as
+unique as you made them, the way inline SVG written by hand already
+behaves.
+
+If you want the smaller output and none of your ids are referenced from
+outside their file, pass OXVG’s default preset as it ships and get
+`cleanupIds` back:
+
+```ts
+import { extend } from '@oxvg/napi';
+
+svgReact({ optimize: extend({ type: 'Default' }) });
+```
+
+Passing an object hands it to OXVG’s `optimise` as-is. An OXVG config is
+the complete list of the optimizations to run, not a set of overrides on
+top of a preset, so this one runs a single optimization and nothing else:
+
+```ts
+svgReact({ optimize: { collapseGroups: { field0: true } } });
+```
+
+For the default preset with a change to it, build the config with OXVG’s
+own `extend`:
+
+```ts
+import { extend } from '@oxvg/napi';
+
+svgReact({
+    optimize: extend(
+        { type: 'Default' },
+        { removeDesc: { removeAny: true } },
+    ),
+});
+```
+
+`extend` only adds, so drop a job by leaving it out of the object you pass:
+
+```ts
+import { extend } from '@oxvg/napi';
+
+// the plugin’s own default, minus inlineStyles
+const { cleanupIds, inlineStyles, ...optimize } = extend({
+    type: 'Default',
+});
+
+svgReact({ optimize });
+```
+
+The option is typed as a plain object rather than as OXVG’s `Jobs`, so that
+this package’s types don’t reference a dependency most installs won’t have.
+For a typed config, annotate it where you write it:
+
+```ts
+import type { Jobs } from '@oxvg/napi';
+
+svgReact({ optimize: { removeDesc: { removeAny: true } } satisfies Jobs });
+```
+
+Two more things about OXVG itself:
+
+1. A job name it doesn’t recognize is ignored silently, which is what
+   `satisfies Jobs` above is for.
+2. `inlineStyles`, in the default preset, folds a rule from an SVG’s own
+   `<style>` element into a `style` attribute and drops the `class` that
+   matched it — usually a generated name like `.cls-1`, but if you style by
+   class name from your app’s CSS and the SVG carries its own rule for that
+   class, leave `inlineStyles` out as above.
+
+#### SVG files the `optimize` option rejects
+
+This plugin’s own parser is deliberately tolerant of markup that real SVG
+files contain but XML rejects. OXVG’s parser runs first and isn’t, so
+turning `optimize` on narrows what builds. Each case fails loudly, naming
+the file and the line, and each still builds with `optimize` off:
+
+- **A doctype whose internal subset declares entities the root element
+  references** — how classic Illustrator (10–CS4) wrote its Adobe
+  namespaces. OXVG rejects any document with a DTD, so the prolog is
+  blanked before it gets there, and the references outlive it:
+  `unknown entity reference 'ns_extend'`.
+- **An unknown entity name** anywhere, such as the HTML-only `&nbsp;`,
+  which XML doesn’t define. Without `optimize` these pass through
+  literally; with it, `unknown entity reference 'nbsp'`.
+- **A minimized attribute** (`<svg hidden>`), which is legal inline in HTML
+  but not in XML. Without `optimize` it reads as `hidden=""`; with it,
+  `expected '=' not '>'`.
+
+If you hit one of these, it’s the option and not your file: normalize the
+SVG once (`svgo`, or any XML formatter) or don’t use the `optimize` option.
+
 The module wrapper is fixed: a typed component that spreads its props onto
 the root `<svg>`, exported as the default export. Any other option throws
 at config time — rejecting unknown options loudly beats silently generating
@@ -174,9 +287,11 @@ replacements:
   is also the only shape `client.d.ts` types
 - `typescript`: the emitted module is compiled immediately, so this had no
   observable effect
+- `svgoConfig`: the `optimize` option above, in OXVG’s config vocabulary
+  rather than SVGO’s
 - `jsxRuntime`, `expandProps`, `titleProp`, `descProp`,
-  `replaceAttrValues`, and SVGR’s pipeline options (`plugins`, `template`,
-  `svgoConfig`): not supported
+  `replaceAttrValues`, and SVGR’s remaining pipeline options (`plugins`,
+  `template`): not supported
 
 Migrating from vite-plugin-svgr (or from this plugin’s svgr-based 0.1
 release): the old `svgrOptions` key throws with a message pointing here —

--- a/packages/vite-plugin-svg-react/package.json
+++ b/packages/vite-plugin-svg-react/package.json
@@ -44,6 +44,7 @@
         "tsc": "tsc --noEmit"
     },
     "devDependencies": {
+        "@oxvg/napi": "^0.0.7",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
@@ -55,6 +56,12 @@
         "vitest": "^4"
     },
     "peerDependencies": {
+        "@oxvg/napi": ">=0.0.7",
         "vite": ">=8.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@oxvg/napi": {
+            "optional": true
+        }
     }
 }

--- a/packages/vite-plugin-svg-react/src/errors.ts
+++ b/packages/vite-plugin-svg-react/src/errors.ts
@@ -1,0 +1,3 @@
+/** The message of a thrown value, which isn’t necessarily an Error. */
+export const getErrorMessage = (error: unknown) =>
+    error instanceof Error ? error.message : String(error);

--- a/packages/vite-plugin-svg-react/src/generate.ts
+++ b/packages/vite-plugin-svg-react/src/generate.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from './errors.js';
 import {
     ATTRIBUTE_MAPPINGS,
     ELEMENT_ATTRIBUTE_MAPPINGS,
@@ -398,8 +399,7 @@ export function generateComponentModule(
     } catch (error) {
         // prefix emitter errors with the source file, matching parseSVG’s
         // own diagnostics
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Invalid SVG in ${filePath}: ${message}`);
+        throw new Error(`Invalid SVG in ${filePath}: ${getErrorMessage(error)}`);
     }
 
     const componentName = getComponentName(filePath);

--- a/packages/vite-plugin-svg-react/src/index.test.ts
+++ b/packages/vite-plugin-svg-react/src/index.test.ts
@@ -3,11 +3,31 @@ import type { ResolvedConfig } from 'vite';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { extend } from '@oxvg/napi';
 import { describe, expect, it } from 'vitest';
 
 import vitePluginSVGReact, { type Options } from './index.js';
 
 const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z"/></svg>';
+
+const DTD_SVG = `\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 4">
+    <path d="M 0,0 L 4,0 L 4,4 Z" fill="#ff0000"/>
+</svg>`;
+
+// classic Illustrator (10–CS4) declares its Adobe namespaces as entities in
+// the doctype’s internal subset and references them from the root element
+const ENTITY_SVG = `\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd" [
+    <!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+]>
+<svg xmlns:x="&ns_extend;" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h1"/>
+</svg>`;
 
 type LoadHook = (
     this: { addWatchFile: (id: string) => void },
@@ -23,21 +43,27 @@ type ResolveIdHook = (
 
 async function loadSVGComponent({
     command,
+    fileName = 'icon.svg',
+    optimize,
+    source = SVG,
     svg,
 }: {
     command: 'build' | 'serve';
+    fileName?: string;
+    optimize?: Options['optimize'];
+    source?: string;
     svg?: Options['svg'];
 }) {
-    const plugin = vitePluginSVGReact({ svg });
+    const plugin = vitePluginSVGReact({ optimize, svg });
     const configResolved = plugin.configResolved as (
         config: Pick<ResolvedConfig, 'command'>,
-    ) => void;
-    configResolved({ command });
+    ) => Promise<void>;
+    await configResolved({ command });
 
     const directory = await mkdtemp(join(tmpdir(), 'vite-plugin-svg-react-'));
     try {
-        const filePath = join(directory, 'icon.svg');
-        await writeFile(filePath, SVG);
+        const filePath = join(directory, fileName);
+        await writeFile(filePath, source);
 
         const load = plugin.load as LoadHook;
         const watchedFiles: Array<string> = [];
@@ -229,6 +255,198 @@ describe('vite-plugin-svg-react', () => {
         expect(() =>
             vitePluginSVGReact({ svg: { svgProps: { d: 'M0 0}' } } }),
         ).not.toThrow();
+    });
+
+    it('leaves the SVG unoptimized by default', async () => {
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            source: '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M 0,0 L 1,0"/></g></svg>',
+        });
+        // the group would be collapsed and the path data rewritten by OXVG
+        expect(code).toContain('"g"');
+    });
+
+    it('optimizes with OXVG’s default preset when optimize is true', async () => {
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: true,
+            source: '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M 0,0 L 1,0"/></g></svg>',
+        });
+        expect(code).not.toContain('"g"');
+    });
+
+    it('runs an OXVG config object as the whole job list', async () => {
+        // an OXVG config isn’t merged into a preset — it is the job list, so
+        // a one-job config leaves everything the default preset would do
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: { collapseGroups: { field0: true } },
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<desc>kept</desc><g><path d="M0 0h1"/></g></svg>',
+        });
+        expect(code).not.toContain('"g"');
+        // removeDesc is in the default preset but not in this config
+        expect(code).toContain('desc');
+    });
+
+    it('leaves ids as authored', async () => {
+        // cleanupIds is dropped from the default preset: it renames ids the
+        // optimizer can’t see all the references to (app CSS,
+        // getElementById), and minifies every file’s down to the same single
+        // letters, which is what makes inlined components collide
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: true,
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<defs><linearGradient id="brandGradient"><stop offset="0"/></linearGradient></defs>' +
+                '<path id="unreferenced" d="M0 0h1v1H0z" fill="url(#brandGradient)"/></svg>',
+        });
+        expect(code).toContain('brandGradient');
+        // an unreferenced id is a hook for something outside the file, so it
+        // survives too
+        expect(code).toContain('unreferenced');
+    });
+
+    it('leaves class names alone', async () => {
+        // the classes an app’s CSS targets can’t be renamed, which rules out
+        // prefixIds (it renames class names along with ids)
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: true,
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<path class="icon-fill" d="M0 0h1v1H0z"/></svg>',
+        });
+        expect(code).toContain('icon-fill');
+    });
+
+    it('optimizes SVGs that carry a doctype', async () => {
+        // OXVG refuses a document with a DTD outright, so the prolog an
+        // Illustrator export writes has to be dropped before it gets there
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: true,
+            source: DTD_SVG,
+        });
+        expect(code).toContain('viewBox');
+        expect(code).not.toContain('#ff0000');
+    });
+
+    it('accepts a config built with OXVG’s extend', async () => {
+        // also a compile-time guard: `extend` returns OXVG’s `Jobs`, an
+        // interface, and TypeScript gives interfaces no implicit index
+        // signature — so typing the option as Record<string, unknown> would
+        // fail tsc right here, as it did for the README’s own examples
+        const { cleanupIds: _cleanupIds, ...optimize } = extend(
+            { type: 'Default' },
+            { removeDesc: { removeAny: true } },
+        );
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize,
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<desc>dropped</desc><g><path d="M0 0h1"/></g></svg>',
+        });
+        expect(code).not.toContain('desc');
+        expect(code).not.toContain('"g"');
+    });
+
+    it('fails loudly on a doctype whose internal subset declares entities', async () => {
+        // A known limitation, pinned here so it stays deliberate: the source
+        // is sliced to its root element for OXVG (which rejects any DTD),
+        // and that drops entity declarations the root element can still
+        // reference — classic Illustrator (10–CS4) declares its Adobe
+        // namespaces this way. Expanding them would be a parser of its own,
+        // to recover namespaces OXVG’s removeEditorsNSData then deletes, so
+        // this fails naming the file instead of parsing part of it.
+        await expect(
+            loadSVGComponent({
+                command: 'build',
+                optimize: true,
+                source: ENTITY_SVG,
+            }),
+        ).rejects.toThrow(/failed to optimize .*icon\.svg.*ns_extend/);
+        // without optimize the same file still builds, entity references
+        // passed through literally
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            source: ENTITY_SVG,
+        });
+        expect(code).toContain('ns_extend');
+    });
+
+    it('names the SVG whose optimization failed', async () => {
+        await expect(
+            loadSVGComponent({
+                command: 'build',
+                optimize: true,
+                source: '<svg xmlns="http://www.w3.org/2000/svg"><path',
+            }),
+        ).rejects.toThrow(/failed to optimize .*icon\.svg/);
+    });
+
+    it('gives up this parser’s tolerances for non-XML markup', async () => {
+        // parse.ts accepts these deliberately (a minimized attribute is
+        // legal inline in HTML; an unknown entity name passes through
+        // literally), OXVG’s parser runs first and doesn’t. Pinned because
+        // the README promises each fails by name and builds without
+        // `optimize` — a user hitting one has to be able to tell it’s the
+        // option and not their file.
+        const cases = [
+            {
+                pattern: /expected '=' not '>'/,
+                source: '<svg xmlns="http://www.w3.org/2000/svg" hidden><path d="M0 0h1"/></svg>',
+            },
+            {
+                pattern: /unknown entity reference 'nbsp'/,
+                source: '<svg xmlns="http://www.w3.org/2000/svg"><text>a&nbsp;b</text></svg>',
+            },
+        ];
+        for (const { pattern, source } of cases) {
+            await expect(
+                loadSVGComponent({ command: 'build', optimize: true, source }),
+            ).rejects.toThrow(pattern);
+            await expect(
+                loadSVGComponent({ command: 'build', source }),
+            ).resolves.toBeTruthy();
+        }
+    });
+
+    it('reports OXVG error positions at the line the file actually has', async () => {
+        // the prolog is blanked rather than cut off, so OXVG counts from the
+        // same origin the editor does; slicing it away reported line 1 for
+        // an error five lines into the file
+        await expect(
+            loadSVGComponent({
+                command: 'build',
+                optimize: true,
+                source: ENTITY_SVG,
+            }),
+        ).rejects.toThrow(/at 5:/);
+    });
+
+    it('rejects an optimize value that is neither a boolean nor a config', () => {
+        for (const optimize of [42, 'true', ['collapseGroups'], null]) {
+            expect(() =>
+                // @ts-expect-error optimize is a boolean or an OXVG config
+                vitePluginSVGReact({ optimize }),
+            ).toThrow(/optimize must be a boolean or an OXVG config object/);
+        }
+    });
+
+    it('rejects an optimize config OXVG can’t read, at config time', async () => {
+        // OXVG’s own message names no file, and this runs before any SVG is
+        // loaded, so the error has to point back at the option itself
+        const plugin = vitePluginSVGReact({ optimize: { removeViewBox: {} } });
+        const configResolved = plugin.configResolved as (
+            config: Pick<ResolvedConfig, 'command'>,
+        ) => Promise<void>;
+        await expect(configResolved({ command: 'build' })).rejects.toThrow(
+            /OXVG rejected the optimize config/,
+        );
     });
 
     it('rejects an unmatched brace inside a regex literal or comment', () => {

--- a/packages/vite-plugin-svg-react/src/index.ts
+++ b/packages/vite-plugin-svg-react/src/index.ts
@@ -7,10 +7,22 @@ import {
     generateComponentModule,
     getComponentOptionsError,
 } from './generate.js';
+import { createOptimizer, type OptimizeConfig, type Optimizer } from './optimize.js';
 
 export type { ComponentOptions } from './generate.js';
+export type { OptimizeConfig } from './optimize.js';
 
 export type Options = {
+    /**
+     * Optimize each SVG with OXVG before it’s converted to a component.
+     * `true` runs OXVG’s default preset minus cleanupIds, so no id or class
+     * name is renamed; an object is an OXVG config used as-is.
+     *
+     * Needs the optional @oxvg/napi peer dependency installed.
+     *
+     * @default false
+     */
+    optimize?: boolean | OptimizeConfig;
     /**
      * Options shaping the generated <svg> element (dimensions, icon, svgProps)
      * with the same semantics as svgr’s options of the same names.
@@ -18,6 +30,7 @@ export type Options = {
     svg?: ComponentOptions;
 };
 
+const OPTION_NAMES: ReadonlySet<string> = new Set(['optimize', 'svg']);
 const svgReactImportFilter = /\.svg\?react$/;
 // virtual module prefix (Rollup/Vite convention)
 const VIRTUAL_PREFIX = '\0vite-plugin-svg-react:';
@@ -30,13 +43,15 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
     // silently dropped option surfaces as broken imports or missing behavior
     // with an error that points nowhere near the cause, and only TypeScript
     // consumers get a compile-time diagnostic.
-    const unsupportedTopLevel = Object.keys(options).filter((name) => name !== 'svg');
+    const unsupportedTopLevel = Object.keys(options).filter(
+        (name) => !OPTION_NAMES.has(name),
+    );
     if (unsupportedTopLevel.length > 0) {
         // point migrations from the svgr-era API (this plugin ≤ 0.1 and
         // vite-plugin-svgr) at the renamed, narrowed shape
         const hint = unsupportedTopLevel.includes('svgrOptions')
             ? 'svgrOptions was renamed to svg and narrowed to dimensions, icon, and svgProps (see the README’s Options section).'
-            : 'The only supported option is svg.';
+            : `Supported options: ${Array.from(OPTION_NAMES).join(', ')}.`;
         throw new Error(
             `vite-plugin-svg-react: unsupported options: ${unsupportedTopLevel.join(', ')}. ${hint}`,
         );
@@ -66,6 +81,24 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
         );
     }
 
+    // `false` and `true` both have to be spellable, so this reads the value
+    // rather than its presence; anything that isn’t a boolean or a config
+    // object would reach OXVG as one and be silently ignored there
+    const { optimize = false } = options;
+    if (
+        typeof optimize !== 'boolean' &&
+        (typeof optimize !== 'object' || optimize === null || Array.isArray(optimize))
+    ) {
+        throw new Error(
+            'vite-plugin-svg-react: optimize must be a boolean or an OXVG config object ' +
+                '(see the README’s Options section).',
+        );
+    }
+
+    // null when optimization is off; narrowing here keeps the setting’s two
+    // live shapes (the default preset, or a config object) intact downstream
+    const optimizeSetting = optimize === false ? null : optimize;
+
     const componentOptions: ComponentOptions = options.svg ?? {};
     // option values, not just their names: svgProps reaches the generated
     // module verbatim, so an invalid one has to fail here rather than as a
@@ -77,8 +110,13 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
         );
     }
     let development = false;
+    // memoized: the plugin loads @oxvg/napi and validates the config once,
+    // then every load shares the resulting optimizer
+    let optimizerPromise: null | Promise<Optimizer> = null;
+    const getOptimizer = (setting: OptimizeConfig | true) =>
+        (optimizerPromise ??= createOptimizer(setting));
     return {
-        configResolved(config) {
+        async configResolved(config) {
             // Match the jsx transform of the main pipeline (dev runtime
             // outside `vite build`) so dev SSR doesn’t import
             // react/jsx-runtime from these virtual modules only — the dep
@@ -87,6 +125,11 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
             // forces a cold-cache re-optimization. See “Why the dev JSX
             // runtime in dev matters” in the README.
             development = config.command === 'serve';
+            // resolve the optimizer at config time so a missing @oxvg/napi or
+            // a config OXVG rejects fails with a message naming the option,
+            // rather than on the first .svg?react import with one naming
+            // whichever SVG got there first
+            if (optimizeSetting != null) await getOptimizer(optimizeSetting);
         },
         enforce: 'pre',
         async load(id) {
@@ -96,7 +139,10 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
             // the virtual id hides the on-disk source from Rollup, so
             // editing the SVG wouldn’t invalidate this module otherwise
             this.addWatchFile(filePath);
-            const svg = await fs.readFile(filePath, 'utf-8');
+            let svg = await fs.readFile(filePath, 'utf-8');
+            if (optimizeSetting != null) {
+                svg = (await getOptimizer(optimizeSetting))(svg, filePath);
+            }
 
             const code = generateComponentModule(svg, filePath, componentOptions);
 

--- a/packages/vite-plugin-svg-react/src/optimize.ts
+++ b/packages/vite-plugin-svg-react/src/optimize.ts
@@ -1,0 +1,147 @@
+import { getErrorMessage } from './errors.js';
+import { getRootElementOffset } from './parse.js';
+
+/**
+ * An OXVG optimiser config: the `Jobs` object `@oxvg/napi`’s `optimise`
+ * takes, where each key names a job and its value that job’s parameters.
+ *
+ * Deliberately `object` and not `Record<string, unknown>`: `Jobs` is an
+ * interface, and TypeScript gives interfaces no implicit index signature, so
+ * a `Jobs` value — what `extend` returns — isn’t assignable to a Record.
+ * The plugin rejects a non-object (and null, and an array) at config time,
+ * which is the part a type can’t enforce for a plain-JS vite.config anyway.
+ */
+export type OptimizeConfig = object;
+
+/** Optimize an SVG source, naming its file path in any error it throws. */
+export type Optimizer = (svg: string, filePath: string) => string;
+
+// The slice of @oxvg/napi this plugin uses, described structurally rather
+// than imported from the package’s own types: @oxvg/napi is an optional peer
+// dependency, so a type import would leave an unresolvable module specifier
+// in this package’s published .d.ts for every install that doesn’t have it.
+// Consumers who do install it can still type their own config against the
+// real thing, with `satisfies Jobs` at the call site (see the README).
+type OXVG = {
+    // a Record rather than OptimizeConfig: the result gets destructured, so
+    // it has to be indexable here even though callers only pass it along
+    extend: (
+        preset: { type: 'Default' },
+        config?: OptimizeConfig,
+    ) => Record<string, unknown>;
+    optimise: (svg: string, config?: OptimizeConfig) => string;
+};
+
+// Everything but a line feed, so blanking the prolog preserves line and
+// column. \n only is deliberate, and enough: under CRLF the \r sits at the
+// end of a line, so blanking it moves nothing, and OXVG counts lines by \n
+// alone — a file using lone \r line endings reports line 1 whether or not
+// the prolog is touched. parseSVG’s own positions count the same way, so the
+// two agree on such a file rather than one being a regression on the other.
+const NON_NEWLINE_REGEX = /[^\n]/g;
+const OXVG_MODULE = '@oxvg/napi';
+
+// What `optimize: true` runs: OXVG’s default preset minus cleanupIds, which
+// minifies ids and drops unreferenced ones. That’s a rename the optimizer
+// can’t verify — anything pointing at an id from outside the file (app CSS,
+// getElementById, an aria-labelledby) breaks silently — and collapsing every
+// file’s ids to the same `a` and `b` makes duplicate DOM ids likely as soon
+// as two components are inlined on one page.
+const getDefaultConfig = (extend: OXVG['extend']): OptimizeConfig => {
+    const { cleanupIds: _cleanupIds, ...defaults } = extend({ type: 'Default' });
+    return defaults;
+};
+
+const importOXVG = async (): Promise<OXVG> => {
+    try {
+        const oxvg: unknown = await import('@oxvg/napi');
+        return oxvg as OXVG;
+    } catch (error) {
+        // covers both a missing package and a missing platform binary,
+        // which is the same fix from the consumer’s side
+        throw new Error(
+            `vite-plugin-svg-react: the optimize option needs ${OXVG_MODULE}, which failed to load. ` +
+                `Install it (npm install --save-dev ${OXVG_MODULE}) or remove the optimize option.`,
+            { cause: error },
+        );
+    }
+};
+
+let oxvgPromise: null | Promise<OXVG> = null;
+
+// Memoized so the native module loads once per process rather than once per
+// SVG — but a failure isn’t memoized, or the error would outlive its own
+// advice: Node doesn’t cache a rejected dynamic import, and vite restarts
+// its config in-process while this module instance survives, so installing
+// @oxvg/napi and saving vite.config again has to be able to succeed instead
+// of replaying “which failed to load” at a consumer who just fixed it.
+const loadOXVG = async (): Promise<OXVG> => {
+    oxvgPromise ??= importOXVG();
+    try {
+        return await oxvgPromise;
+    } catch (error) {
+        oxvgPromise = null;
+        throw error;
+    }
+};
+
+/**
+ * Build the optimizer for an `optimize` option that isn’t `false`, loading
+ * @oxvg/napi and running the resolved config once so that a missing package
+ * or a config OXVG rejects fails here — where the message can name the
+ * option — rather than on the first `.svg?react` import, where it would name
+ * whichever SVG happened to get there first.
+ */
+export async function createOptimizer(
+    options: OptimizeConfig | true,
+): Promise<Optimizer> {
+    const { extend, optimise } = await loadOXVG();
+    // a config object is handed to `optimise` verbatim, because that’s what
+    // `optimise` does with it — an OXVG config isn’t merged into a preset,
+    // it *is* the job list (`{ mergePaths: … }` means “only merge paths”),
+    // and quietly adding or dropping jobs would make the option something
+    // other than the passthrough it’s documented as
+    const config = options === true ? getDefaultConfig(extend) : options;
+
+    const optimizer: Optimizer = (svg, filePath) => {
+        // OXVG refuses a document with a DTD outright, and its parser has no
+        // use for the rest of the prolog either, all of which component
+        // generation discards anyway — so the prolog is blanked out rather
+        // than cut off. OXVG accepts the leading whitespace, and keeping the
+        // bytes means the line:column in its errors still points where the
+        // file actually is: cutting an 8-line Illustrator prolog reported
+        // line 1 for what the editor calls line 8.
+        //
+        // What blanking can’t carry over is a doctype’s internal subset,
+        // the one part of the prolog the root element can depend on: classic
+        // Illustrator (10–CS4) declares its Adobe namespaces as entities
+        // there. Those references outlive the prolog, so OXVG fails the file
+        // with `unknown entity reference` — one of a few tolerances that
+        // `optimize` gives up, documented in the README under the option.
+        const offset = getRootElementOffset(svg);
+        const source =
+            offset <= 0
+                ? svg
+                : svg.slice(0, offset).replace(NON_NEWLINE_REGEX, ' ') +
+                  svg.slice(offset);
+        try {
+            return optimise(source, config);
+        } catch (error) {
+            throw new Error(
+                `vite-plugin-svg-react: failed to optimize ${filePath}: ${getErrorMessage(error)}`,
+                { cause: error },
+            );
+        }
+    };
+
+    try {
+        optimise('<svg xmlns="http://www.w3.org/2000/svg"/>', config);
+    } catch (error) {
+        throw new Error(
+            `vite-plugin-svg-react: OXVG rejected the optimize config: ${getErrorMessage(error)} ` +
+                '(see the README’s Options section).',
+            { cause: error },
+        );
+    }
+    return optimizer;
+}

--- a/packages/vite-plugin-svg-react/src/parse.test.ts
+++ b/packages/vite-plugin-svg-react/src/parse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRootElementOffset } from './parse.js';
+
+// The offset is what lets the optimizer hand OXVG the root element alone —
+// OXVG refuses a document with a DTD, and the rest of the prolog is
+// discarded by component generation anyway — so a wrong one either smuggles
+// prolog into the optimizer or truncates the document.
+describe('getRootElementOffset', () => {
+    it('is 0 for a document that starts with its root element', () => {
+        expect(getRootElementOffset('<svg/>')).toBe(0);
+    });
+
+    it('skips a BOM, the xml prolog, a doctype, and header comments', () => {
+        const svg = [
+            '﻿<?xml version="1.0" encoding="UTF-8"?>',
+            '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">',
+            '<!-- a header comment -->',
+            '<svg/>',
+        ].join('\n');
+        expect(svg.slice(getRootElementOffset(svg))).toBe('<svg/>');
+    });
+
+    it('doesn’t end a doctype at a ">" inside a quoted literal', () => {
+        const svg = '<!DOCTYPE svg SYSTEM "weird>name.dtd"><svg/>';
+        expect(svg.slice(getRootElementOffset(svg))).toBe('<svg/>');
+    });
+
+    it('doesn’t end a doctype at a ">" inside its internal subset', () => {
+        const svg =
+            '<!DOCTYPE svg [ <!ENTITY ns_a "http://a.example"> <!ENTITY gt-ish "a > b"> ]><svg/>';
+        expect(svg.slice(getRootElementOffset(svg))).toBe('<svg/>');
+    });
+
+    it('doesn’t end an internal subset at a "]" inside a comment', () => {
+        const svg = "<!DOCTYPE svg [ <!-- don't strip ] --> ]><svg/>";
+        expect(svg.slice(getRootElementOffset(svg))).toBe('<svg/>');
+    });
+
+    it('is -1 when there’s no root element to find', () => {
+        // parseSVG reports each of these with a position; nothing here needs
+        // to duplicate that, so the caller just leaves the source alone
+        expect(getRootElementOffset('')).toBe(-1);
+        expect(getRootElementOffset('   \n ')).toBe(-1);
+        expect(getRootElementOffset('text before the root<svg/>')).toBe(-1);
+        expect(getRootElementOffset('<?xml version="1.0"<svg/>')).toBe(-1);
+        expect(getRootElementOffset('<!-- unterminated <svg/>')).toBe(-1);
+        expect(getRootElementOffset('<!DOCTYPE svg [ ]<svg/>')).toBe(-1);
+    });
+});

--- a/packages/vite-plugin-svg-react/src/parse.ts
+++ b/packages/vite-plugin-svg-react/src/parse.ts
@@ -35,6 +35,90 @@ const isXMLCharacter = (codePoint: number) =>
     (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
     (codePoint >= 0x10000 && codePoint <= 0x10ffff);
 
+// Offset of the root element’s opening `<`, or -1 if there isn’t one to find
+// (an empty document, text before the root, an unterminated prolog construct).
+// Everything before that offset — a BOM, the xml prolog, a doctype, header
+// comments — is prolog that parseSVG discards, so slicing to it yields the
+// only part of the source a consumer of the parsed tree can observe.
+export function getRootElementOffset(svg: string): number {
+    let index = svg.charCodeAt(0) === 0xfeff ? 1 : 0;
+    while (index < svg.length) {
+        WHITESPACE.lastIndex = index;
+        WHITESPACE.exec(svg);
+        index = WHITESPACE.lastIndex;
+        if (svg[index] !== '<') return -1;
+        if (svg.startsWith('<?', index)) {
+            const end = svg.indexOf('?>', index + 2);
+            if (end === -1) return -1;
+            index = end + 2;
+        } else if (svg.startsWith('<!--', index)) {
+            const end = svg.indexOf('-->', index + 4);
+            if (end === -1) return -1;
+            index = end + 3;
+        } else if (svg.startsWith('<!', index)) {
+            const end = scanDoctypeEnd(svg, index);
+            if (end === -1) return -1;
+            index = end + 1;
+        } else {
+            return index;
+        }
+    }
+    return -1;
+}
+
+// Offset of the terminating '>' of the `<!…>` declaration (in practice, the
+// doctype) starting at `start`, ignoring '>' characters inside quoted
+// literals and inside the bracketed internal subset (which can hold entity
+// declarations with their own '>'s), and skipping comment and
+// processing-instruction bodies so their contents can’t derail the
+// quote/bracket tracking. Returns -1 when the declaration is unterminated,
+// reporting it through `fail` first when one is given.
+//
+// `fail` returns never, and that’s load-bearing rather than descriptive:
+// parseSVG advances past the returned offset unconditionally, so a callback
+// that returned instead of throwing would send it back to offset 0 and loop
+// over the document forever. Typing it this way makes the compiler hold the
+// caller to it.
+const scanDoctypeEnd = (
+    input: string,
+    start: number,
+    fail?: (message: string, at: number) => never,
+): number => {
+    let inSubset = false;
+    let quote = '';
+    for (let scan = start + 2; scan < input.length; scan += 1) {
+        const character = input[scan];
+        if (quote !== '') {
+            if (character === quote) quote = '';
+        } else if (input.startsWith('<!--', scan)) {
+            const commentEnd = input.indexOf('-->', scan + 4);
+            if (commentEnd === -1) {
+                // point the error at the comment, not the doctype
+                if (fail) fail('unterminated comment', scan);
+                return -1;
+            }
+            scan = commentEnd + 2;
+        } else if (input.startsWith('<?', scan)) {
+            const instructionEnd = input.indexOf('?>', scan + 2);
+            if (instructionEnd === -1) {
+                if (fail) fail('unterminated processing instruction', scan);
+                return -1;
+            }
+            scan = instructionEnd + 1;
+        } else if (character === '"' || character === "'") {
+            quote = character;
+        } else if (character === '[') {
+            inSubset = true;
+        } else if (character === ']') {
+            inSubset = false;
+        } else if (character === '>' && !inSubset) {
+            return scan;
+        }
+    }
+    if (fail) fail('unterminated doctype', start);
+    return -1;
+};
+
 // Decode the five predefined XML entities plus decimal/hex character
 // references. Unrecognized names (e.g. HTML-only ones like &nbsp;, which XML
 // doesn’t define) pass through literally, and stay literal in the rendered
@@ -143,45 +227,10 @@ export function parseSVG(svg: string, filePath?: string): XMLElement {
             parent?.children.push({ type: 'text', value: input.slice(start, end) });
             index = end + ']]>'.length;
         } else if (input.startsWith('<!', index)) {
-            // doctype: scan to the terminating '>', ignoring '>' characters
-            // inside quoted literals and inside the bracketed internal subset
-            // (which can hold entity declarations with their own '>'s), and
-            // skipping comment and processing-instruction bodies so their
-            // contents can't derail the quote/bracket tracking
-            let end = -1;
-            let inSubset = false;
-            let quote = '';
-            for (let scan = index + 2; scan < length; scan += 1) {
-                const character = input[scan];
-                if (quote !== '') {
-                    if (character === quote) quote = '';
-                } else if (input.startsWith('<!--', scan)) {
-                    const commentEnd = input.indexOf('-->', scan + 4);
-                    if (commentEnd === -1) {
-                        // point the error at the comment, not the doctype
-                        index = scan;
-                        fail('unterminated comment');
-                    }
-                    scan = commentEnd + 2;
-                } else if (input.startsWith('<?', scan)) {
-                    const instructionEnd = input.indexOf('?>', scan + 2);
-                    if (instructionEnd === -1) {
-                        index = scan;
-                        fail('unterminated processing instruction');
-                    }
-                    scan = instructionEnd + 1;
-                } else if (character === '"' || character === "'") {
-                    quote = character;
-                } else if (character === '[') {
-                    inSubset = true;
-                } else if (character === ']') {
-                    inSubset = false;
-                } else if (character === '>' && !inSubset) {
-                    end = scan;
-                    break;
-                }
-            }
-            if (end === -1) fail('unterminated doctype');
+            const end = scanDoctypeEnd(input, index, (message, at) => {
+                index = at;
+                return fail(message);
+            });
             index = end + 1;
         } else if (input.startsWith('</', index)) {
             index += 2;

--- a/packages/vite-plugin-svg-react/vite.config.js
+++ b/packages/vite-plugin-svg-react/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from '../../vite.config.base.js';
 
 export default defineConfig({
     build: {
-        rolldownOptions: { external: [/^node:/, 'vite'] },
+        rolldownOptions: { external: [/^node:/, '@oxvg/napi', 'vite'] },
     },
     target: 'node20',
 });


### PR DESCRIPTION
Closes #422.

Adds an `optimize` option to `@acusti/vite-plugin-svg-react` that runs each SVG through [OXVG](https://github.com/noahbald/oxvg) — the Rust, SVGO-compatible toolchain — on the raw source, ahead of parsing and emission. Nothing reintroduces a JS compiler. Off by default.

```ts
svgReact({ optimize: true });
```

`@oxvg/napi` is an **optional peer dependency**, so the default install stays dependency-free. Using `optimize` means installing it yourself (`npm i -D @oxvg/napi`) — `peerDependenciesMeta.optional` tells package managers not to auto-install. That's deliberate: the package is 0.1 MB but pulls a 12.5–16 MB native binary per platform, which is a lot to impose on every install of a plugin whose pitch is "zero dependencies", for an option that's off by default.

## `optimize: true` is the default preset minus `cleanupIds`

Nothing it runs renames an id or a class.

`cleanupIds` minifies ids and removes unreferenced ones, which is a rename the optimizer can't verify: anything pointing at an id from outside the file — app CSS, `getElementById`, an `aria-labelledby` — breaks silently. It's also what makes inlined components collide, since every file's ids collapse to the same `a` and `b`, and then an internal `<use href="#a">` resolves against whichever component rendered first. `@svgr/plugin-svgo` works around that by adding `prefixIds` on top, which renames the ids a second time and renames class names with them; leaving them alone keeps ids exactly as unique — or not — as the author made them.

That's a default, not a verdict: the README shows `extend({ type: 'Default' })` for opting back into the renames. Passing an object instead of `true` hands it to OXVG's `optimise` as-is — an OXVG config is the complete list of optimizations to run, not overrides on top of a preset.

## What `optimize` costs

**It narrows what builds.** OXVG parses before this plugin's deliberately tolerant parser, and rejects three things `parseSVG` accepts on purpose: a doctype whose internal subset declares entities the root element references (classic Illustrator 10–CS4 wrote its Adobe namespaces that way), an unknown entity name like `&nbsp;`, and a minimized attribute (`<svg hidden>`). Each fails by name and each still builds with `optimize` off. Documented in the README under **What `optimize` stops accepting**, and pinned by tests.

**OXVG rejects any document with a DTD**, so the prolog is blanked out — spaces, newlines kept — rather than cut off, which keeps the `line:column` in OXVG's errors pointing at the line the file actually has. Cutting it reported line 1 for what the editor calls line 5.

**It ignores job names it doesn't recognize**, silently: `optimise(svg, { notAJob: {} })` doesn't throw. There's no drift-free way to validate them at runtime — the presets expose only 36 of 57 job keys, and `extend` is stricter about params than `optimise`, so a round-trip check would reject valid configs. The README shows `satisfies Jobs` at the call site for consumers who want the names typed.

## Failure modes

Both resolve when Vite resolves the config, so the message names the option rather than whichever SVG loaded first:

- missing `@oxvg/napi` → `the optimize option needs @oxvg/napi, which failed to load. Install it (…) or remove the optimize option.` (verified by hiding the package from the store). Not memoized on failure, so installing it and re-saving `vite.config` recovers in the same process.
- a config OXVG rejects → `OXVG rejected the optimize config: …`

## Notes on the types

`OptimizeConfig` is `object`, not `Record<string, unknown>`: OXVG's `Jobs` is an interface, and TypeScript gives interfaces no implicit index signature, so a Record rejects the config `extend` returns. The published `.d.ts` still carries no `@oxvg/napi` reference. A test builds its config with `extend` and passes it to the plugin, so `bun run tsc` catches a regression there.

## Commits

1. `chore: sync bun.lock with vite-plugin-react-compiler 0.5.0` — pre-existing drift on `main` that any `bun install` rewrites, kept out of the feature's blame.
2. `refactor(vite-plugin-svg-react): extract the prolog scan from parseSVG` — `scanDoctypeEnd` plus `getRootElementOffset`, sharing one set of rules rather than writing a second approximate scanner.
3. `feat(vite-plugin-svg-react): add an opt-in OXVG optimization pass`.

## Testing

`bun run build`, `test` (420 passing), `lint`, `tsc`, and `format:check` all clean. New coverage: default-off, default preset applied, config-object passthrough, `extend`-built config, ids preserved, class names preserved, doctype-bearing SVGs, error positions, the three strictness cases, per-file error naming, option validation, config-time config rejection, plus direct unit tests for `getRootElementOffset`.

Also verified end to end through the plugin's `load` hook on a doctype-bearing SVG: `id="brandGradient"`/`id="outline"` and `mark-fill`/`mark-dot` survive while the drawing still optimizes (`M 0,0 L 24.00000,0 L 24,24 Z` → `M0 0h24v24Z`), and the built `dist/index.js` externalizes `@oxvg/napi`.

Changeset included as a minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8Q4AktSmaUEAaAJ4pvQpM
