### PR TITLE
feat(vite-plugin-svg-react): per-file id prefixes and optimize include/exclude

### DIFF
--- a/.changeset/optimize-include-exclude.md
+++ b/.changeset/optimize-include-exclude.md
@@ -1,0 +1,20 @@
+---
+'@acusti/vite-plugin-svg-react': minor
+---
+
+The object form of `optimize` is now `{ exclude, include, jobs }`, each
+optional. `include` and `exclude` narrow which SVGs the pass runs on — a
+glob, a RegExp, or an array of either, matched against the path relative to
+the vite root with Vite’s `createFilter` semantics — and `jobs` is the OXVG
+job list that the 0.3 release took as the option’s value itself. With no
+`jobs`, the default preset runs, so
+`optimize: { exclude: ['src/illustrations/**'] }` is the full default minus
+those files, which still become components from their source as written.
+The `true` short form is not affected by this reshaping (what it runs
+changed separately; see the entry above). A job list with `cleanupIds` gets
+the per-file `prefixIds` unless it brings its own, so a customized preset
+stays as collision-safe as the default, and dropping `cleanupIds` keeps ids
+as authored.
+
+Breaking: passing an OXVG job list as `optimize` directly now throws with a
+message pointing at `jobs`; move it there.

--- a/.changeset/prefix-ids-per-file.md
+++ b/.changeset/prefix-ids-per-file.md
@@ -15,7 +15,7 @@ The cost is that an id referenced only from outside its file (app CSS,
 `cleanupIds` can tell, and is removed. To keep ids as authored, pass the
 default preset minus `cleanupIds` as a config object; the README shows how.
 
-For config objects, a `prefixIds` prefix of `{ type: 'Default' }` is now
-resolved to the same per-file prefix rather than reaching OXVG as the
-literal `prefix`; an explicit prefix or `{ type: 'None' }` is passed
+For a job list of your own, a `prefixIds` prefix of `{ type: 'Default' }`
+is now resolved to the same per-file prefix rather than reaching OXVG as
+the literal `prefix`; an explicit prefix or `{ type: 'None' }` is passed
 through unchanged.

--- a/.changeset/prefix-ids-per-file.md
+++ b/.changeset/prefix-ids-per-file.md
@@ -1,0 +1,21 @@
+---
+'@acusti/vite-plugin-svg-react': minor
+---
+
+`optimize: true` now runs OXVG’s full default preset, `cleanupIds`
+included, and prefixes each file’s ids with a prefix derived from the file:
+its base name, a `-`, and a 4-character hash of its path relative to the
+vite root, with `_` between the prefix and the id (`arrow-3f2a_a`). Ids
+come out minified, and unique across components inlined on one page, where
+0.3.0 left them untouched to avoid the collisions `cleanupIds` alone
+causes. Class names still aren’t renamed.
+
+The cost is that an id referenced only from outside its file (app CSS,
+`getElementById`, an `aria-labelledby` elsewhere) is unreferenced as far as
+`cleanupIds` can tell, and is removed. To keep ids as authored, pass the
+default preset minus `cleanupIds` as a config object; the README shows how.
+
+For config objects, a `prefixIds` prefix of `{ type: 'Default' }` is now
+resolved to the same per-file prefix rather than reaching OXVG as the
+literal `prefix`; an explicit prefix or `{ type: 'None' }` is passed
+through unchanged.

--- a/packages/vite-plugin-svg-react/README.md
+++ b/packages/vite-plugin-svg-react/README.md
@@ -172,20 +172,11 @@ svgReact({ optimize: true });
 and the plugin stays dependency-free if you don’t. Optimization runs on the
 raw SVG source, so the rest of the pipeline is unchanged by it.
 
-`optimize: true` runs OXVG’s default preset, which already leaves `viewBox`
-alone (unlike SVGO’s `preset-default`), plus one job of our own on top of
-it. The preset’s `cleanupIds` minifies ids and removes unreferenced ones,
-and it minifies every file’s ids down to the same `a` and `b` — so as soon
-as two components are inlined on one page, an internal `<use href="#a">` or
-`fill="url(#a)"` resolves against whichever component rendered first.
-SVGO’s `prefixIds` exists for exactly this, prefixing each file’s ids with
-its file name, but OXVG’s `optimise` takes no path, so its `Default` prefix
-is the literal string `prefix` in every file and the ids collide the same.
-This plugin does have the path, so it runs `prefixIds` with a prefix
-derived from each file: the file’s base name plus a 4-character hash of its
-path relative to the vite root, separated from the id by `_`. Two files
-named `arrow.svg` in different directories get different prefixes, and the
-output is the same on every machine:
+`optimize: true` runs OXVG’s default preset, which leaves `viewBox` alone
+(unlike SVGO’s `preset-default`), plus `prefixIds`. Ids come out minified
+and prefixed with the file’s base name and a 4-character hash of its path
+relative to the vite root, so they stay unique when components are inlined
+together and come out the same on every machine:
 
 ```
 // src/icons/arrow.svg, as authored
@@ -197,73 +188,118 @@ output is the same on every machine:
 <path fill="url(#arrow-58f3_a)"/>
 ```
 
-Class names aren’t prefixed (`prefixClassNames: false`), and nothing in the
-default preset renames a class, so the classes your app’s CSS targets stay
-as you wrote them. Ids don’t: an id referenced only from outside the file —
-your app’s CSS, `getElementById`, an `aria-labelledby` on another element —
-is unreferenced as far as `cleanupIds` can tell, and removed. References
-inside the file, `aria-labelledby` included, are rewritten with the id. The
-prefix is stable for a given path, but the minified part isn’t: which id
-becomes `a` depends on the order of references in the file, so an edit to
-the SVG can reassign it. If you reference ids from outside their files,
-don’t bind to the optimized names; drop `cleanupIds` from the preset and
-leave `prefixIds` out, which keeps every id exactly as unique as you made
-it, the way inline SVG written by hand already behaves:
+Every reference inside the file — `href="#…"`, `url(#…)`, `aria-labelledby`
+— is rewritten to match. Class names are left as you wrote them, with one
+exception: a class the SVG’s own `<style>` element styles is folded into a
+`style` attribute and dropped (`inlineStyles`, see the end of this
+section).
+
+To avoid issues, don’t reference an id inside an SVG from outside it (app
+CSS, `getElementById`, an `aria-labelledby` on another element). An `id`
+that isn’t referenced anywhere else in the file is removed, and the
+minified part isn’t stable — which id becomes `a` depends on the order of
+references in the file, so an edit to the SVG can reassign it. For an id
+the rest of your app needs, put it on the component instead. Props spread
+onto the root `<svg>`, so an `id` prop lands there, and everything inside
+is reachable from it by class:
+
+```tsx
+import Hero from './hero.svg?react';
+
+function Banner() {
+    return <Hero id="hero-art" />;
+}
+```
+
+```css
+#hero-art .wheel {
+    animation: spin 4s linear infinite;
+}
+```
+
+If an SVG’s ids have to stay as authored, leave `cleanupIds` out and pass
+the rest of the preset as `jobs`:
 
 ```ts
 import { extend } from '@oxvg/napi';
 
-// the default preset minus cleanupIds, and no prefixIds
-const { cleanupIds, ...optimize } = extend({ type: 'Default' });
+// the default preset minus cleanupIds
+const { cleanupIds, ...jobs } = extend({ type: 'Default' });
 
-svgReact({ optimize });
+svgReact({ optimize: { jobs } });
 ```
 
-Passing an object hands it to OXVG’s `optimise` as-is. An OXVG config is
-the complete list of the optimizations to run, not a set of overrides on
-top of a preset, so this one runs a single optimization and nothing else:
+Or keep the default and leave those files out of the pass. An object form
+of the option takes `include` and `exclude` patterns — a glob, a RegExp, or
+an array of either, matched with Vite’s `createFilter` against each SVG’s
+path relative to the vite root (`icons/star.svg`), for RegExps and globs
+alike — alongside the `jobs` to run. Each is optional: with no `jobs`, the
+default preset runs; with no `include`, every SVG that `exclude` doesn’t
+match is optimized. Excluded SVGs still become components, just from their
+source as written:
 
 ```ts
-svgReact({ optimize: { collapseGroups: { field0: true } } });
+svgReact({
+    optimize: {
+        exclude: ['src/illustrations/**', /\.animated\.svg$/],
+        include: 'src/**',
+    },
+});
 ```
 
-The one value the plugin fills in is a `prefixIds` prefix of
-`{ type: 'Default' }`, which is meaningless to `optimise` without a path:
-it resolves to the same per-file prefix `optimize: true` uses, so this is
-the default preset with `prefixIds` also prefixing class names:
+`jobs` is handed to OXVG’s `optimise` as-is. An OXVG job list is the
+complete list of the optimizations to run, not a set of overrides on top of
+a preset, so this one runs a single optimization and nothing else:
+
+```ts
+svgReact({ optimize: { jobs: { collapseGroups: { field0: true } } } });
+```
+
+The plugin owns one key in the list, `prefixIds`. A job list with
+`cleanupIds` gets the per-file `prefixIds` that `optimize: true` uses
+unless it brings its own, so a customized preset stays as collision-safe as
+the default one, and a list without `cleanupIds` isn’t prefixed. In a
+`prefixIds` of your own, a `prefix` of `{ type: 'Default' }` — which is
+meaningless to `optimise` without a path — resolves to that same per-file
+prefix, so this is the default preset with `prefixIds` also prefixing class
+names:
 
 ```ts
 import { extend } from '@oxvg/napi';
 
 svgReact({
-    optimize: extend(
-        { type: 'Default' },
-        {
-            prefixIds: {
-                delim: '_',
-                prefix: { type: 'Default' },
-                prefixClassNames: true,
-                prefixIds: true,
+    optimize: {
+        jobs: extend(
+            { type: 'Default' },
+            {
+                prefixIds: {
+                    delim: '_',
+                    prefix: { type: 'Default' },
+                    prefixClassNames: true,
+                    prefixIds: true,
+                },
             },
-        },
-    ),
+        ),
+    },
 });
 ```
 
 A `prefix` of `{ type: 'Prefix', field0: 'app' }` or `{ type: 'None' }` is
 left alone.
 
-For the default preset with a change to it, build the config with OXVG’s
+For the default preset with a change to it, build the job list with OXVG’s
 own `extend`:
 
 ```ts
 import { extend } from '@oxvg/napi';
 
 svgReact({
-    optimize: extend(
-        { type: 'Default' },
-        { removeDesc: { removeAny: true } },
-    ),
+    optimize: {
+        jobs: extend(
+            { type: 'Default' },
+            { removeDesc: { removeAny: true } },
+        ),
+    },
 });
 ```
 
@@ -272,21 +308,22 @@ svgReact({
 ```ts
 import { extend } from '@oxvg/napi';
 
-// the default preset minus inlineStyles (and, since this is a config
-// object, without the prefixIds that `optimize: true` adds)
-const { inlineStyles, ...optimize } = extend({ type: 'Default' });
+// the default preset minus inlineStyles
+const { inlineStyles, ...jobs } = extend({ type: 'Default' });
 
-svgReact({ optimize });
+svgReact({ optimize: { jobs } });
 ```
 
-The option is typed as a plain object rather than as OXVG’s `Jobs`, so that
+`jobs` is typed as a plain object rather than as OXVG’s `Jobs`, so that
 this package’s types don’t reference a dependency most installs won’t have.
-For a typed config, annotate it where you write it:
+For a typed job list, annotate it where you write it:
 
 ```ts
 import type { Jobs } from '@oxvg/napi';
 
-svgReact({ optimize: { removeDesc: { removeAny: true } } satisfies Jobs });
+svgReact({
+    optimize: { jobs: { removeDesc: { removeAny: true } } satisfies Jobs },
+});
 ```
 
 Two more things about OXVG itself:

--- a/packages/vite-plugin-svg-react/README.md
+++ b/packages/vite-plugin-svg-react/README.md
@@ -172,30 +172,51 @@ svgReact({ optimize: true });
 and the plugin stays dependency-free if you don’t. Optimization runs on the
 raw SVG source, so the rest of the pipeline is unchanged by it.
 
-The default preset we pass is OXVG’s default preset with `cleanupIds`
-dropped. That preset already leaves `viewBox` alone (unlike SVGO’s
-`preset-default`), and nothing it runs renames an id or a class.
+`optimize: true` runs OXVG’s default preset, which already leaves `viewBox`
+alone (unlike SVGO’s `preset-default`), plus one job of our own on top of
+it. The preset’s `cleanupIds` minifies ids and removes unreferenced ones,
+and it minifies every file’s ids down to the same `a` and `b` — so as soon
+as two components are inlined on one page, an internal `<use href="#a">` or
+`fill="url(#a)"` resolves against whichever component rendered first.
+SVGO’s `prefixIds` exists for exactly this, prefixing each file’s ids with
+its file name, but OXVG’s `optimise` takes no path, so its `Default` prefix
+is the literal string `prefix` in every file and the ids collide the same.
+This plugin does have the path, so it runs `prefixIds` with a prefix
+derived from each file: the file’s base name plus a 4-character hash of its
+path relative to the vite root, separated from the id by `_`. Two files
+named `arrow.svg` in different directories get different prefixes, and the
+output is the same on every machine:
 
-`cleanupIds` minifies ids and removes unreferenced ones, which is a rename
-the optimizer can’t verify: anything pointing at an id from outside the
-file — your app’s CSS, `getElementById`, an `aria-labelledby` — breaks
-silently. It’s also what makes inlined components collide, since every
-file’s ids collapse to the same `a` and `b`, and then an internal
-`<use href="#a">` or `fill="url(#a)"` resolves against whichever component
-rendered first. `@svgr/plugin-svgo` works around that by adding `prefixIds`
-on top, which renames the ids a second time and renames class names with
-them; this plugin defaults to not renaming either, so ids stay exactly as
-unique as you made them, the way inline SVG written by hand already
-behaves.
+```
+// src/icons/arrow.svg, as authored
+<linearGradient id="arrowGradient">…</linearGradient>
+<path fill="url(#arrowGradient)"/>
 
-If you want the smaller output and none of your ids are referenced from
-outside their file, pass OXVG’s default preset as it ships and get
-`cleanupIds` back:
+// optimized
+<linearGradient id="arrow-58f3_a">…</linearGradient>
+<path fill="url(#arrow-58f3_a)"/>
+```
+
+Class names aren’t prefixed (`prefixClassNames: false`), and nothing in the
+default preset renames a class, so the classes your app’s CSS targets stay
+as you wrote them. Ids don’t: an id referenced only from outside the file —
+your app’s CSS, `getElementById`, an `aria-labelledby` on another element —
+is unreferenced as far as `cleanupIds` can tell, and removed. References
+inside the file, `aria-labelledby` included, are rewritten with the id. The
+prefix is stable for a given path, but the minified part isn’t: which id
+becomes `a` depends on the order of references in the file, so an edit to
+the SVG can reassign it. If you reference ids from outside their files,
+don’t bind to the optimized names; drop `cleanupIds` from the preset and
+leave `prefixIds` out, which keeps every id exactly as unique as you made
+it, the way inline SVG written by hand already behaves:
 
 ```ts
 import { extend } from '@oxvg/napi';
 
-svgReact({ optimize: extend({ type: 'Default' }) });
+// the default preset minus cleanupIds, and no prefixIds
+const { cleanupIds, ...optimize } = extend({ type: 'Default' });
+
+svgReact({ optimize });
 ```
 
 Passing an object hands it to OXVG’s `optimise` as-is. An OXVG config is
@@ -205,6 +226,32 @@ top of a preset, so this one runs a single optimization and nothing else:
 ```ts
 svgReact({ optimize: { collapseGroups: { field0: true } } });
 ```
+
+The one value the plugin fills in is a `prefixIds` prefix of
+`{ type: 'Default' }`, which is meaningless to `optimise` without a path:
+it resolves to the same per-file prefix `optimize: true` uses, so this is
+the default preset with `prefixIds` also prefixing class names:
+
+```ts
+import { extend } from '@oxvg/napi';
+
+svgReact({
+    optimize: extend(
+        { type: 'Default' },
+        {
+            prefixIds: {
+                delim: '_',
+                prefix: { type: 'Default' },
+                prefixClassNames: true,
+                prefixIds: true,
+            },
+        },
+    ),
+});
+```
+
+A `prefix` of `{ type: 'Prefix', field0: 'app' }` or `{ type: 'None' }` is
+left alone.
 
 For the default preset with a change to it, build the config with OXVG’s
 own `extend`:
@@ -225,10 +272,9 @@ svgReact({
 ```ts
 import { extend } from '@oxvg/napi';
 
-// the plugin’s own default, minus inlineStyles
-const { cleanupIds, inlineStyles, ...optimize } = extend({
-    type: 'Default',
-});
+// the default preset minus inlineStyles (and, since this is a config
+// object, without the prefixIds that `optimize: true` adds)
+const { inlineStyles, ...optimize } = extend({ type: 'Default' });
 
 svgReact({ optimize });
 ```

--- a/packages/vite-plugin-svg-react/src/index.test.ts
+++ b/packages/vite-plugin-svg-react/src/index.test.ts
@@ -1,12 +1,13 @@
 import type { ResolvedConfig } from 'vite';
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { extend } from '@oxvg/napi';
 import { describe, expect, it } from 'vitest';
 
 import vitePluginSVGReact, { type Options } from './index.js';
+import { getIdPrefix, PREFIX_DELIMITER } from './optimize.js';
 
 const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z"/></svg>';
 
@@ -56,13 +57,16 @@ async function loadSVGComponent({
 }) {
     const plugin = vitePluginSVGReact({ optimize, svg });
     const configResolved = plugin.configResolved as (
-        config: Pick<ResolvedConfig, 'command'>,
+        config: Pick<ResolvedConfig, 'command' | 'root'>,
     ) => Promise<void>;
-    await configResolved({ command });
 
+    // the temp directory stands in for the vite root, so fileName is the
+    // SVG’s root-relative path (a subdirectory is fine)
     const directory = await mkdtemp(join(tmpdir(), 'vite-plugin-svg-react-'));
     try {
+        await configResolved({ command, root: directory });
         const filePath = join(directory, fileName);
+        await mkdir(dirname(filePath), { recursive: true });
         await writeFile(filePath, source);
 
         const load = plugin.load as LoadHook;
@@ -290,28 +294,103 @@ describe('vite-plugin-svg-react', () => {
         expect(code).toContain('desc');
     });
 
-    it('leaves ids as authored', async () => {
-        // cleanupIds is dropped from the default preset: it renames ids the
-        // optimizer can’t see all the references to (app CSS,
-        // getElementById), and minifies every file’s down to the same single
-        // letters, which is what makes inlined components collide
+    it('minifies ids and prefixes them per file', async () => {
+        // cleanupIds minifies every file’s ids down to the same `a` and
+        // `b`, which is what makes inlined components collide; prefixIds
+        // with a prefix derived from the file makes them unique again
+        const { code, filePath } = await loadSVGComponent({
+            command: 'build',
+            fileName: 'icons/brand.svg',
+            optimize: true,
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<defs><linearGradient id="brandGradient"><stop offset="0"/></linearGradient></defs>' +
+                '<path d="M0 0h1v1H0z" fill="url(#brandGradient)"/></svg>',
+        });
+        const prefix = getIdPrefix(filePath, dirname(dirname(filePath)));
+        expect(prefix).toMatch(/^brand-[0-9a-f]{4}$/);
+        const id = `${prefix}${PREFIX_DELIMITER}a`;
+        expect(code).toContain(`id: "${id}"`);
+        expect(code).toContain(`url(#${id})`);
+        expect(code).not.toContain('brandGradient');
+    });
+
+    it('gives same-named files in different directories different prefixes', async () => {
+        const source =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<defs><path id="shape" d="M0 0h1"/></defs><use href="#shape"/></svg>';
+        const ids = await Promise.all(
+            ['small/arrow.svg', 'large/arrow.svg'].map(async (fileName) => {
+                const { code } = await loadSVGComponent({
+                    command: 'build',
+                    fileName,
+                    optimize: true,
+                    source,
+                });
+                return /id: "([^"]+)"/.exec(code ?? '')?.[1];
+            }),
+        );
+        expect(ids[0]).toMatch(/^arrow-[0-9a-f]{4}_a$/);
+        expect(ids[1]).toMatch(/^arrow-[0-9a-f]{4}_a$/);
+        expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it('resolves a config object’s Default prefix per file', async () => {
+        // `optimise` takes no path, so OXVG resolves `{ type: 'Default' }`
+        // to the literal string `prefix` — the plugin has the path, and
+        // fills in the same per-file prefix `optimize: true` uses
         const { code } = await loadSVGComponent({
             command: 'build',
-            optimize: true,
+            optimize: {
+                prefixIds: {
+                    delim: '_',
+                    prefix: { type: 'Default' },
+                    prefixClassNames: false,
+                    prefixIds: true,
+                },
+            },
+            source: '<svg xmlns="http://www.w3.org/2000/svg"><path id="shape" d="M0 0h1"/></svg>',
+        });
+        expect(code).toMatch(/id: "icon-[0-9a-f]{4}_shape"/);
+        expect(code).not.toContain('prefix_shape');
+    });
+
+    it('leaves an explicit prefixIds prefix alone', async () => {
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: {
+                prefixIds: {
+                    delim: '-',
+                    prefix: { field0: 'app', type: 'Prefix' },
+                    prefixClassNames: false,
+                    prefixIds: true,
+                },
+            },
+            source: '<svg xmlns="http://www.w3.org/2000/svg"><path id="shape" d="M0 0h1"/></svg>',
+        });
+        expect(code).toContain('id: "app-shape"');
+    });
+
+    it('leaves ids as authored when cleanupIds is dropped', async () => {
+        // the README’s recipe for ids referenced from outside the file (app
+        // CSS, getElementById): the default preset minus cleanupIds, and
+        // without the prefixIds `optimize: true` adds
+        const { cleanupIds: _cleanupIds, ...optimize } = extend({ type: 'Default' });
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize,
             source:
                 '<svg xmlns="http://www.w3.org/2000/svg">' +
                 '<defs><linearGradient id="brandGradient"><stop offset="0"/></linearGradient></defs>' +
                 '<path id="unreferenced" d="M0 0h1v1H0z" fill="url(#brandGradient)"/></svg>',
         });
         expect(code).toContain('brandGradient');
-        // an unreferenced id is a hook for something outside the file, so it
-        // survives too
         expect(code).toContain('unreferenced');
     });
 
     it('leaves class names alone', async () => {
-        // the classes an app’s CSS targets can’t be renamed, which rules out
-        // prefixIds (it renames class names along with ids)
+        // the classes an app’s CSS targets can’t be renamed, so the
+        // prefixIds `optimize: true` adds runs with prefixClassNames off
         const { code } = await loadSVGComponent({
             command: 'build',
             optimize: true,

--- a/packages/vite-plugin-svg-react/src/index.test.ts
+++ b/packages/vite-plugin-svg-react/src/index.test.ts
@@ -7,7 +7,6 @@ import { extend } from '@oxvg/napi';
 import { describe, expect, it } from 'vitest';
 
 import vitePluginSVGReact, { type Options } from './index.js';
-import { getIdPrefix, PREFIX_DELIMITER } from './optimize.js';
 
 const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z"/></svg>';
 
@@ -284,7 +283,7 @@ describe('vite-plugin-svg-react', () => {
         // a one-job config leaves everything the default preset would do
         const { code } = await loadSVGComponent({
             command: 'build',
-            optimize: { collapseGroups: { field0: true } },
+            optimize: { jobs: { collapseGroups: { field0: true } } },
             source:
                 '<svg xmlns="http://www.w3.org/2000/svg">' +
                 '<desc>kept</desc><g><path d="M0 0h1"/></g></svg>',
@@ -298,7 +297,7 @@ describe('vite-plugin-svg-react', () => {
         // cleanupIds minifies every file’s ids down to the same `a` and
         // `b`, which is what makes inlined components collide; prefixIds
         // with a prefix derived from the file makes them unique again
-        const { code, filePath } = await loadSVGComponent({
+        const { code } = await loadSVGComponent({
             command: 'build',
             fileName: 'icons/brand.svg',
             optimize: true,
@@ -307,11 +306,10 @@ describe('vite-plugin-svg-react', () => {
                 '<defs><linearGradient id="brandGradient"><stop offset="0"/></linearGradient></defs>' +
                 '<path d="M0 0h1v1H0z" fill="url(#brandGradient)"/></svg>',
         });
-        const prefix = getIdPrefix(filePath, dirname(dirname(filePath)));
-        expect(prefix).toMatch(/^brand-[0-9a-f]{4}$/);
-        const id = `${prefix}${PREFIX_DELIMITER}a`;
-        expect(code).toContain(`id: "${id}"`);
-        expect(code).toContain(`url(#${id})`);
+        // the documented scheme, pinned rather than recomputed: sanitized
+        // base name, the first 4 hex chars of sha256('icons/brand.svg'), `_`
+        expect(code).toContain('id: "brand-bc08_a"');
+        expect(code).toContain('url(#brand-bc08_a)');
         expect(code).not.toContain('brandGradient');
     });
 
@@ -335,18 +333,20 @@ describe('vite-plugin-svg-react', () => {
         expect(ids[0]).not.toBe(ids[1]);
     });
 
-    it('resolves a config object’s Default prefix per file', async () => {
+    it('resolves a job list’s Default prefix per file', async () => {
         // `optimise` takes no path, so OXVG resolves `{ type: 'Default' }`
         // to the literal string `prefix` — the plugin has the path, and
         // fills in the same per-file prefix `optimize: true` uses
         const { code } = await loadSVGComponent({
             command: 'build',
             optimize: {
-                prefixIds: {
-                    delim: '_',
-                    prefix: { type: 'Default' },
-                    prefixClassNames: false,
-                    prefixIds: true,
+                jobs: {
+                    prefixIds: {
+                        delim: '_',
+                        prefix: { type: 'Default' },
+                        prefixClassNames: false,
+                        prefixIds: true,
+                    },
                 },
             },
             source: '<svg xmlns="http://www.w3.org/2000/svg"><path id="shape" d="M0 0h1"/></svg>',
@@ -359,11 +359,13 @@ describe('vite-plugin-svg-react', () => {
         const { code } = await loadSVGComponent({
             command: 'build',
             optimize: {
-                prefixIds: {
-                    delim: '-',
-                    prefix: { field0: 'app', type: 'Prefix' },
-                    prefixClassNames: false,
-                    prefixIds: true,
+                jobs: {
+                    prefixIds: {
+                        delim: '-',
+                        prefix: { field0: 'app', type: 'Prefix' },
+                        prefixClassNames: false,
+                        prefixIds: true,
+                    },
                 },
             },
             source: '<svg xmlns="http://www.w3.org/2000/svg"><path id="shape" d="M0 0h1"/></svg>',
@@ -371,14 +373,29 @@ describe('vite-plugin-svg-react', () => {
         expect(code).toContain('id: "app-shape"');
     });
 
-    it('leaves ids as authored when cleanupIds is dropped', async () => {
-        // the README’s recipe for ids referenced from outside the file (app
-        // CSS, getElementById): the default preset minus cleanupIds, and
-        // without the prefixIds `optimize: true` adds
-        const { cleanupIds: _cleanupIds, ...optimize } = extend({ type: 'Default' });
+    it('adds the per-file prefixIds to a job list that has cleanupIds', async () => {
+        // a customized preset stays as collision-safe as the default one:
+        // cleanupIds without a prefixIds of its own gets the plugin’s
         const { code } = await loadSVGComponent({
             command: 'build',
-            optimize,
+            optimize: {
+                jobs: extend({ type: 'Default' }, { removeDesc: { removeAny: true } }),
+            },
+            source:
+                '<svg xmlns="http://www.w3.org/2000/svg">' +
+                '<defs><path id="shape" d="M0 0h1"/></defs><use href="#shape"/></svg>',
+        });
+        expect(code).toMatch(/id: "icon-[0-9a-f]{4}_a"/);
+    });
+
+    it('leaves ids as authored when cleanupIds is dropped', async () => {
+        // the README’s recipe for ids referenced from outside the file (app
+        // CSS, getElementById): the default preset minus cleanupIds, which
+        // is also what keeps the plugin from adding prefixIds
+        const { cleanupIds: _cleanupIds, ...jobs } = extend({ type: 'Default' });
+        const { code } = await loadSVGComponent({
+            command: 'build',
+            optimize: { jobs },
             source:
                 '<svg xmlns="http://www.w3.org/2000/svg">' +
                 '<defs><linearGradient id="brandGradient"><stop offset="0"/></linearGradient></defs>' +
@@ -418,13 +435,13 @@ describe('vite-plugin-svg-react', () => {
         // interface, and TypeScript gives interfaces no implicit index
         // signature — so typing the option as Record<string, unknown> would
         // fail tsc right here, as it did for the README’s own examples
-        const { cleanupIds: _cleanupIds, ...optimize } = extend(
+        const { cleanupIds: _cleanupIds, ...jobs } = extend(
             { type: 'Default' },
             { removeDesc: { removeAny: true } },
         );
         const { code } = await loadSVGComponent({
             command: 'build',
-            optimize,
+            optimize: { jobs },
             source:
                 '<svg xmlns="http://www.w3.org/2000/svg">' +
                 '<desc>dropped</desc><g><path d="M0 0h1"/></g></svg>',
@@ -507,24 +524,94 @@ describe('vite-plugin-svg-react', () => {
         ).rejects.toThrow(/at 5:/);
     });
 
-    it('rejects an optimize value that is neither a boolean nor a config', () => {
-        for (const optimize of [42, 'true', ['collapseGroups'], null]) {
+    it('optimizes only the SVGs include matches', async () => {
+        // a glob and a RegExp both match the root-relative path; a RegExp
+        // anchored at the start would never match an absolute one
+        const source =
+            '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M 0,0 L 1,0"/></g></svg>';
+        const optimize = { include: ['icons/**', /^badges\//] };
+        const icon = await loadSVGComponent({
+            command: 'build',
+            fileName: 'icons/star.svg',
+            optimize,
+            source,
+        });
+        expect(icon.code).not.toContain('"g"');
+        const badge = await loadSVGComponent({
+            command: 'build',
+            fileName: 'badges/new.svg',
+            optimize,
+            source,
+        });
+        expect(badge.code).not.toContain('"g"');
+        const illustration = await loadSVGComponent({
+            command: 'build',
+            fileName: 'illustrations/hero.svg',
+            optimize,
+            source,
+        });
+        expect(illustration.code).toContain('"g"');
+    });
+
+    it('skips the SVGs exclude matches', async () => {
+        // patterns resolve against the vite root, the way every other
+        // plugin’s include/exclude do
+        const source =
+            '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M 0,0 L 1,0"/></g></svg>';
+        const optimize = { exclude: 'illustrations/**' };
+        const icon = await loadSVGComponent({
+            command: 'build',
+            fileName: 'icons/star.svg',
+            optimize,
+            source,
+        });
+        expect(icon.code).not.toContain('"g"');
+        const illustration = await loadSVGComponent({
+            command: 'build',
+            fileName: 'illustrations/hero.svg',
+            optimize,
+            source,
+        });
+        expect(illustration.code).toContain('"g"');
+    });
+
+    it('rejects an optimize value that is neither a boolean nor an object', () => {
+        // a Date has no own keys, so it would pass the unknown-keys check
+        // and silently enable optimization if any object were accepted
+        for (const optimize of [42, 'true', ['collapseGroups'], null, new Date()]) {
             expect(() =>
-                // @ts-expect-error optimize is a boolean or an OXVG config
+                // @ts-expect-error optimize is a boolean or an options object
                 vitePluginSVGReact({ optimize }),
-            ).toThrow(/optimize must be a boolean or an OXVG config object/);
+            ).toThrow(/optimize must be a boolean or an object/);
         }
     });
 
-    it('rejects an optimize config OXVG can’t read, at config time', async () => {
+    it('rejects an OXVG job list passed as optimize itself', () => {
+        // the ≤ 0.3 shape; the message has to name where the job list went
+        expect(() =>
+            // @ts-expect-error a job list goes under jobs
+            vitePluginSVGReact({ optimize: { collapseGroups: { field0: true } } }),
+        ).toThrow(/unsupported optimize options: collapseGroups.*under jobs/);
+    });
+
+    it('rejects an optimize.jobs value that isn’t an object', () => {
+        for (const jobs of [true, 'default', ['collapseGroups'], null]) {
+            expect(() =>
+                // @ts-expect-error jobs is an OXVG job list
+                vitePluginSVGReact({ optimize: { jobs } }),
+            ).toThrow(/optimize\.jobs must be an OXVG job list object/);
+        }
+    });
+
+    it('rejects a job list OXVG can’t read, at config time', async () => {
         // OXVG’s own message names no file, and this runs before any SVG is
         // loaded, so the error has to point back at the option itself
-        const plugin = vitePluginSVGReact({ optimize: { removeViewBox: {} } });
+        const plugin = vitePluginSVGReact({ optimize: { jobs: { removeViewBox: {} } } });
         const configResolved = plugin.configResolved as (
-            config: Pick<ResolvedConfig, 'command'>,
+            config: Pick<ResolvedConfig, 'command' | 'root'>,
         ) => Promise<void>;
-        await expect(configResolved({ command: 'build' })).rejects.toThrow(
-            /OXVG rejected the optimize config/,
+        await expect(configResolved({ command: 'build', root: '/app' })).rejects.toThrow(
+            /OXVG rejected optimize\.jobs/,
         );
     });
 

--- a/packages/vite-plugin-svg-react/src/index.ts
+++ b/packages/vite-plugin-svg-react/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
-import { type Plugin, transformWithOxc } from 'vite';
+import path from 'node:path';
+import { createFilter, type FilterPattern, type Plugin, transformWithOxc } from 'vite';
 
 import {
     COMPONENT_OPTION_NAMES,
@@ -12,21 +13,42 @@ import { createOptimizer, type OptimizeConfig, type Optimizer } from './optimize
 export type { ComponentOptions } from './generate.js';
 export type { OptimizeConfig } from './optimize.js';
 
+export type OptimizeOptions = {
+    /**
+     * SVGs not to optimize, as a glob, RegExp, or array of either, matched
+     * against the file path relative to the vite root (`icons/star.svg`)
+     * with Vite’s `createFilter`. Wins over `include`.
+     */
+    exclude?: FilterPattern;
+    /**
+     * The only SVGs to optimize, in the same form as `exclude`. Omit to
+     * optimize every SVG `exclude` doesn’t match.
+     */
+    include?: FilterPattern;
+    /**
+     * The OXVG jobs to run, as the complete job list `optimise` takes — not
+     * overrides on a preset. Omit for the default preset (see `optimize`).
+     * A list with cleanupIds gets the per-file prefixIds unless it brings
+     * its own, and a prefixIds prefix of `{ type: 'Default' }` is resolved
+     * per file the way the default preset’s is.
+     */
+    jobs?: OptimizeConfig;
+};
+
 export type Options = {
     /**
      * Optimize each SVG with OXVG before it’s converted to a component.
      * `true` runs OXVG’s default preset, which minifies ids, plus prefixIds
      * with a prefix derived from each file’s path, so the minified ids stay
      * unique across components inlined on one page; class names aren’t
-     * renamed. An object is an OXVG config used as-is, except that a
-     * prefixIds prefix of `{ type: 'Default' }` is resolved to that same
-     * per-file prefix.
+     * renamed. An object narrows which SVGs are optimized (`include`,
+     * `exclude`) and/or replaces the job list (`jobs`).
      *
      * Needs the optional @oxvg/napi peer dependency installed.
      *
      * @default false
      */
-    optimize?: boolean | OptimizeConfig;
+    optimize?: boolean | OptimizeOptions;
     /**
      * Options shaping the generated <svg> element (dimensions, icon, svgProps)
      * with the same semantics as svgr’s options of the same names.
@@ -35,6 +57,11 @@ export type Options = {
 };
 
 const OPTION_NAMES: ReadonlySet<string> = new Set(['optimize', 'svg']);
+const OPTIMIZE_OPTION_NAMES: ReadonlySet<string> = new Set([
+    'exclude',
+    'include',
+    'jobs',
+]);
 const svgReactImportFilter = /\.svg\?react$/;
 // virtual module prefix (Rollup/Vite convention)
 const VIRTUAL_PREFIX = '\0vite-plugin-svg-react:';
@@ -86,22 +113,54 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
     }
 
     // `false` and `true` both have to be spellable, so this reads the value
-    // rather than its presence; anything that isn’t a boolean or a config
-    // object would reach OXVG as one and be silently ignored there
+    // rather than its presence; anything that isn’t a boolean or an options
+    // object would otherwise be read as one and silently default
     const { optimize = false } = options;
-    if (
-        typeof optimize !== 'boolean' &&
-        (typeof optimize !== 'object' || optimize === null || Array.isArray(optimize))
-    ) {
+    if (typeof optimize !== 'boolean' && !isPlainObject(optimize)) {
         throw new Error(
-            'vite-plugin-svg-react: optimize must be a boolean or an OXVG config object ' +
-                '(see the README’s Options section).',
+            'vite-plugin-svg-react: optimize must be a boolean or an object with ' +
+                'exclude, include, and/or jobs (see the README’s Options section).',
         );
     }
 
-    // null when optimization is off; narrowing here keeps the setting’s two
-    // live shapes (the default preset, or a config object) intact downstream
-    const optimizeSetting = optimize === false ? null : optimize;
+    if (isPlainObject(optimize)) {
+        const unsupportedOptimizeOptions = Object.keys(optimize).filter(
+            (name) => !OPTIMIZE_OPTION_NAMES.has(name),
+        );
+        if (unsupportedOptimizeOptions.length > 0) {
+            // most likely an OXVG job list passed the way this plugin ≤ 0.3
+            // took it, so name the key it moved to
+            throw new Error(
+                `vite-plugin-svg-react: unsupported optimize options: ${unsupportedOptimizeOptions.join(', ')}. ` +
+                    'Supported options: exclude, include, jobs; an OXVG job list ' +
+                    'goes under jobs (see the README’s Options section).',
+            );
+        }
+        // an OXVG job list is an object; anything else reaches `optimise` as
+        // one and is ignored silently
+        if (optimize.jobs !== undefined && !isPlainObject(optimize.jobs)) {
+            throw new Error(
+                'vite-plugin-svg-react: optimize.jobs must be an OXVG job list object ' +
+                    '(see the README’s Options section).',
+            );
+        }
+    }
+
+    // null when optimization is off, so the two live settings (the default
+    // preset, or a job list) stay intact downstream
+    const optimizeSetting: null | OptimizeConfig | true =
+        optimize === false ? null : optimize === true ? true : (optimize.jobs ?? true);
+    // which SVGs the pass runs on. The filter sees the root-relative path,
+    // not the absolute one: createFilter’s `resolve` option roots string
+    // globs only and tests a RegExp against whatever id it’s given, so
+    // resolving against the absolute path would make `/^icons\//` match
+    // nothing while `icons/**` matched
+    const optimizeFilter = isPlainObject(optimize)
+        ? createFilter(optimize.include, optimize.exclude, { resolve: false })
+        : null;
+    const shouldOptimize = (filePath: string) =>
+        optimizeFilter == null ||
+        optimizeFilter(path.relative(root, filePath).split(path.sep).join('/'));
 
     const componentOptions: ComponentOptions = options.svg ?? {};
     // option values, not just their names: svgProps reaches the generated
@@ -148,7 +207,7 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
             // editing the SVG wouldn’t invalidate this module otherwise
             this.addWatchFile(filePath);
             let svg = await fs.readFile(filePath, 'utf-8');
-            if (optimizeSetting != null) {
+            if (optimizeSetting != null && shouldOptimize(filePath)) {
                 svg = (await getOptimizer(optimizeSetting))(svg, filePath);
             }
 
@@ -180,4 +239,12 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
             return { id: VIRTUAL_PREFIX + resolved.id };
         },
     };
+}
+
+// a plain object only: a Date or a class instance has no own keys to fail
+// the unknown-keys check, so it would silently pass as `{}`
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (value == null || typeof value !== 'object') return false;
+    const prototype: unknown = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
 }

--- a/packages/vite-plugin-svg-react/src/index.ts
+++ b/packages/vite-plugin-svg-react/src/index.ts
@@ -15,8 +15,12 @@ export type { OptimizeConfig } from './optimize.js';
 export type Options = {
     /**
      * Optimize each SVG with OXVG before it’s converted to a component.
-     * `true` runs OXVG’s default preset minus cleanupIds, so no id or class
-     * name is renamed; an object is an OXVG config used as-is.
+     * `true` runs OXVG’s default preset, which minifies ids, plus prefixIds
+     * with a prefix derived from each file’s path, so the minified ids stay
+     * unique across components inlined on one page; class names aren’t
+     * renamed. An object is an OXVG config used as-is, except that a
+     * prefixIds prefix of `{ type: 'Default' }` is resolved to that same
+     * per-file prefix.
      *
      * Needs the optional @oxvg/napi peer dependency installed.
      *
@@ -110,11 +114,14 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
         );
     }
     let development = false;
+    // the id prefix hashes each SVG’s path relative to this, so that the
+    // output doesn’t depend on where the project is checked out
+    let root = process.cwd();
     // memoized: the plugin loads @oxvg/napi and validates the config once,
     // then every load shares the resulting optimizer
     let optimizerPromise: null | Promise<Optimizer> = null;
     const getOptimizer = (setting: OptimizeConfig | true) =>
-        (optimizerPromise ??= createOptimizer(setting));
+        (optimizerPromise ??= createOptimizer(setting, root));
     return {
         async configResolved(config) {
             // Match the jsx transform of the main pipeline (dev runtime
@@ -125,6 +132,7 @@ export default function vitePluginSVGReact(options: Options = {}): Plugin {
             // forces a cold-cache re-optimization. See “Why the dev JSX
             // runtime in dev matters” in the README.
             development = config.command === 'serve';
+            root = config.root;
             // resolve the optimizer at config time so a missing @oxvg/napi or
             // a config OXVG rejects fails with a message naming the option,
             // rather than on the first .svg?react import with one naming

--- a/packages/vite-plugin-svg-react/src/optimize.test.ts
+++ b/packages/vite-plugin-svg-react/src/optimize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getIdPrefix } from './optimize.js';
+
+describe('getIdPrefix', () => {
+    it('joins the sanitized base name to a hash of the root-relative path', () => {
+        // the first 4 hex chars of sha256('src/icons/arrow-left.svg'), pinned
+        // so that a change to the hash source or length fails here
+        expect(getIdPrefix('/app/src/icons/arrow-left.svg', '/app')).toBe(
+            'arrow-left-' + '0b0a',
+        );
+    });
+
+    it('depends on the path relative to the root, not the absolute path', () => {
+        // the same file in two checkouts optimizes to the same output
+        expect(getIdPrefix('/home/a/app/src/icon.svg', '/home/a/app')).toBe(
+            getIdPrefix('/ci/build/src/icon.svg', '/ci/build'),
+        );
+        expect(getIdPrefix('/app/src/icon.svg', '/app')).not.toBe(
+            getIdPrefix('/app/src/small/icon.svg', '/app'),
+        );
+    });
+
+    it('sanitizes the base name to what a CSS id selector takes unescaped', () => {
+        expect(getIdPrefix('/app/icon.small@2x.svg', '/app')).toMatch(
+            /^icon-small-2x-[0-9a-f]{4}$/,
+        );
+        // a leading digit would need escaping, and isn’t a valid XML name
+        expect(getIdPrefix('/app/24-arrow.svg', '/app')).toMatch(
+            /^_24-arrow-[0-9a-f]{4}$/,
+        );
+    });
+});

--- a/packages/vite-plugin-svg-react/src/optimize.ts
+++ b/packages/vite-plugin-svg-react/src/optimize.ts
@@ -61,24 +61,30 @@ const OXVG_MODULE = '@oxvg/napi';
  */
 export const PREFIX_DELIMITER = '_';
 
-// What `optimize: true` runs: OXVG’s default preset, whose cleanupIds
-// minifies every file’s ids down to the same `a` and `b`, plus prefixIds
-// with a per-file prefix (resolved below) to make them unique again once
-// components are inlined together. Class names aren’t prefixed: nothing in
-// the preset renames a class, and an app’s CSS is more likely to select by
-// class than by id.
+// The prefixIds job that rides along with cleanupIds: cleanupIds minifies
+// every file’s ids down to the same `a` and `b`, and a per-file prefix
+// (resolved below) makes them unique again once components are inlined
+// together. Class names aren’t prefixed: nothing in the preset renames a
+// class, and an app’s CSS is more likely to select by class than by id.
+const DEFAULT_PREFIX_IDS: PrefixIdsJob = {
+    delim: PREFIX_DELIMITER,
+    prefix: { type: 'Default' },
+    prefixClassNames: false,
+    prefixIds: true,
+};
+
+// what `optimize: true` runs: OXVG’s default preset plus the prefixIds above
 const getDefaultConfig = (extend: OXVG['extend']): OptimizeConfig =>
-    extend(
-        { type: 'Default' },
-        {
-            prefixIds: {
-                delim: PREFIX_DELIMITER,
-                prefix: { type: 'Default' },
-                prefixClassNames: false,
-                prefixIds: true,
-            } satisfies PrefixIdsJob,
-        },
-    );
+    extend({ type: 'Default' }, { prefixIds: DEFAULT_PREFIX_IDS });
+
+// A job list with cleanupIds gets the per-file prefixIds unless it brings
+// its own, so that a customized preset stays as collision-safe as the
+// default one, and a list without cleanupIds (the recipe for keeping ids as
+// authored) isn’t prefixed either.
+const withDefaultPrefixIds = (config: OptimizeConfig): OptimizeConfig =>
+    'cleanupIds' in config && !('prefixIds' in config)
+        ? { ...config, prefixIds: DEFAULT_PREFIX_IDS }
+        : config;
 
 const isPrefixIdsJob = (value: unknown): value is PrefixIdsJob =>
     typeof value === 'object' &&
@@ -162,14 +168,15 @@ export async function createOptimizer(
     root: string,
 ): Promise<Optimizer> {
     const { extend, optimise } = await loadOXVG();
-    // a config object is handed to `optimise` verbatim, because that’s what
+    // a job list is handed to `optimise` as-is, because that’s what
     // `optimise` does with it — an OXVG config isn’t merged into a preset,
-    // it *is* the job list (`{ mergePaths: … }` means “only merge paths”),
-    // and quietly adding or dropping jobs would make the option something
-    // other than the passthrough it’s documented as. The one value filled
-    // in is a prefixIds prefix of `{ type: 'Default' }`, which means nothing
-    // without a path (see getFilePrefixedJob), and only that value.
-    const config = options === true ? getDefaultConfig(extend) : options;
+    // it *is* the job list (`{ mergePaths: … }` means “only merge paths”).
+    // The plugin owns one key in it, prefixIds: added alongside cleanupIds
+    // when absent (withDefaultPrefixIds), and a prefix of
+    // `{ type: 'Default' }` — meaningless to `optimise`, which has no path —
+    // resolved per file (getFilePrefixedJob).
+    const config =
+        options === true ? getDefaultConfig(extend) : withDefaultPrefixIds(options);
     const filePrefixedJob = getFilePrefixedJob(config);
     const getConfig = (filePath: string): OptimizeConfig => {
         if (filePrefixedJob == null) return config;
@@ -223,8 +230,9 @@ export async function createOptimizer(
             getConfig(path.join(root, 'icon.svg')),
         );
     } catch (error) {
+        const option = options === true ? 'optimize' : 'optimize.jobs';
         throw new Error(
-            `vite-plugin-svg-react: OXVG rejected the optimize config: ${getErrorMessage(error)} ` +
+            `vite-plugin-svg-react: OXVG rejected ${option}: ${getErrorMessage(error)} ` +
                 '(see the README’s Options section).',
             { cause: error },
         );

--- a/packages/vite-plugin-svg-react/src/optimize.ts
+++ b/packages/vite-plugin-svg-react/src/optimize.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
 import { getErrorMessage } from './errors.js';
 import { getRootElementOffset } from './parse.js';
 
@@ -32,6 +35,14 @@ type OXVG = {
     optimise: (svg: string, config?: OptimizeConfig) => string;
 };
 
+// The parameters of OXVG’s prefixIds job, as far as this plugin reads them
+type PrefixIdsJob = {
+    delim: string;
+    prefix: { type: 'Default' } | { type: 'None' } | { field0: string; type: 'Prefix' };
+    prefixClassNames: boolean;
+    prefixIds: boolean;
+};
+
 // Everything but a line feed, so blanking the prolog preserves line and
 // column. \n only is deliberate, and enough: under CRLF the \r sits at the
 // end of a line, so blanking it moves nothing, and OXVG counts lines by \n
@@ -41,15 +52,69 @@ type OXVG = {
 const NON_NEWLINE_REGEX = /[^\n]/g;
 const OXVG_MODULE = '@oxvg/napi';
 
-// What `optimize: true` runs: OXVG’s default preset minus cleanupIds, which
-// minifies ids and drops unreferenced ones. That’s a rename the optimizer
-// can’t verify — anything pointing at an id from outside the file (app CSS,
-// getElementById, an aria-labelledby) breaks silently — and collapsing every
-// file’s ids to the same `a` and `b` makes duplicate DOM ids likely as soon
-// as two components are inlined on one page.
-const getDefaultConfig = (extend: OXVG['extend']): OptimizeConfig => {
-    const { cleanupIds: _cleanupIds, ...defaults } = extend({ type: 'Default' });
-    return defaults;
+/**
+ * What separates a file’s prefix from the id it’s applied to. The prefix
+ * ends in a hash, so the delimiter only has to be unambiguous against that:
+ * `_` is, and unlike the `-` that joins the base name to the hash, it stays
+ * legible in a CSS selector, valid in an XML name, and needs no escaping
+ * anywhere an app might reference the resulting id.
+ */
+export const PREFIX_DELIMITER = '_';
+
+// What `optimize: true` runs: OXVG’s default preset, whose cleanupIds
+// minifies every file’s ids down to the same `a` and `b`, plus prefixIds
+// with a per-file prefix (resolved below) to make them unique again once
+// components are inlined together. Class names aren’t prefixed: nothing in
+// the preset renames a class, and an app’s CSS is more likely to select by
+// class than by id.
+const getDefaultConfig = (extend: OXVG['extend']): OptimizeConfig =>
+    extend(
+        { type: 'Default' },
+        {
+            prefixIds: {
+                delim: PREFIX_DELIMITER,
+                prefix: { type: 'Default' },
+                prefixClassNames: false,
+                prefixIds: true,
+            } satisfies PrefixIdsJob,
+        },
+    );
+
+const isPrefixIdsJob = (value: unknown): value is PrefixIdsJob =>
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { prefix?: unknown }).prefix === 'object' &&
+    (value as { prefix: null | object }).prefix !== null;
+
+// the config’s prefixIds job if it asks for the default prefix, which is the
+// one this plugin resolves per file
+const getFilePrefixedJob = (config: OptimizeConfig): null | PrefixIdsJob => {
+    const { prefixIds } = config as { prefixIds?: unknown };
+    if (!isPrefixIdsJob(prefixIds) || prefixIds.prefix.type !== 'Default') {
+        return null;
+    }
+    return prefixIds;
+};
+
+/**
+ * The id prefix for an SVG file: its base name, sanitized to the characters
+ * an id keeps unescaped in CSS, plus a short hash of its path relative to
+ * the vite root. The hash is what makes `icons/small/arrow.svg` and
+ * `icons/large/arrow.svg` differ; hashing the relative path rather than the
+ * absolute one keeps the output identical across machines and checkouts.
+ */
+export const getIdPrefix = (filePath: string, root: string): string => {
+    const relativePath = path.relative(root, filePath).split(path.sep).join('/');
+    const hash = createHash('sha256').update(relativePath).digest('hex').slice(0, 4);
+    const baseName = path
+        .basename(filePath)
+        .replace(/\.[^.]*$/, '')
+        .replace(/[^0-9A-Za-z_-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    // an id that starts with a digit or a hyphen has to be escaped in a CSS
+    // selector and isn’t a valid XML name; a leading underscore is both
+    const name = /^[A-Za-z_]/.test(baseName) ? baseName : `_${baseName}`;
+    return `${name}-${hash}`;
 };
 
 const importOXVG = async (): Promise<OXVG> => {
@@ -94,14 +159,30 @@ const loadOXVG = async (): Promise<OXVG> => {
  */
 export async function createOptimizer(
     options: OptimizeConfig | true,
+    root: string,
 ): Promise<Optimizer> {
     const { extend, optimise } = await loadOXVG();
     // a config object is handed to `optimise` verbatim, because that’s what
     // `optimise` does with it — an OXVG config isn’t merged into a preset,
     // it *is* the job list (`{ mergePaths: … }` means “only merge paths”),
     // and quietly adding or dropping jobs would make the option something
-    // other than the passthrough it’s documented as
+    // other than the passthrough it’s documented as. The one value filled
+    // in is a prefixIds prefix of `{ type: 'Default' }`, which means nothing
+    // without a path (see getFilePrefixedJob), and only that value.
     const config = options === true ? getDefaultConfig(extend) : options;
+    const filePrefixedJob = getFilePrefixedJob(config);
+    const getConfig = (filePath: string): OptimizeConfig => {
+        if (filePrefixedJob == null) return config;
+        // a spread keeps the job at its existing key, though OXVG runs jobs
+        // in its own fixed order (cleanupIds before prefixIds) regardless
+        return {
+            ...config,
+            prefixIds: {
+                ...filePrefixedJob,
+                prefix: { field0: getIdPrefix(filePath, root), type: 'Prefix' },
+            },
+        };
+    };
 
     const optimizer: Optimizer = (svg, filePath) => {
         // OXVG refuses a document with a DTD outright, and its parser has no
@@ -125,7 +206,7 @@ export async function createOptimizer(
                 : svg.slice(0, offset).replace(NON_NEWLINE_REGEX, ' ') +
                   svg.slice(offset);
         try {
-            return optimise(source, config);
+            return optimise(source, getConfig(filePath));
         } catch (error) {
             throw new Error(
                 `vite-plugin-svg-react: failed to optimize ${filePath}: ${getErrorMessage(error)}`,
@@ -135,7 +216,12 @@ export async function createOptimizer(
     };
 
     try {
-        optimise('<svg xmlns="http://www.w3.org/2000/svg"/>', config);
+        // resolved for a stand-in path, so what’s validated is the shape
+        // that runs, prefix included
+        optimise(
+            '<svg xmlns="http://www.w3.org/2000/svg"/>',
+            getConfig(path.join(root, 'icon.svg')),
+        );
     } catch (error) {
         throw new Error(
             `vite-plugin-svg-react: OXVG rejected the optimize config: ${getErrorMessage(error)} ` +


### PR DESCRIPTION
## Summary

Two changes to the `optimize` option added in #448, each its own commit and changeset (both minor).

### 1. `optimize: true` runs the full default preset, with ids prefixed per file

0.3.0 dropped `cleanupIds` from the default because it minifies every file's ids down to the same `a` and `b`, so components inlined together collide. Measured on a real icon set, that gave up about a tenth of the savings.

OXVG's `prefixIds` is the fix, but `optimise` takes no path, so its `{ type: 'Default' }` prefix degrades to the literal string `prefix` in every file. The `load` hook does have the path, so the optimizer now resolves the config per file: the default preset plus `prefixIds` with a prefix of the file's sanitized base name and a 4-char sha256 of its path relative to the vite root, joined to the id by `_`:

```html
<!-- src/icons/arrow.svg -->
<linearGradient id="arrow-58f3_a">…<path fill="url(#arrow-58f3_a)"/>
```

- Hashing the root-relative path keeps output identical across machines; same-named files in different directories get different prefixes.
- Class names stay unprefixed. In-file references, `aria-labelledby` included, are rewritten.
- A job list's own `{ type: 'Default' }` prefix gets the same treatment; explicit and `None` prefixes pass through.
- The cost is what 0.3.0 avoided: an id referenced only from outside its file is unreferenced to `cleanupIds` and removed. The README says so, notes that the minified suffix isn't stable across edits, and gives the drop-`cleanupIds` recipe.

Verified in Chromium that `<use href>`, `url(#…)` fills, clip paths and masks all resolve through the prefixed ids. OXVG runs jobs in its own fixed order (`cleanupIds` before `prefixIds`) regardless of key order.

### 2. Object form of `optimize` is now `{ exclude, include, jobs }`

For the files that shouldn't go through `cleanupIds` (an illustration whose ids app CSS animates) while the icon set next to them should.

```ts
svgReact({ optimize: { exclude: ['src/illustrations/**'] } });
```

- `include`/`exclude` are Vite `FilterPattern`s, resolved against the vite root with `createFilter`, so semantics match every other plugin's. Excluded SVGs still become components from their source as written.
- `jobs` is the OXVG job list the option itself used to be. Every key is optional; no `jobs` means the default preset.
- **Breaking for 0.3.0 configs:** a job list passed as `optimize` directly now throws with a message naming `jobs`, rather than sniffing the object for OXVG keys.

## Test plan

- [x] New tests: per-file prefix and `url(#…)` rewrite, same-named files in different dirs differ, Default prefix in a job list resolved per file, explicit prefix left alone, `getIdPrefix` stability and sanitizing, include-only, exclude-only, legacy job-list shape throws, non-object `jobs` throws
- [x] `bun run --filter '@acusti/vite-plugin-svg-react' test` (93 passing), `tsc`, `build`
- [x] `bun run lint`, `bun run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj5sTV4JRWs9DP2uXfjKEd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj5sTV4JRWs9DP2uXfjKEd)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/acusti/uikit/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

