### PR TITLE
Upgrade vitest to v5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/appsync-fetch": {
@@ -38,7 +38,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/aws-signature-v4": {
@@ -48,7 +48,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/css-value-input": {
@@ -69,7 +69,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -82,7 +82,7 @@
       "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/date-picker": {
@@ -101,7 +101,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -151,7 +151,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -171,7 +171,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -184,7 +184,7 @@
       "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/parsing": {
@@ -193,7 +193,7 @@
       "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/post": {
@@ -203,7 +203,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/styling": {
@@ -219,7 +219,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -232,7 +232,7 @@
       "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/uniquify": {
@@ -241,7 +241,7 @@
       "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
     },
     "packages/use-bounding-client-rect": {
@@ -253,7 +253,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -272,7 +272,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -292,7 +292,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",
@@ -309,7 +309,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "vite": ">=8.0.0",
@@ -328,7 +328,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4",
+        "vitest": "^5",
       },
       "peerDependencies": {
         "@oxvg/napi": ">=0.0.7",
@@ -815,8 +815,6 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@storybook/addon-docs": ["@storybook/addon-docs@10.6.0", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/icons": "^2.0.2", "@storybook/react-dom-shim": "10.6.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0", "unplugin": "^2.3.5" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.6.0" }, "optionalPeers": ["@types/react"] }, "sha512-Fk3rUQWeGyCfL170OkmRp6Ruyv7MHPb/xrKa6YNk7FlGmlVLi5tKzh2T/0J13vWEy8wiu2MV3IBu8iRsaUR+Cw=="],
 
     "@storybook/builder-vite": ["@storybook/builder-vite@10.6.0", "", { "dependencies": { "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.6.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-7zt8tYB6dnSO8fbjUz91MHexGDpf9HrLlA3FAmlVb+2ZL3eWUs499L3I6BDUymcWu7oW5WCBJlB8ERj8ZLLzig=="],
@@ -931,19 +929,15 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.1", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
+    "@vitest/mocker": ["@vitest/mocker@5.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0", "estree-walker": "^3.0.3", "magic-string": "^1.2.3" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
-
-    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
-
-    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
 
@@ -1169,7 +1163,7 @@
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+    "magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1220,8 +1214,6 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
-
-    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
@@ -1289,15 +1281,15 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+    "tinybench": ["tinybench@6.1.4", "", {}, "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ=="],
 
-    "tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
-    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -1325,7 +1317,7 @@
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
-    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
+    "vitest": ["vitest@5.0.0", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0", "chai": "^6.2.2", "es-module-lexer": "^2.3.2", "expect-type": "^1.4.0", "magic-string": "^1.2.3", "obug": "^2.1.4", "picomatch": "^4.0.7", "std-env": "^4.2.0", "tinybench": "6.1.4", "tinyexec": "1.3.0", "tinyglobby": "^0.2.17", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0", "@vitest/browser-preview": "5.0.0", "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0", "@vitest/coverage-istanbul": "5.0.0", "@vitest/coverage-v8": "5.0.0", "@vitest/ui": "5.0.0", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -1353,6 +1345,12 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@changesets/cli/tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+
+    "@changesets/format/tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+
+    "@changesets/git/tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
@@ -1361,26 +1359,16 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "@storybook/react-vite/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
-
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "@vitest/mocker/@vitest/spy": ["@vitest/spy@5.0.0", "", {}, "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g=="],
 
     "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
-
-    "storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
-
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
-
-    "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
-
-    "storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
-
-    "storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
-
-    "storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "overrides": {
         "zod-validation-error": "^4.0.2"

--- a/packages/appsync-fetch/package.json
+++ b/packages/appsync-fetch/package.json
@@ -45,6 +45,6 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/aws-signature-v4/package.json
+++ b/packages/aws-signature-v4/package.json
@@ -41,7 +41,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "engines": {
         "node": ">=20"

--- a/packages/css-value-input/package.json
+++ b/packages/css-value-input/package.json
@@ -53,7 +53,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/css-values/package.json
+++ b/packages/css-values/package.json
@@ -39,6 +39,6 @@
     "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -59,7 +59,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -56,7 +56,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/dropdown/src/Menubar.test.tsx
+++ b/packages/dropdown/src/Menubar.test.tsx
@@ -323,9 +323,17 @@ describe('@acusti/dropdown Menubar', () => {
 
             await user.click(screen.getByRole('button', { name: 'hide File' }));
 
-            expect(
-                screen.getByRole('menuitem', { name: 'Edit' }).getAttribute('tabindex'),
-            ).toBe('0');
+            // The holder really leaving is only settled a microtask after the
+            // commit, so the reconcile that hands the stop on — and the effect
+            // it schedules — land a render later than the click itself. The
+            // stop still has to arrive: if it never does, this times out.
+            await waitFor(() => {
+                expect(
+                    screen
+                        .getByRole('menuitem', { name: 'Edit' })
+                        .getAttribute('tabindex'),
+                ).toBe('0');
+            });
         });
 
         it('hands the tab stop on when the holder becomes disabled', async () => {

--- a/packages/input-text/package.json
+++ b/packages/input-text/package.json
@@ -47,7 +47,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/matchmaking/package.json
+++ b/packages/matchmaking/package.json
@@ -43,6 +43,6 @@
     "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/parsing/package.json
+++ b/packages/parsing/package.json
@@ -37,6 +37,6 @@
     "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/post/package.json
+++ b/packages/post/package.json
@@ -39,6 +39,6 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -46,7 +46,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/textual/package.json
+++ b/packages/textual/package.json
@@ -41,6 +41,6 @@
     "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/uniquify/package.json
+++ b/packages/uniquify/package.json
@@ -45,6 +45,6 @@
     "devDependencies": {
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     }
 }

--- a/packages/use-bounding-client-rect/package.json
+++ b/packages/use-bounding-client-rect/package.json
@@ -40,7 +40,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/use-is-out-of-bounds/package.json
+++ b/packages/use-is-out-of-bounds/package.json
@@ -45,7 +45,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/use-keyboard-events/package.json
+++ b/packages/use-keyboard-events/package.json
@@ -46,7 +46,7 @@
         "react-dom": "^19.2.7",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "react": "^19 || ~0.0.0-experimental < 0.0.0-f",

--- a/packages/vite-plugin-react-compiler/package.json
+++ b/packages/vite-plugin-react-compiler/package.json
@@ -47,7 +47,7 @@
         "@types/node": "^26.1.0",
         "typescript": "^7",
         "vite": "^8",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "vite": ">=8.0.0"

--- a/packages/vite-plugin-svg-react/package.json
+++ b/packages/vite-plugin-svg-react/package.json
@@ -53,7 +53,7 @@
         "react-dom": "^19",
         "typescript": "^7",
         "vite": "^8.0.0-0",
-        "vitest": "^4"
+        "vitest": "^5"
     },
     "peerDependencies": {
         "@oxvg/napi": ">=0.0.7",


### PR DESCRIPTION
Bumps `vitest` from `^4` to `^5` (resolving to `5.0.0`) in the root and all 19 workspaces.

Two commits: the bump itself, plus one test fix it surfaced.

## The bump

None of the v4 → v5 breaking changes required a config or source change. Each one, checked against this repo:

- **`clearMocks` now defaults to `true`.** The one `vi.fn()` used across tests (`packages/appsync-fetch/src/index.test.ts`) only needs its implementation, which `mockClear()` preserves.
- **`vi.mock`/`vi.hoisted` must be top level.** The repo's single `vi.mock` call already is.
- **Inline projects now inherit the root config.** `vitest.config.js` declares `projects: ['packages/*/vite.config.js']` — config file paths, not inline objects — so the new inheritance default doesn't apply.
- **Not used anywhere in the repo:** `test.sequential`, `bench()`, `expect.poll()`, fake timers, coverage thresholds, and the JSON/JUnit reporters (whose output now defaults to files rather than stdout).
- **New `.vitest/` artifact root.** No such directory is produced by this suite, so `.gitignore` is unchanged.
- **New floors: Node ≥ 22.12 and Vite ≥ 6.4.** The CI matrix (`22.x`, `24.x`) and `vite ^8` already satisfy both.

Lockfile changes are confined to vitest and its own dependency tree — no unrelated churn.

## The test fix

The first CI run failed on `build (24.x)` only — `Menubar.test.tsx > hands the tab stop on when an intermediate component unmounts the holder`, expecting `tabindex="0"` on Edit and getting `-1`. `build (22.x)` passed on the same commit.

That test is the only one exercising the *deferred* hand-off path. When an intermediate component unmounts the holder, `Menubar` never re-renders, so the hand-off can't ride the commit: the member's cleanup queues a microtask (`Menubar.tsx:168`), that microtask calls `reconcile()`, and the bar's effect (`Menubar.tsx:97`) only then moves the stop. Asserting synchronously right after `await user.click(...)` raced that chain. The sibling disabled/`<Activity>` tests don't go through it — there the holder stays registered and `registerMember` clears the stop during the commit — which is why they assert synchronously and passed.

The fix wraps that one assertion in `waitFor`, the idiom the file already imports and uses. It doesn't soften what's asserted: with `reconcile()` removed, the test still fails on timeout, so a hand-off that never arrives is still caught.

**Caveat worth stating:** I could not establish that vitest 5 *caused* this. Passing on 22.x and failing on 24.x for identical code makes it timing-dependent rather than a deterministic v5 behavior change, so the race is latent in the test and could have flaked under v4 too. It did not reproduce locally in ~57 runs (node 22 and 24, full suite and package-only, pinned to 2 cores, and under CPU starvation). If you'd rather this land separately against `main` and keep this PR a pure dependency bump, that's an easy split.

## Validation

From the repository root after `bun run build`:

- `bun run test` — 26 files, 432 tests passing; 6 consecutive full-suite runs on node 24 and one on node 22, no recurrence
- `bun run tsc` — clean
- `bun run lint` — clean
- `bun run format:check` — clean

## Note

`5.0.0` is a very recent release; `4.1.11` is still carried under the `V4` dist-tag if you'd rather hold off. No changeset is included, matching how prior devDependency bumps were committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YV9ezEJc9WiSW2SzCvZ5mr

<!-- This is an auto-generated description by cubic. --><a href="https://cubic.dev/pr/acusti/uikit/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>
<!-- End of auto-generated description by cubic. -->