### PR TITLE
Clarify the px-stripping bug in vite-plugin-svg-react README

### DIFF
--- a/packages/vite-plugin-svg-react/README.md
+++ b/packages/vite-plugin-svg-react/README.md
@@ -54,16 +54,18 @@ below. What consumers get out of it:
   first `.svg?react` import costs single-digit milliseconds instead of the
   hundreds of milliseconds it takes to load and warm up a Babel pipeline.
 - **Seven SVGR conversion bugs fixed:** CDATA sections are preserved rather
-  than dropped; `px` style values stay strings (SVGR’s px-stripping
-  corrupted React-unitless properties, turning `line-height: 20px` into a
-  multiplier of 20); semicolons inside `url(…)` and inside CSS comments no
-  longer truncate a style value, and the comments themselves are removed
-  rather than left in as invalid CSS; attribute values containing double
-  quotes no longer emit invalid JSX; whitespace between the children of a
-  text-content element survives, so `<tspan>A</tspan> <tspan>B</tspan>`
-  still renders “A B” rather than “AB”; and attribute values become numbers
-  only when that round-trips, so `id="001"` stays `001` rather than turning
-  into `1` and breaking the `<use href="#001">` pointing at it.
+  than dropped; `px` values inside a `style` attribute stay strings (SVGR
+  stripped the unit, and React only adds it back to the CSS properties that
+  take one, so `line-height: 20px` became a multiplier of 20 and
+  `--gap: 6px` a bare `6`); semicolons inside `url(…)` and inside CSS
+  comments no longer truncate a style value, and the comments themselves
+  are removed rather than left in as invalid CSS; attribute values
+  containing double quotes no longer emit invalid JSX; whitespace between
+  the children of a text-content element survives, so
+  `<tspan>A</tspan> <tspan>B</tspan>` still renders “A B” rather than “AB”;
+  and attribute values become numbers only when that round-trips, so
+  `id="001"` stays `001` rather than turning into `1` and breaking the
+  `<use href="#001">` pointing at it.
 
 [SVGO][]-style optimization is available as an opt-in: the `optimize`
 option below runs each SVG through [OXVG][] — the Rust, SVGO-compatible SVG


### PR DESCRIPTION
The `px` bullet in the "Seven SVGR conversion bugs fixed" list described the bug as corrupting "React-unitless properties", sitting in a section that otherwise talks about attribute conversion. That reads as though `lineHeight` were a React prop, when the bug was confined to the `style` object: SVGR stripped `px` only in `stringToObjectStyle`, which runs only for `style="…"` — every other attribute kept `20px` as a string.

The bullet now says where the stripping happened and why the round-trip fails: React re-appends `px` to numeric style values via `dangerousStyleValue`, but skips that for unitless properties and custom properties, so those two are the cases that break.

It also adds the custom-property half of the corruption — `--gap: 6px` became a bare `6` — which `generate.ts` and `generate.test.ts` both cover but the README omitted.

Docs only; no behavior change. The rest of the paragraph reflowed because oxfmt rewraps markdown prose, no wording changed there. No changeset, matching the other README-only commits in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TtE9gdT2pGPfFMaEXW4KS

---
_Generated by [Claude Code](https://claude.ai/code/session_018TtE9gdT2pGPfFMaEXW4KS)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

